### PR TITLE
assert

### DIFF
--- a/pyiron_atomistics/hamilton/murnaghan.py
+++ b/pyiron_atomistics/hamilton/murnaghan.py
@@ -426,7 +426,8 @@ class Murnaghan(AtomisticParallelMaster):
         Returns: Structure with equilibrium volume
 
         """
-        assert (self.structure is not None)
+        if not (self.structure is not None):
+            raise AssertionError()
         snapshot = self.structure.copy()
         old_vol = snapshot.get_volume()
         new_vol = self["output/equilibrium_volume"]

--- a/pyiron_atomistics/job/atomistic.py
+++ b/pyiron_atomistics/job/atomistic.py
@@ -380,7 +380,8 @@ class AtomisticGenericJob(GenericJobCore):
 
 
         """
-        assert (self.structure is not None)
+        if not (self.structure is not None):
+            raise AssertionError()
         snapshot = self.structure.copy()
         snapshot.cell = self.get("output/generic/cells")[iteration_step]
         snapshot.positions = self.get("output/generic/positions")[iteration_step]

--- a/pyiron_atomistics/md_analysis/trajectory_analysis.py
+++ b/pyiron_atomistics/md_analysis/trajectory_analysis.py
@@ -37,8 +37,10 @@ class TrajectoryAnalysis(object):
 
     @job.setter
     def job(self, val):
-        assert isinstance(val, (AtomisticGenericJob, JobPath))
-        assert (val.status == "finished")
+        if not (isinstance(val, (AtomisticGenericJob, JobPath))):
+            raise AssertionError()
+        if not (val.status == "finished"):
+            raise AssertionError()
         self._job = val
         self._set_trajectory()
 
@@ -67,7 +69,8 @@ def unwrap_coordinates(positions, cell=None, is_relative=False):
     unwrapped_positions = positions.copy()
     if len(unwrapped_positions) > 1:
         if not is_relative:
-            assert (cell is not None)
+            if not (cell is not None):
+                raise AssertionError()
             rel_positions = np.dot(unwrapped_positions, np.linalg.inv(cell))
         else:
             rel_positions = unwrapped_positions.copy()

--- a/pyiron_atomistics/structure/atoms.py
+++ b/pyiron_atomistics/structure/atoms.py
@@ -104,7 +104,8 @@ class Atoms(object):
         if (elements is None) and (numbers is None) and (indices is None):
             return
         if numbers is not None:  # for ASE compatibility
-            assert (elements is None)
+            if not (elements is None):
+                raise AssertionError()
             elements = self.numbers_to_elements(numbers)
         if elements is not None:
             el_object_list = None
@@ -742,7 +743,8 @@ class Atoms(object):
                 self._pbc = value
             elif value in (True, False):
                 value = self.dimension * [value]
-            assert (np.shape(np.array(value)) == (self.dimension,))
+            if not (np.shape(np.array(value)) == (self.dimension,)):
+                raise AssertionError()
             self._pbc = np.array(value, bool)
 
     def convert_element(self, el, pse=None):
@@ -1400,7 +1402,8 @@ class Atoms(object):
 
                     dd0 = neighbors[0][i][i_nbr + i_start]
                     dd = np.sqrt(np.dot(vec_r_ij, vec_r_ij))
-                    assert (dd - dd0 < 0.001)
+                    if not (dd - dd0 < 0.001):
+                        raise AssertionError()
                     # if (dd - dd0 > 0.001):
                     #     print "wrong: ", vec_r_ij, dd,dd0,i_nbr,ind,ind0,i
                     #     print self.positions[ind0], extended_cell.positions[ind], vec0
@@ -1447,7 +1450,8 @@ class Atoms(object):
                 break
             shell_dict[i_shell] = np.mean(dist[shells == i_shell])
             # print ("shells: ", i_shell, shell_dict[i_shell])
-        assert (max(shell_dict.keys()) == max_shell)
+        if not (max(shell_dict.keys()) == max_shell):
+            raise AssertionError()
         return shell_dict
 
     def get_shell_radius(self, shell=1, id_list=None):
