### PR TITLE
Drop support for old python < 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,6 @@ setup(
                  'Intended Audience :: Science/Research',
                  'Operating System :: OS Independent',
                  'Programming Language :: Python :: 3',
-                 'Programming Language :: Python :: 3.4',
-                 'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
                  'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
We do this already for all other repos, I guess this one just slipped through.