### PR TITLE
make maxStepLength consistent with sxextopt

### DIFF
--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -457,6 +457,7 @@ class SphinxBase(GenericDFTJob):
                 optimizer = 'ricQN'
             self.input.sphinx.main[optimizer] = Group(table_name = "input")
             self.input.sphinx.main[optimizer]["maxSteps"] = str(self.input["Istep"])
+            self.input.sphinx.main[optimizer]["maxStepLength"] = str(0.1/BOHR_TO_ANGSTROM)
             if "dE" in self.input and "dF" in self.input:
                 self.input["dE"] = 1e-3
             if "dE" in self.input:


### PR DESCRIPTION
This is required not only because `maxStepLength` is not consistent with SxExtOpt, but also it does crazy stuff to the structure.