### PR TITLE
Update copyright to 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018, Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+Copyright (c) 2021, Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/pyiron_atomistics/atomistics/generic/object_type.py
+++ b/pyiron_atomistics/atomistics/generic/object_type.py
@@ -8,7 +8,7 @@ from pyiron_base import Settings
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -18,7 +18,7 @@ except (ImportError, TypeError, AttributeError):
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/job/interactive.py
+++ b/pyiron_atomistics/atomistics/job/interactive.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 
 __author__ = "Osamu Waseda, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/job/interactivewrapper.py
+++ b/pyiron_atomistics/atomistics/job/interactivewrapper.py
@@ -8,7 +8,7 @@ from pyiron_atomistics.atomistics.structure.atoms import Atoms as PAtoms
 
 __author__ = "Osamu Waseda, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/job/potentials.py
+++ b/pyiron_atomistics/atomistics/job/potentials.py
@@ -12,7 +12,7 @@ from pyiron_base import Settings
 
 __author__ = "Martin Boeckmann, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/job/sqs.py
+++ b/pyiron_atomistics/atomistics/job/sqs.py
@@ -21,7 +21,7 @@ except ImportError:
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "0.1"

--- a/pyiron_atomistics/atomistics/job/structurecontainer.py
+++ b/pyiron_atomistics/atomistics/job/structurecontainer.py
@@ -4,7 +4,7 @@
 
 __author__ = "Yury Lysogorskiy, Jan Janssen, Marvin Poul"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "0.1"

--- a/pyiron_atomistics/atomistics/master/convergence_volume.py
+++ b/pyiron_atomistics/atomistics/master/convergence_volume.py
@@ -7,7 +7,7 @@ from pyiron_atomistics.atomistics.master.serial import SerialMaster
 
 __author__ = "Yury Lysogorskiy"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/master/elastic.py
+++ b/pyiron_atomistics/atomistics/master/elastic.py
@@ -14,7 +14,7 @@ import warnings
 
 __author__ = "Sam Waseda"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -15,7 +15,7 @@ from pyiron_base import JobGenerator
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/master/parallel.py
+++ b/pyiron_atomistics/atomistics/master/parallel.py
@@ -11,7 +11,7 @@ from pyiron_atomistics.atomistics.job.atomistic import AtomisticGenericJob
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/master/phonopy.py
+++ b/pyiron_atomistics/atomistics/master/phonopy.py
@@ -20,7 +20,7 @@ from pyiron_base import JobGenerator, Settings
 
 __author__ = "Jan Janssen, Yury Lysogorskiy"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/master/quasi.py
+++ b/pyiron_atomistics/atomistics/master/quasi.py
@@ -8,7 +8,7 @@ from pyiron_atomistics.atomistics.master.parallel import AtomisticParallelMaster
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "0.0.1"

--- a/pyiron_atomistics/atomistics/master/serial.py
+++ b/pyiron_atomistics/atomistics/master/serial.py
@@ -9,7 +9,7 @@ from pyiron_atomistics.atomistics.job.atomistic import AtomisticGenericJob
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/master/sqsmaster.py
+++ b/pyiron_atomistics/atomistics/master/sqsmaster.py
@@ -8,7 +8,7 @@ from pyiron_base import JobGenerator
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "0.0.1"

--- a/pyiron_atomistics/atomistics/master/structure.py
+++ b/pyiron_atomistics/atomistics/master/structure.py
@@ -12,7 +12,7 @@ The StructureListMaster class is a parallel master consisting of a list of struc
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/structure/_visualize.py
+++ b/pyiron_atomistics/atomistics/structure/_visualize.py
@@ -10,7 +10,7 @@ from scipy.interpolate import interp1d
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -11,7 +11,7 @@ from pyiron_atomistics.atomistics.structure.pyscal import get_steinhardt_paramet
 
 __author__ = "Joerg Neugebauer, Sam Waseda"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/structure/atom.py
