### PR TITLE
Add 'msd' flag to lammps calc_md to get mean squared displacements directly from lammps

### DIFF
--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -244,6 +244,7 @@ class AtomisticGenericJob(GenericJobCore):
         tloop=None,
         initial_temperature=True,
         langevin=False,
+        msd=False,
     ):
         self._generic_input["calc_mode"] = "md"
         self._generic_input["temperature"] = temperature
@@ -891,3 +892,15 @@ class GenericOutput(object):
             return hdf5_path.list_nodes()
         else:
             return []
+
+    @property
+    def mean_squared_displacement(self):
+        """
+        The mean-squared displacement computed directly within Lammps.
+
+        WARNINGS:
+            1. This works only if the job is a `Lammps` job.
+            2. Returns an output ONLY when the `msd` flag in set to True in `calc_md` for a Lammps job.
+            3. Returns None if used with `calc_static`, `calc_minimize` and `calc_vcsgc` for a Lammps job.
+        """
+        return self._job["output/generic/mean_squared_displacement"]

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -603,6 +603,9 @@ class LammpsBase(AtomisticGenericJob):
                 )
                 df["mean_pressures"] = pressures.tolist()
 
+            if "v_msd" in df:
+                df["mean_squared_displacement"] = df.pop("v_msd")
+
             with self.project_hdf5.open("output/generic") as hdf_output:
                 # This is a hack for backward comparability
                 for k, v in df.items():
@@ -671,6 +674,7 @@ class LammpsBase(AtomisticGenericJob):
         langevin=False,
         delta_temp=None,
         delta_press=None,
+        msd=False,
     ):
         # Docstring set programmatically -- Ensure that changes to signature or defaults stay consistent!
         if self.server.run_mode.interactive_non_modal:
@@ -690,6 +694,7 @@ class LammpsBase(AtomisticGenericJob):
             tloop=tloop,
             initial_temperature=initial_temperature,
             langevin=langevin,
+            msd=msd,
         )
         self.input.control.calc_md(
             temperature=temperature,
@@ -706,7 +711,8 @@ class LammpsBase(AtomisticGenericJob):
             delta_temp=delta_temp,
             delta_press=delta_press,
             job_name=self.job_name,
-            rotation_matrix=rotation_matrix
+            rotation_matrix=rotation_matrix,
+            msd=msd
         )
     calc_md.__doc__ = LammpsControl.calc_md.__doc__
 

--- a/pyiron_atomistics/lammps/control.py
+++ b/pyiron_atomistics/lammps/control.py
@@ -427,7 +427,8 @@ class LammpsControl(GenericParameters):
         delta_temp=None,
         delta_press=None,
         job_name="",
-        rotation_matrix=None
+        rotation_matrix=None,
+        msd=False
     ):
         """
         Set an MD calculation within LAMMPS. Nosé Hoover is used by default.
@@ -471,6 +472,8 @@ class LammpsControl(GenericParameters):
             job_name (str): Job name of the job to generate a unique random seed.
             rotation_matrix (numpy.ndarray): The rotation matrix from the pyiron to Lammps coordinate
                 frame.
+            msd (bool): (True or False) Calculate the mean-squared displacement over all the atoms in the structure
+                for a Lammps job
         """
         if self["units"] not in LAMMPS_UNIT_CONVERSIONS.keys():
             raise NotImplementedError
@@ -605,6 +608,14 @@ class LammpsControl(GenericParameters):
                 seed=seed,
                 gaussian=True,
                 job_name=job_name
+            )
+
+        if msd:
+            self.modify(
+                compute___1="all msd com yes",
+                variable___msd=" equal c_1[4]",
+                thermo_style=self.get("thermo_style") + " v_msd",
+                append_if_not_present=True,
             )
 
     def calc_vcsgc(

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -287,6 +287,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         langevin=False,
         delta_temp=None,
         delta_press=None,
+        msd=False,
     ):
         super(LammpsInteractive, self).calc_md(
             temperature=temperature,
@@ -302,6 +303,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             langevin=langevin,
             delta_temp=delta_temp,
             delta_press=delta_press,
+            msd=msd,
         )
         if self.interactive_is_activated() and (
             self.server.run_mode.interactive

--- a/tests/atomistics/job/test_atomistic.py
+++ b/tests/atomistics/job/test_atomistic.py
@@ -68,6 +68,10 @@ class TestAtomisticGenericJob(unittest.TestCase):
             disp_ref.append(np.dot(diff, cell))
         self.assertTrue(np.allclose(disp, disp_ref))
 
+    def test_get_mean_squared_displacement(self):
+        self.job["output/generic/mean_squared_displacement"] = None
+        self.assertIsNone(self.job.output.mean_squared_displacement)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/atomistics/job/test_atomistic.py
+++ b/tests/atomistics/job/test_atomistic.py
@@ -68,10 +68,5 @@ class TestAtomisticGenericJob(unittest.TestCase):
             disp_ref.append(np.dot(diff, cell))
         self.assertTrue(np.allclose(disp, disp_ref))
 
-    def test_get_mean_squared_displacement(self):
-        self.job["output/generic/mean_squared_displacement"] = None
-        self.assertIsNone(self.job.output.mean_squared_displacement)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -619,6 +619,13 @@ class TestLammps(unittest.TestCase):
         self.assertTrue(np.isclose(float(m.group(7)), 0.0 * cnv))
         self.assertTrue(np.isclose(float(m.group(8)), 0.0 * cnv))
 
+        # test if msd flag works
+        self.md_control_job.calc_md(temperature=300., msd=True)
+        self.assertEqual(self.md_control_job.input.control["compute___1"], "all msd com yes")
+        self.assertEqual(self.md_control_job.input.control["variable___msd"], " equal c_1[4]")
+        self.assertEqual(self.md_control_job.input.control["thermo_style"],
+                         "custom step temp pe etotal pxx pxy pxz pyy pyz pzz vol v_msd")
+
     def test_read_restart_file(self):
         self.job_read_restart.read_restart_file()
         self.assertIsNone(self.job_read_restart['dimension'])


### PR DESCRIPTION
I usually manually calculate msd from the total displacements. Getting msd directly from lammps seemed more efficient. It is not super important to merge this PR, though.