### PR TITLE
use pyiron-internal is_skewed

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -1948,6 +1948,25 @@ class Atoms(ASEAtoms):
         return self._analyse.pyscal_voronoi_volume()
     get_voronoi_volume.__doc__ = Analyse.pyscal_voronoi_volume.__doc__
 
+    def is_skewed(self, tolerance=1.0e-8):
+        """
+        Check whether the simulation box is skewed/sheared. The algorithm compares the box volume
+        and the product of the box length in each direction. If these numbers do not match, the box
+        is considered to be skewed and the function returns True
+
+        Args:
+            tolerance (float): Relative tolerance above which the structure is considered as skewed
+
+        Returns:
+            (bool): Whether the box is skewed or not.
+        """
+        volume = self.get_volume()
+        prod = np.linalg.norm(self.cell, axis=-1).prod()
+        if volume > 0:
+            if abs(volume-prod)/volume < tolerance:
+                return False
+        return True
+
     def find_mic(self, v, vectors=True):
         """
         Find vectors following minimum image convention (mic). In principle this

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -123,9 +123,6 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             )
         elif was_skewed:
             self._interactive_lib_command(
-                "change_box all triclinic"
-            )
-            self._interactive_lib_command(
                 "change_box all x final 0 %f y final 0 %f z final 0 %f \
                 xy final %f xz final %f yz final %f remap units box"
                 % (lx, ly, lz, 0.0, 0.0, 0.0)

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -108,8 +108,8 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
                 "Warning: setting upper trangular matrix might slow down the calculation"
             )
 
-        is_skewed = self._structure_current.is_skewed()
-        was_skewed = self._structure_previous.is_skewed()
+        is_skewed = self._structure_current.is_skewed(tolerance=1.0e-8)
+        was_skewed = self._structure_previous.is_skewed(tolerance=1.0e-8)
 
         if is_skewed:
             if not was_skewed:

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -108,30 +108,20 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
                 "Warning: setting upper trangular matrix might slow down the calculation"
             )
 
-        is_skewed = self._prism.is_skewed()
-        is_scaled = self.structure._is_scaled
-        if is_scaled:
-            warnings.warn('set_relative() is deprecated as of 2020-02-26. It is not guaranteed from pyiron_atomistics vers. 0.3')
+        is_skewed = self._structure_current.is_skewed()
+        was_skewed = self._structure_previous.is_skewed()
 
-        if is_skewed and is_scaled:
-            self._interactive_lib_command(
-                "change_box all triclinic"
-            )
+        if is_skewed:
+            if not was_skewed:
+                self._interactive_lib_command(
+                    "change_box all triclinic"
+                )
             self._interactive_lib_command(
                 "change_box all x final 0 %f y final 0 %f z final 0 %f \
                  xy final %f xz final %f yz final %f remap units box"
                 % (lx, ly, lz, xy, xz, yz)
             )
-        elif is_skewed and not is_scaled:
-            self._interactive_lib_command(
-                "change_box all triclinic"
-            )
-            self._interactive_lib_command(
-                "change_box all x final 0 %f y final 0 %f z final 0 %f \
-                xy final %f xz final %f yz final %f units box"
-                % (lx, ly, lz, xy, xz, yz)
-            )
-        elif not is_skewed and is_scaled:
+        elif was_skewed:
             self._interactive_lib_command(
                 "change_box all triclinic"
             )
@@ -143,17 +133,10 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             self._interactive_lib_command(
                 "change_box all ortho"
             )
-        else:  # is neither skewed nor scaled
+        else:
             self._interactive_lib_command(
-                "change_box all triclinic"
-            )
-            self._interactive_lib_command(
-                "change_box all x final 0 %f y final 0 %f z final 0 %f \
-                xy final %f xz final %f yz final %f units box"
-                % (lx, ly, lz, 0.0, 0.0, 0.0)
-            )
-            self._interactive_lib_command(
-                "change_box all ortho"
+                "change_box all x final 0 %f y final 0 %f z final 0 %f remap units box"
+                % (lx, ly, lz)
             )
 
     def interactive_volume_getter(self):

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -1607,6 +1607,14 @@ class TestAtoms(unittest.TestCase):
             np.linalg.norm(position-structure.cell*0.1), 0
         )
 
+    def test_is_skewed(self):
+        structure = CrystalStructure("Fe", bravais_basis="bcc", lattice_constant=4.2, pbc=True)
+        self.assertFalse(structure.is_skewed())
+        structure.cell[0,0] += 0.01
+        self.assertFalse(structure.is_skewed())
+        structure.cell[1,0] += 0.01
+        self.assertTrue(structure.is_skewed())
+
     @staticmethod
     def test_set_dihedral():
         structure = ase_to_pyiron(molecule('H2COH'))

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -1609,11 +1609,17 @@ class TestAtoms(unittest.TestCase):
 
     def test_is_skewed(self):
         structure = CrystalStructure("Fe", bravais_basis="bcc", lattice_constant=4.2, pbc=True)
-        self.assertFalse(structure.is_skewed())
+        self.assertFalse(
+            structure.is_skewed(), "is_skewed() returned True, while structure is not skewed"
+        )
         structure.cell[0,0] += 0.01
-        self.assertFalse(structure.is_skewed())
+        self.assertFalse(
+            structure.is_skewed(), "is_skewed() returned True, while structure is not skewed"
+        )
         structure.cell[1,0] += 0.01
-        self.assertTrue(structure.is_skewed())
+        self.assertTrue(
+            structure.is_skewed(), "is_skewed() returned False, while structure is skewed"
+        )
 
     @staticmethod
     def test_set_dihedral():

--- a/tests/lammps/test_interactive.py
+++ b/tests/lammps/test_interactive.py
@@ -63,18 +63,29 @@ class TestLammpsInteractive(unittest.TestCase):
         project.remove(enable=True)
 
     def test_interactive_cells_setter(self):
-        self.job.interactive_cells_setter(np.eye(3))
+        atoms = Atoms("Fe8", positions=np.zeros((8, 3)), cell=np.eye(3), pbc=True)
+        self.job._structure_previous = atoms.copy()
+        self.job._structure_current = atoms.copy()
+        self.job.interactive_cells_setter(self.job._structure_current.cell)
         self.assertEqual(
-            self.job._interactive_library._command[-3],
-            "change_box all triclinic",
+            self.job._interactive_library._command[-1],
+            "change_box all x final 0 1.000000 y final 0 1.000000 z final 0 1.000000 remap units box",
         )
-        self.assertEqual(
-            self.job._interactive_library._command[-2],
-            "change_box all x final 0 1.000000 y final 0 1.000000 z final 0 1.000000                 xy final 0.000000 xz final 0.000000 yz final 0.000000 units box",
-        )
+        self.job._structure_previous = atoms.copy()
+        self.job._structure_current = atoms.copy()
+        self.job._structure_previous.cell[1,0] += 0.01
+        self.job.interactive_cells_setter(self.job._structure_current.cell)
         self.assertEqual(
             self.job._interactive_library._command[-1],
             "change_box all ortho",
+        )
+        self.job._structure_previous = atoms.copy()
+        self.job._structure_current = atoms.copy()
+        self.job._structure_current.cell[1,0] += 0.01
+        self.job.interactive_cells_setter(self.job._structure_current.cell)
+        self.assertEqual(
+            self.job._interactive_library._command[-2],
+            "change_box all triclinic",
         )
 
     def test_interactive_positions_setter(self):


### PR DESCRIPTION
Certain fixes in LAMMPS do not work with `fix orthogonal` etc., which used to work before (essentially before [this commit](https://github.com/pyiron/pyiron_atomistics/commit/04ad909b78b056ea8cfa9433e03050cf7ee25f64)). As I didn't really see how to check whether LAMMPS sees `triclinic` or `orthogonal` from pyiron, I decided to implement it inside pyiron. Hopefully this one is acceptable...