+++ b/pyiron_atomistics/atomistics/structure/atom.py
@@ -10,7 +10,7 @@ from ase.atom import Atom as ASEAtom
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -27,7 +27,7 @@ import spglib
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -35,7 +35,7 @@ import types
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/structure/neighbors.py
+++ b/pyiron_atomistics/atomistics/structure/neighbors.py
@@ -12,7 +12,7 @@ import warnings
 
 __author__ = "Joerg Neugebauer, Sam Waseda"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/structure/periodic_table.py
+++ b/pyiron_atomistics/atomistics/structure/periodic_table.py
@@ -12,7 +12,7 @@ import pandas
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal, Martin Boeckmann"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/structure/phonopy.py
+++ b/pyiron_atomistics/atomistics/structure/phonopy.py
@@ -9,7 +9,7 @@ from pyiron_base import Settings
 
 __author__ = "Osamu Waseda"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/structure/pyironase.py
+++ b/pyiron_atomistics/atomistics/structure/pyironase.py
@@ -11,7 +11,7 @@ except ImportError:
 
 __author__ = "Joerg Neugebauer"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/structure/pyscal.py
+++ b/pyiron_atomistics/atomistics/structure/pyscal.py
@@ -10,7 +10,7 @@ from sklearn import cluster
 
 __author__ = "Sarath Menon, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/structure/sparse_list.py
+++ b/pyiron_atomistics/atomistics/structure/sparse_list.py
@@ -12,7 +12,7 @@ from collections import OrderedDict, Sequence
 
 __author__ = "Joerg Neugebauer"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/thermodynamics/thermo_bulk.py
+++ b/pyiron_atomistics/atomistics/thermodynamics/thermo_bulk.py
@@ -9,7 +9,7 @@ import numpy as np
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/atomistics/volumetric/generic.py
+++ b/pyiron_atomistics/atomistics/volumetric/generic.py
@@ -8,7 +8,7 @@ from pyiron_atomistics.vasp.structure import write_poscar
 
 __author__ = "Sudarsan Surendralal, Su-Hyun Yoo"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH "
     "- Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/dft/job/generic.py
+++ b/pyiron_atomistics/dft/job/generic.py
@@ -9,7 +9,7 @@ import warnings
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/dft/master/convergence_encut_parallel.py
+++ b/pyiron_atomistics/dft/master/convergence_encut_parallel.py
@@ -17,7 +17,7 @@ except (ImportError, RuntimeError):
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/dft/master/convergence_encut_serial.py
+++ b/pyiron_atomistics/dft/master/convergence_encut_serial.py
@@ -7,7 +7,7 @@ from pyiron_atomistics.atomistics.master.serial import SerialMaster
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/dft/master/convergence_kpoint_parallel.py
+++ b/pyiron_atomistics/dft/master/convergence_kpoint_parallel.py
@@ -17,7 +17,7 @@ except (ImportError, RuntimeError):
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/dft/master/murnaghan_dft.py
+++ b/pyiron_atomistics/dft/master/murnaghan_dft.py
@@ -7,7 +7,7 @@ from pyiron_atomistics.atomistics.master.murnaghan import Murnaghan, DebyeModel
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/dft/waves/bandstructure.py
+++ b/pyiron_atomistics/dft/waves/bandstructure.py
@@ -13,7 +13,7 @@ from pyiron_base import PyironObject
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/dft/waves/dos.py
+++ b/pyiron_atomistics/dft/waves/dos.py
@@ -7,7 +7,7 @@ import numpy as np
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/dft/waves/electronic.py
+++ b/pyiron_atomistics/dft/waves/electronic.py
@@ -11,7 +11,7 @@ from pyiron_atomistics.dft.waves.dos import Dos
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH "
     "- Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/gpaw/gpaw.py
+++ b/pyiron_atomistics/gpaw/gpaw.py
@@ -8,7 +8,7 @@ from pyiron_base import GenericParameters, Settings, ImportAlarm
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/gpaw/pyiron_ase.py
+++ b/pyiron_atomistics/gpaw/pyiron_ase.py
@@ -17,7 +17,7 @@ except ImportError:
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/interactive/activation_relaxation_technique.py
+++ b/pyiron_atomistics/interactive/activation_relaxation_technique.py
@@ -7,7 +7,7 @@ from pyiron_atomistics.atomistics.job.interactivewrapper import InteractiveWrapp
 from pyiron_base import InputList, Settings
 
 __author__ = "Osamu Waseda"