@@ -1991,7 +1995,8 @@ class Atoms(object):
         self.indices = new_indices
 
     def __eq__(self, other):
-        assert (isinstance(other, Atoms))
+        if not (isinstance(other, Atoms)):
+            raise AssertionError()
         conditions = []
         for a_1, a_2 in zip(self, other):
             conditions.append(a_1 == a_2)
@@ -2166,7 +2171,8 @@ class Atoms(object):
         if isinstance(vec, int):
             vec = [vec] * self.dimension
 
-        assert (len(vec) == self.dimension)
+        if not (len(vec) == self.dimension):
+            raise AssertionError()
 
         i_vec = np.array([vec[0], 1, 1])
         if self.dimension > 1:
@@ -2271,12 +2277,14 @@ class Atoms(object):
 
         positions = self.positions
         if isinstance(a0, list) or isinstance(a0, np.ndarray):
-            assert len(a0)==3
+            if not (len(a0) == 3):
+                raise AssertionError()
             a0 = np.array(a0)
         else:
             a0 = positions[a0]
         if isinstance(a1, list) or isinstance(a1, np.ndarray):
-            assert len(a1)==3
+            if not (len(a1) == 3):
+                raise AssertionError()
             a1 = np.array(a1)
         else:
             a1 = positions[a1]
@@ -2435,7 +2443,8 @@ class Atoms(object):
                 vector = np.cross((0, 0, 1), v2)
                 if norm(vector) < eps:
                     vector = np.cross((1, 0, 0), v2)
-                assert norm(vector) >= eps
+                if not (norm(vector) >= eps):
+                    raise AssertionError()
             elif s > 0:
                 vector /= s
 
@@ -2452,7 +2461,8 @@ class Atoms(object):
             center = np.array(center)
 
         if index_list is not None:
-            assert (len(index_list) > 0)
+            if not (len(index_list) > 0):
+                raise AssertionError()
             rotate_list = index_list
         else:
             rotate_list = [range(len(self))]

--- a/pyiron_atomistics/structure/periodic_table.py
+++ b/pyiron_atomistics/structure/periodic_table.py
@@ -192,7 +192,8 @@ class PeriodicTable(object):
                     del new_element.tags['sub_tags']
 
             if new_element.Parent is None:
-                assert (el in self.dataframe.index.values)
+                if not (el in self.dataframe.index.values):
+                    raise AssertionError()
                 if len(new_element.sub['tags']) > 0:
                     raise ValueError('Element cannot get tag-assignment twice')
                 if 'tags' not in self.dataframe.keys():

--- a/pyiron_atomistics/structure/sparse_list.py
+++ b/pyiron_atomistics/structure/sparse_list.py
@@ -211,8 +211,10 @@ class SparseList(object):
         self._default = new_list._default
 
     def __add__(self, other):
-        assert (isinstance(other, SparseList))
-        assert (self._default == other._default)
+        if not (isinstance(other, SparseList)):
+            raise AssertionError()
+        if not (self._default == other._default):
+            raise AssertionError()
         new_list = self.__copy__()
         shifted_dict = {i + self._length: val for i, val in other._dict.items()}
         new_list._dict.update(shifted_dict)
@@ -286,7 +288,8 @@ class SparseArrayElement(object):
         return out_str
 
     def __eq__(self, other):
-        assert (isinstance(other, SparseArrayElement))
+        if not (isinstance(other, SparseArrayElement)):
+            raise AssertionError()
         conditions = []
         for key in self._lists.keys():
             try:
@@ -383,7 +386,8 @@ class SparseArray(object):
         for key, val in self._lists.items():
             # for val in self._lists.values():
             #     print ("consistency: ", key, len(val), len(self))
-            assert (len(val) == self._length)
+            if not (len(val) == self._length):
+                raise AssertionError()
 
     def __str__(self):
         out_str = "\n"


### PR DESCRIPTION
It was discovered that some projects used assert to enforce interface constraints. However, assert is removed with compiling to optimised byte code (python -o producing *.pyo files). This caused various protections to be removed. The use of assert is also considered as general bad practice in OpenStack codebases.