### PR TITLE
Remove deprecated final_structure from phonopy example

### DIFF
--- a/notebooks/phonopy_example.ipynb
+++ b/notebooks/phonopy_example.ipynb
@@ -82,7 +82,7 @@
     "    job_type = pr.job_type.Lammps\n",
     "    \n",
     "    ref = project.create_job(job_type, name + \"_ref\")\n",
-    "    ref.structure = template_job.get_final_structure().copy()\n",
+    "    ref.structure = template_job.get_structure().copy()\n",
     "    ref.potential = template_job.potential\n",
     "    \n",
     "    phono = project.create_job(pr.job_type.PhonopyJob, name)\n",
@@ -228,7 +228,7 @@
    },
    "outputs": [],
    "source": [
-    "basis_rel = job_unit.get_final_structure()"
+    "basis_rel = job_unit.get_structure()"
    ]
   },
   {
@@ -535,7 +535,7 @@
    ],
    "source": [
     "# Loop the phonon calculation over all the volumes\n",
-    "sc_bulk_rel = job_bulk_1.get_final_structure()\n",
+    "sc_bulk_rel = job_bulk_1.get_structure()\n",
     "bulk_free_energies = np.zeros((len(scales), len(temperatures)))\n",
     "\n",
     "for i, scale in enumerate(scales):\n",


### PR DESCRIPTION
`final_structure()` is deprecated, so I replaced it (on github directly, so I didn't run it again, but should be fine).