-__copyright__ = "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH " \
+__copyright__ = "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH " \
                 "- Computational Materials Design (CM) Department"
 __version__ = "1.0"
 __maintainer__ = "Osamu Waseda"

--- a/pyiron_atomistics/interactive/scipy_minimizer.py
+++ b/pyiron_atomistics/interactive/scipy_minimizer.py
@@ -12,7 +12,7 @@ import warnings
 
 __author__ = "Osamu Waseda"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/interactive/sxextoptint.py
+++ b/pyiron_atomistics/interactive/sxextoptint.py
@@ -18,7 +18,7 @@ from pyiron_atomistics.sphinx.base import InputWriter
 
 __author__ = "Jan Janssen, Osamu Waseda"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -22,7 +22,7 @@ from pyiron_atomistics.lammps.structure import LammpsStructure, UnfoldingPrism
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH "
     "- Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/lammps/control.py
+++ b/pyiron_atomistics/lammps/control.py
@@ -12,7 +12,7 @@ import scipy.constants as spc
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -23,7 +23,7 @@ except ImportError:
 
 __author__ = "Osamu Waseda, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/lammps/lammps.py
+++ b/pyiron_atomistics/lammps/lammps.py
@@ -6,7 +6,7 @@ from pyiron_atomistics.lammps.interactive import LammpsInteractive
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "- Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/lammps/potential.py
+++ b/pyiron_atomistics/lammps/potential.py
@@ -13,7 +13,7 @@ from pyiron_atomistics.atomistics.job.potentials import PotentialAbstract, find_
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/lammps/structure.py
+++ b/pyiron_atomistics/lammps/structure.py
@@ -19,7 +19,7 @@ except ImportError:
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal, Yury Lysogorskiy, Jan Janssen, Markus Tautschnig"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/project.py
+++ b/pyiron_atomistics/project.py
@@ -25,7 +25,7 @@ from pyiron_atomistics.atomistics.master.parallel import pipe
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -31,7 +31,7 @@ from pyiron_base import Settings, InputList, job_status_successful_lst, deprecat
 
 __author__ = "Osamu Waseda, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/sphinx/interactive.py
+++ b/pyiron_atomistics/sphinx/interactive.py
@@ -20,7 +20,7 @@ HARTREE_OVER_BOHR_TO_EV_OVER_ANGSTROM = HARTREE_TO_EV / BOHR_TO_ANGSTROM
 
 __author__ = "Osamu Waseda, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/sphinx/sphinx.py
+++ b/pyiron_atomistics/sphinx/sphinx.py
@@ -7,7 +7,7 @@ from pyiron_atomistics.sphinx.interactive import SphinxInteractive
 
 __author__ = "Osamu Waseda, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/sphinx/structure.py
+++ b/pyiron_atomistics/sphinx/structure.py
@@ -10,7 +10,7 @@ from pyiron_atomistics.atomistics.structure.periodic_table import PeriodicTable
 
 __author__ = "Sudarsan Surendralal, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/sphinx/volumetric_data.py
