### PR TITLE
Get structure fast

### DIFF
--- a/pyiron_atomistics/atomistics/job/interactive.py
+++ b/pyiron_atomistics/atomistics/job/interactive.py
@@ -411,7 +411,9 @@ class GenericInteractiveOutput(GenericOutput):
 
     def _key_from_hdf(self, key):
         """
-        Get all entries from the HDF5 file for a specific key - stored under 'output/interactive/<key>'
+        Get all entries from the HDF5 file for a specific key - stored under 'output/interactive/<key>'.  If not found
+        there the key is looked up in the regular HDF storage location 'output/<key>' via the property on our super
+        class :class:`.GenericOutput`.
 
         Args:
             key (str): name of the key
@@ -419,7 +421,10 @@ class GenericInteractiveOutput(GenericOutput):
         Returns:
 
         """
-        return self._job["output/interactive/" + key]
+        fetched = self._job["output/interactive/" + key]
+        if fetched is None or len(fetched) == 0:
+            fetched = getattr(super(), key)
+        return fetched
 
     def _key_from_property(self, key, prop):
         """
@@ -461,8 +466,6 @@ class GenericInteractiveOutput(GenericOutput):
         """
         cached = self._lst_from_cache(key)
         fetched = self._key_from_hdf(key)
-        if fetched is None or len(fetched) == 0:
-            fetched = getattr(super(), key)
         if fetched is None or len(fetched) == 0:
             return cached
         elif len(cached) == 0:

--- a/pyiron_atomistics/atomistics/job/interactive.py
+++ b/pyiron_atomistics/atomistics/job/interactive.py
@@ -401,7 +401,7 @@ class GenericInteractiveOutput(GenericOutput):
             key (str): name of the key
 
         Returns:
-            list:
+            list: list of arrays stored in the interactive cache
         """
         lst = self._key_from_cache(key)
         if len(lst) != 0 and isinstance(lst[-1], list):
@@ -464,7 +464,7 @@ class GenericInteractiveOutput(GenericOutput):
         Returns:
             :class:`numpy.ndarray`: collected values from all previous steps
         """
-        cached = self._lst_from_cache(key)
+        cached = np.array(self._lst_from_cache(key))
         fetched = self._key_from_hdf(key)
         if fetched is None or len(fetched) == 0:
             return cached


### PR DESCRIPTION
See #41.

This cuts the time on the same sample structure down to \~2s.  There's a similar overhead (\~.5s) for other properties of `GenericInteractiveOutput` that are read via `_key_from_property`.  Pending feedback on #45 I'll cut that too.  I'll assume the rest is due to us reading the full arrays from HDF5 and then indexing them even if we only need a tiny part of them.  But to leverage that we'd have to touch HDF5 code and anyways the current speed up is enough to make it bearable for the POTENTIALS workshop.

For some reason this patch also makes the waiting time on the SQL connection disappear.

Example trace after the patch
```
         70225 function calls (69858 primitive calls) in 1.956 seconds

   Ordered by: internal time
   List reduced from 1008 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      115    0.803    0.007    1.309    0.011 {built-in method numpy.array}
        8    0.504    0.063    0.505    0.063 /u/system/SLES12/soft/pyiron/dev/anaconda3/lib/python3.7/site-packages/h5py/_hl/dataset.py:947(read_direct)
        2    0.304    0.152    0.304    0.152 {method 'tolist' of 'numpy.ndarray' objects}
       14    0.155    0.011    0.156    0.011 {built-in method psycopg2._psycopg._connect}
       14    0.049    0.003    0.049    0.003 {method 'execute' of 'psycopg2.extensions.cursor' objects}
      124    0.021    0.000    0.024    0.000 {method '_g_new' of 'tables.hdf5extension.File' objects}
        2    0.011    0.005    0.545    0.273 /u/zora/software/pyiron_atomistics/pyiron_atomistics/atomistics/job/interactive.py:477(cells)
       14    0.008    0.001    0.008    0.001 {method 'rollback' of 'psycopg2.extensions.connection' objects}
      286    0.004    0.000    0.004    0.000 {method '_g_get_objinfo' of 'tables.hdf5extension.Group' objects}
     5548    0.004    0.000    0.004    0.000 /u/system/SLES12/soft/pyiron/dev/anaconda3/lib/python3.7/site-packages/tables/group.py:838(__setattr__)
```