### PR TITLE
Add `ase` class as subdomain of `pr.create.structure`.

### DIFF
--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -65,6 +65,17 @@ class StructureFactory(PyironFactory):
             return ase_to_pyiron(ase_cut(*args, **kwargs))
         cut.__doc__ += ase_cut.__doc__
     
+        def stack(*args, **kwargs):
+            """
+            Returns an ASE's stack result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.
+
+            ase.build.stack docstring:
+
+            """
+            s.publication_add(publication_ase())
+            return ase_to_pyiron(ase_stack(*args, **kwargs))
+        cut.__doc__ += ase_stack.__doc__
+
     @classmethod
     def cut(cls, *args, **kwargs):
         """
@@ -80,6 +91,14 @@ class StructureFactory(PyironFactory):
     #     """
     #     return StructureFactory.ase.cut(*args, **kwargs)
     # cut.__doc__ += ase.cut.__doc__
+
+    @classmethod
+    def stack(cls, *args, **kwargs):
+        """
+        Returns:
+            pyiron_atomistics.atomstic.structure.ase.stack
+        """
+        return cls.ase.stack(*args, **kwargs)
 
     def ase_read(self, *args, **kwargs):
         """

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -25,8 +25,9 @@ from ase.build import (
         root_surface,
         root_surface_analysis,
         surface as ase_surf,
+        cut as ase_cut,
+        stack as ase_stack
     )
-from ase.build import cut as ase_cut, stack as ase_stack
 from ase.spacegroup import crystal as ase_crystal
 from ase.io import read
 import numpy as np
@@ -52,40 +53,44 @@ __date__ = "May 1, 2020"
 s = Settings()
 
 
+class AseFactory:
+    def cut(self, *args, **kwargs):
+        """
+        Returns an ASE's cut result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.
+
+        ase.build.cut docstring:
+
+        """
+        s.publication_add(publication_ase())
+        return ase_to_pyiron(ase_cut(*args, **kwargs))
+    cut.__doc__ += ase_cut.__doc__
+
+    def stack(self, *args, **kwargs):
+        """
+        Returns an ASE's stack result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.
+
+        ase.build.stack docstring:
+
+        """
+        s.publication_add(publication_ase())
+        return ase_to_pyiron(ase_stack(*args, **kwargs))
+    stack.__doc__ += ase_stack.__doc__
+
+    def crystal(self, *args, **kwargs):
+        """
+        Returns an ASE's crystal result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.
+
+        ase.spacegroup.crystal docstring:
+
+        """
+        s.publication_add(publication_ase())
+        return ase_to_pyiron(ase_crystal(*args, **kwargs))
+    crystal.__doc__ += ase_crystal.__doc__
+
+
 class StructureFactory(PyironFactory):
-    class ase:
-        def cut(*args, **kwargs):
-            """
-            Returns an ASE's cut result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.
-
-            ase.build.cut docstring:
-
-            """
-            s.publication_add(publication_ase())
-            return ase_to_pyiron(ase_cut(*args, **kwargs))
-        cut.__doc__ += ase_cut.__doc__
-    
-        def stack(*args, **kwargs):
-            """
-            Returns an ASE's stack result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.
-
-            ase.build.stack docstring:
-
-            """
-            s.publication_add(publication_ase())
-            return ase_to_pyiron(ase_stack(*args, **kwargs))
-        stack.__doc__ += ase_stack.__doc__
-
-        def crystal(*args, **kwargs):
-            """
-            Returns an ASE's crystal result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.
-
-            ase.spacegroup.crystal docstring:
-
-            """
-            s.publication_add(publication_ase())
-            return ase_to_pyiron(ase_crystal(*args, **kwargs))
-        crystal.__doc__ += ase_crystal.__doc__
+    def __init__(self):
+        self.ase = AseFactory()
 
     @classmethod
     def cut(cls, *args, **kwargs):

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -92,29 +92,13 @@ class StructureFactory(PyironFactory):
     def __init__(self):
         self.ase = AseFactory()
 
-    @classmethod
-    def cut(cls, *args, **kwargs):
-        """
-        Returns:
-            pyiron_atomistics.atomstic.structure.ase.cut
-        """
-        return cls.ase.cut(*args, **kwargs)
+    def cut(self, *args, **kwargs):
+        return self.ase.cut(*args, **kwargs)
+    cut.__doc__ = AseFactory.cut.__doc__
 
-    # def cut(*args, **kwargs):
-    #     """
-    #     Returns:
-    #         pyiron_atomistics.atomstic.structure.ase.cut
-    #     """
-    #     return StructureFactory.ase.cut(*args, **kwargs)
-    # cut.__doc__ += ase.cut.__doc__
-
-    @classmethod
-    def stack(cls, *args, **kwargs):
-        """
-        Returns:
-            pyiron_atomistics.atomstic.structure.ase.stack
-        """
-        return cls.ase.stack(*args, **kwargs)
+    def stack(self, *args, **kwargs):
+        return self.ase.stack(*args, **kwargs)
+    stack.__doc__ = AseFactory.stack.__doc__
 
     def ase_read(self, *args, **kwargs):
         """

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -37,7 +37,7 @@ from pyiron_atomistics.atomistics.structure.atoms import CrystalStructure, ase_t
 from pyiron_atomistics.atomistics.structure.periodic_table import PeriodicTable
 from pyiron_base import Settings, PyironFactory
 import types
-
+from functools import wraps
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
@@ -54,6 +54,7 @@ s = Settings()
 
 
 class AseFactory:
+    @wraps(ase_cut)
     def cut(self, *args, **kwargs):
         """
         Returns an ASE's cut result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.