+++ b/pyiron_atomistics/sphinx/volumetric_data.py
@@ -11,7 +11,7 @@ from pyiron_atomistics.atomistics.volumetric.generic import VolumetricData
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/table/datamining.py
+++ b/pyiron_atomistics/table/datamining.py
@@ -45,7 +45,7 @@ from pyiron_atomistics.table.funct import (
 
 __author__ = "Uday Gajera, Jan Janssen, Joerg Neugebauer"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "0.0.1"

--- a/pyiron_atomistics/testing/executable.py
+++ b/pyiron_atomistics/testing/executable.py
@@ -13,7 +13,7 @@ Simple python executable that resembles the behavior of a real job
 
 __author__ = "Joerg Neugebauer"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/testing/randomatomistic.py
+++ b/pyiron_atomistics/testing/randomatomistic.py
@@ -16,7 +16,7 @@ Example Job class for testing the pyiron classes
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/thermodynamics/hessian.py
+++ b/pyiron_atomistics/thermodynamics/hessian.py
@@ -7,7 +7,7 @@ from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.atomistics.job.interactive import GenericInteractive
 
 __author__ = "Jan Janssen"
-__copyright__ = "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH " \
+__copyright__ = "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH " \
                 "- Computational Materials Design (CM) Department"
 __version__ = "1.0"
 __maintainer__ = "Jan Janssen"

--- a/pyiron_atomistics/thermodynamics/interfacemethod.py
+++ b/pyiron_atomistics/thermodynamics/interfacemethod.py
@@ -17,7 +17,7 @@ import random
 from sklearn.neighbors import KernelDensity
 
 __author__ = "Lifang Zhu, Jan Janssen"
-__copyright__ = "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH " \
+__copyright__ = "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH " \
                 "- Computational Materials Design (CM) Department"
 __version__ = "1.0"
 __maintainer__ = "Jan Janssen"

--- a/pyiron_atomistics/thermodynamics/sxphonons.py
+++ b/pyiron_atomistics/thermodynamics/sxphonons.py
@@ -14,7 +14,7 @@ from pyiron_atomistics.atomistics.master.parallel import AtomisticParallelMaster
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -27,7 +27,7 @@ import warnings
 
 __author__ = "Sudarsan Surendralal, Felix Lochner"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -18,7 +18,7 @@ from pyiron_atomistics.atomistics.job.interactive import GenericInteractive
 
 __author__ = "Osamu Waseda, Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/vasp/metadyn.py
+++ b/pyiron_atomistics/vasp/metadyn.py
@@ -12,7 +12,7 @@ import posixpath
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/vasp/oszicar.py
+++ b/pyiron_atomistics/vasp/oszicar.py
@@ -6,7 +6,7 @@ import numpy as np
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -10,7 +10,7 @@ import re
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/vasp/potential.py
+++ b/pyiron_atomistics/vasp/potential.py
@@ -14,7 +14,7 @@ from pyiron_atomistics.atomistics.job.potentials import PotentialAbstract, find_
 
 __author__ = "Jan Janssen"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/vasp/procar.py
+++ b/pyiron_atomistics/vasp/procar.py
@@ -10,7 +10,7 @@ from pyiron_atomistics.dft.waves.electronic import ElectronicStructure
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/vasp/report.py
+++ b/pyiron_atomistics/vasp/report.py
@@ -7,7 +7,7 @@ from scipy.integrate import cumtrapz
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/vasp/structure.py
+++ b/pyiron_atomistics/vasp/structure.py
@@ -9,7 +9,7 @@ import warnings
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/vasp/vasp.py
+++ b/pyiron_atomistics/vasp/vasp.py
@@ -6,7 +6,7 @@ from pyiron_atomistics.vasp.interactive import VaspInteractive
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/vasp/vasprun.py
+++ b/pyiron_atomistics/vasp/vasprun.py
@@ -18,7 +18,7 @@ import warnings
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/pyiron_atomistics/vasp/vaspsol.py
+++ b/pyiron_atomistics/vasp/vaspsol.py
@@ -5,7 +5,7 @@
 from pyiron_atomistics.vasp.vasp import Vasp
 
 __author__ = "Jan Janssen"
-__copyright__ = "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - " \
+__copyright__ = "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - " \
                 "Computational Materials Design (CM) Department"
 __version__ = "1.0"
 __maintainer__ = "Jan Janssen"

--- a/pyiron_atomistics/vasp/volumetric_data.py
+++ b/pyiron_atomistics/vasp/volumetric_data.py
@@ -12,7 +12,7 @@ from pyiron_atomistics.atomistics.volumetric.generic import VolumetricData
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"

--- a/tests/sphinx/test_structure.py
+++ b/tests/sphinx/test_structure.py
@@ -12,7 +12,7 @@ from pyiron_atomistics.sphinx.structure import read_atoms
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
-    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"


### PR DESCRIPTION
We update the copyright statement here because `pyiron_atomistics` was first released in the current version in 2021. 