### PR TITLE
set a default mixer for VASP

### DIFF
--- a/pyiron_atomistics/atomistics/master/phonopy.py
+++ b/pyiron_atomistics/atomistics/master/phonopy.py
@@ -330,7 +330,7 @@ class PhonopyJob(AtomisticParallelMaster):
             t_step=t_step, t_max=t_max, t_min=t_min, temperatures=temperatures
         )
         tp_dict = self.phonopy.get_thermal_properties_dict()
-        kJ_mol_to_eV = 1000/scipy.constant.Avogadro/scipy.constants.electron_volt
+        kJ_mol_to_eV = 1000/scipy.constants.Avogadro/scipy.constants.electron_volt
         return Thermal(tp_dict['temperatures'],
                        tp_dict['free_energy'] * kJ_mol_to_eV,
                        tp_dict['entropy'],

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -1308,6 +1308,8 @@ class VaspBase(GenericDFTJob):
             spin_mixing_parameter (float):
 
         """
+        if method is None:
+            method = "PULAY"
         if method.upper() == "PULAY":
             self.input.incar["IMIX"] = 4
         if method.upper() == "KERKER":

--- a/tests/vasp/test_vasp.py
+++ b/tests/vasp/test_vasp.py
@@ -407,6 +407,11 @@ class TestVasp(unittest.TestCase):
         self.assertEqual(self.job.input.incar["EDIFFG"], -0.001)
         self.assertEqual(self.job.input.incar["EDIFF"], 1e-7)
 
+    def test_mixing_parameter(self):
+        job = self.project.create_job('Vasp', 'mixing_parameter')
+        job.set_mixing_parameters(density_mixing_parameter=0.1)
+        self.assertEqual(job.input.incar['IMIX'], 4)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Following [this page](https://www.vasp.at/wiki/index.php/IMIX) I set the default mixer to Pulay for VASP (which appears also reasonable to me). Whether the default is Pulay or not, something has to be done because `None.upper()` gives an unintelligible error message.