@@ -63,8 +64,8 @@ class AseFactory:
         """
         s.publication_add(publication_ase())
         return ase_to_pyiron(ase_cut(*args, **kwargs))
-    cut.__doc__ += ase_cut.__doc__
 
+    @wraps(ase_stack)
     def stack(self, *args, **kwargs):
         """
         Returns an ASE's stack result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.
@@ -74,8 +75,8 @@ class AseFactory:
         """
         s.publication_add(publication_ase())
         return ase_to_pyiron(ase_stack(*args, **kwargs))
-    stack.__doc__ += ase_stack.__doc__
 
+    @wraps(ase_crystal)
     def crystal(self, *args, **kwargs):
         """
         Returns an ASE's crystal result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.
@@ -85,7 +86,6 @@ class AseFactory:
         """
         s.publication_add(publication_ase())
         return ase_to_pyiron(ase_crystal(*args, **kwargs))
-    crystal.__doc__ += ase_crystal.__doc__
 
 
 class StructureFactory(PyironFactory):

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -74,7 +74,7 @@ class StructureFactory(PyironFactory):
             """
             s.publication_add(publication_ase())
             return ase_to_pyiron(ase_stack(*args, **kwargs))
-        cut.__doc__ += ase_stack.__doc__
+        stack.__doc__ += ase_stack.__doc__
 
     @classmethod
     def cut(cls, *args, **kwargs):

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -76,6 +76,17 @@ class StructureFactory(PyironFactory):
             return ase_to_pyiron(ase_stack(*args, **kwargs))
         stack.__doc__ += ase_stack.__doc__
 
+        def crystal(*args, **kwargs):
+            """
+            Returns an ASE's crystal result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.
+
+            ase.spacegroup.crystal docstring:
+
+            """
+            s.publication_add(publication_ase())
+            return ase_to_pyiron(ase_crystal(*args, **kwargs))
+        crystal.__doc__ += ase_crystal.__doc__
+
     @classmethod
     def cut(cls, *args, **kwargs):
         """

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -53,6 +53,34 @@ s = Settings()
 
 
 class StructureFactory(PyironFactory):
+    class ase:
+        def cut(*args, **kwargs):
+            """
+            Returns an ASE's cut result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.
+
+            ase.build.cut docstring:
+
+            """
+            s.publication_add(publication_ase())
+            return ase_to_pyiron(ase_cut(*args, **kwargs))
+        cut.__doc__ += ase_cut.__doc__
+    
+    @classmethod
+    def cut(cls, *args, **kwargs):
+        """
+        Returns:
+            pyiron_atomistics.atomstic.structure.ase.cut
+        """
+        return cls.ase.cut(*args, **kwargs)
+
+    # def cut(*args, **kwargs):
+    #     """
+    #     Returns:
+    #         pyiron_atomistics.atomstic.structure.ase.cut
+    #     """
+    #     return StructureFactory.ase.cut(*args, **kwargs)
+    # cut.__doc__ += ase.cut.__doc__
+
     def ase_read(self, *args, **kwargs):
         """
         Returns a ASE's read result, wrapped as a `pyiron_atomistics.atomstic.structure.atoms.Atoms` object.

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -26,6 +26,8 @@ from ase.build import (
         root_surface_analysis,
         surface as ase_surf,
     )
+from ase.build import cut as ase_cut, stack as ase_stack
+from ase.spacegroup import crystal as ase_crystal
 from ase.io import read
 import numpy as np
 from pymatgen import Structure, Lattice, PeriodicSite

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -63,7 +63,7 @@ class AseFactory:
 
         """
         s.publication_add(publication_ase())
-        return ase_to_pyiron(ase_cut(*args, **kwargs))
+        return ase_cut(*args, **kwargs)
 
     @wraps(ase_stack)
     def stack(self, *args, **kwargs):
@@ -74,7 +74,7 @@ class AseFactory:
 
         """
         s.publication_add(publication_ase())
-        return ase_to_pyiron(ase_stack(*args, **kwargs))
+        return ase_stack(*args, **kwargs)
 
     @wraps(ase_crystal)
     def crystal(self, *args, **kwargs):


### PR DESCRIPTION
- `ase.build.cut` is available as `pr.create.structure.ase.cut` or `pr.create.structure.cut`
- `ase.build.stack` is available as `pr.create.structure.ase.stack` or `pr.create.structure.stack`
- `ase.spacegroup.crystal` is available as `pr.create.structure.ase.crystal`

Note: as @niklassiemer already mentioned in [#1307](https://github.com/pyiron/pyiron/issues/1307) there is [crystal](https://github.com/pyiron/pyiron_atomistics/blob/859dec1f2d027b51676726c8670e599c5a81b487/pyiron_atomistics/atomistics/structure/factory.py#L155) method in [StructureFactory](https://github.com/pyiron/pyiron_atomistics/blob/859dec1f2d027b51676726c8670e599c5a81b487/pyiron_atomistics/atomistics/structure/factory.py#L50). Therefore, `pr.create.structure.crystal` does not refer to `pr.create.structure.ase.crystal`.
