### PR TITLE
Get chemical symbols

### DIFF
--- a/pyiron_atomistics/atomistics/structure/neighbors.py
+++ b/pyiron_atomistics/atomistics/structure/neighbors.py
@@ -571,9 +571,7 @@ class Neighbors(Tree):
 
     @property
     def chemical_symbols(self):
-        """
-            Returns chemical symbols of the neighboring atoms.
-        """
+        """ Returns chemical symbols of the neighboring atoms.  """
         return self._ref_structure.get_chemical_symbols()[self.indices]
 
     @property

--- a/pyiron_atomistics/atomistics/structure/neighbors.py
+++ b/pyiron_atomistics/atomistics/structure/neighbors.py
@@ -570,6 +570,13 @@ class Neighbors(Tree):
         return to_return.replace('given positions', 'each atom')
 
     @property
+    def chemical_symbols(self):
+        """
+            Returns chemical symbols of the neighboring atoms.
+        """
+        return self._ref_structure.get_chemical_symbols()[self.indices]
+
+    @property
     def shells(self):
         """
             Returns the cell numbers of each atom according to the distances

--- a/pyiron_atomistics/atomistics/structure/neighbors.py
+++ b/pyiron_atomistics/atomistics/structure/neighbors.py
@@ -571,7 +571,7 @@ class Neighbors(Tree):
 
     @property
     def chemical_symbols(self):
-        """ Returns chemical symbols of the neighboring atoms.  """
+        """Returns chemical symbols of the neighboring atoms."""
         return self._ref_structure.get_chemical_symbols()[self.indices]
 
     @property

--- a/tests/atomistics/structure/test_neighbors.py
+++ b/tests/atomistics/structure/test_neighbors.py
@@ -5,6 +5,7 @@
 import unittest
 import numpy as np
 from pyiron_atomistics.atomistics.structure.atoms import Atoms, CrystalStructure
+from pyiron_atomistics.atomistics.structure.factory import StructureFactory
 import warnings
 
 
@@ -340,7 +341,7 @@ class TestAtoms(unittest.TestCase):
             neigh.norm_order = 3
 
     def test_chemical_symbols(self):
-        basis = CrystalStructure("Fe", bravais_basis="bcc", lattice_constants=1)
+        basis = StructureFactory().ase_bulk('Fe', cubic=True)
         basis[0] = 'Ni'
         neigh = basis.get_neighbors(num_neighbors=1)
         self.assertEqual(neigh.chemical_symbols[0,0], 'Fe')

--- a/tests/atomistics/structure/test_neighbors.py
+++ b/tests/atomistics/structure/test_neighbors.py
@@ -339,6 +339,13 @@ class TestAtoms(unittest.TestCase):
         with self.assertRaises(ValueError):
             neigh.norm_order = 3
 
+    def test_chemical_symbols(self):
+        basis = CrystalStructure("Fe", bravais_basis="bcc", lattice_constants=1)
+        basis[0] = 'Ni'
+        neigh = basis.get_neighbors(num_neighbors=1)
+        self.assertEqual(neigh.chemical_symbols[0,0], 'Fe')
+        self.assertEqual(neigh.chemical_symbols[1,0], 'Ni')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I added `neigh.chemical_symbols` which gives the chemical symbols of the neighboring atoms.

I was not sure if I should call it `neigh.get_chemical_symbols()` or make it a property. Since there's no argument to add, I decided to make it a property, but I'm open to suggestions.