### PR TITLE
change location of compress

### DIFF
--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1940,7 +1940,7 @@ class Output(object):
             return None
         spins = np.loadtxt(posixpath.join(cwd, file_name))
         self._parse_dict["atom_scf_spins"] = self.splitter(
-            [ss[self._job.id_spx_to_pyi] for ss in spins[:, 1:]],
+            np.array([ss[self._job.id_spx_to_pyi] for ss in spins[:, 1:]]),
             spins[:, 0]
         )
 

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1359,12 +1359,14 @@ class SphinxBase(GenericDFTJob):
             es_obj.atoms = self.get_structure(-1)
             return es_obj
 
-    def collect_output(self, force_update=False):
+    def collect_output(self, force_update=False, compress=True):
         """
         Collects the outputs and stores them to the hdf file
         """
         self._output_parser.collect(directory=self.working_directory)
         self._output_parser.to_hdf(self._hdf5, force_update=force_update)
+        if compress:
+            self.compress()
 
     def convergence_check(self):
         """
@@ -2361,7 +2363,6 @@ class Output(object):
                                              cwd=directory)
         self.collect_charge_density(file_name="rho.sxb",
                                     cwd=directory)
-        self._job.compress()
 
     def to_hdf(self, hdf, force_update=False):
         """

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1359,13 +1359,13 @@ class SphinxBase(GenericDFTJob):
             es_obj.atoms = self.get_structure(-1)
             return es_obj
 
-    def collect_output(self, force_update=False, compress=True):
+    def collect_output(self, force_update=False, compress_files=True):
         """
         Collects the outputs and stores them to the hdf file
         """
         self._output_parser.collect(directory=self.working_directory)
         self._output_parser.to_hdf(self._hdf5, force_update=force_update)
-        if compress:
+        if compress_files:
             self.compress()
 
     def convergence_check(self):
@@ -1940,7 +1940,7 @@ class Output(object):
             return None
         spins = np.loadtxt(posixpath.join(cwd, file_name))
         self._parse_dict["atom_scf_spins"] = self.splitter(
-            np.array([ss[self._job.id_spx_to_pyi] for ss in spins[:, 1:]]),
+            [ss[self._job.id_spx_to_pyi] for ss in spins[:, 1:]],
             spins[:, 0]
         )
 

--- a/pyiron_atomistics/sphinx/interactive.py
+++ b/pyiron_atomistics/sphinx/interactive.py
@@ -213,8 +213,8 @@ class SphinxInteractive(SphinxBase, GenericInteractive):
                                     "interactive/atom_spin_constraints"
                                 ]
 
-    def collect_output(self, force_update=False):
-        super(SphinxInteractive, self).collect_output(force_update=force_update)
+    def collect_output(self, force_update=False, compress=True):
+        super(SphinxInteractive, self).collect_output(force_update=force_update, compress=compress)
         self._output_interactive_to_generic()
 
     def interactive_close(self):

--- a/pyiron_atomistics/sphinx/interactive.py
+++ b/pyiron_atomistics/sphinx/interactive.py
@@ -213,8 +213,8 @@ class SphinxInteractive(SphinxBase, GenericInteractive):
                                     "interactive/atom_spin_constraints"
                                 ]
 
-    def collect_output(self, force_update=False, compress=True):
-        super(SphinxInteractive, self).collect_output(force_update=force_update, compress=compress)
+    def collect_output(self, force_update=False, compress_files=True):
+        super(SphinxInteractive, self).collect_output(force_update=force_update, compress_files=compress_files)
         self._output_interactive_to_generic()
 
     def interactive_close(self):


### PR DESCRIPTION
Make it possible to take a look at the output of running jobs without making changes to output files.