### PR TITLE
Fail hard instead of silently returning None

### DIFF
--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -173,7 +173,7 @@ class StructureFactory(PyironFactory):
             surface.pbc = pbc
             return ase_to_pyiron(surface)
         else:
-            return None
+            raise ValueError(f"Surface type {surface_type} not recognized.")
 
     @staticmethod
     def surface_hkl(lattice, hkl, layers, vacuum=1.0, center=False, pbc=True):


### PR DESCRIPTION
`pr.structure.create.surface` currently silently returns `None` if the string-valued surface code is something unexpected. I'd rather raise an exception.