### PR TITLE
Bind ASE structure conversion to `Atoms` and `StructureFactory`

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2647,6 +2647,12 @@ class Atoms(ASEAtoms):
     def to_ase(self):
         return pyiron_to_ase(self)
 
+    def to_pymatgen(self):
+        return pyiron_to_pymatgen(self)
+
+    def to_ovito(self):
+        return pyiron_to_ovito(self)
+
 
 class _CrystalStructure(Atoms):
     """

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2644,6 +2644,9 @@ class Atoms(ASEAtoms):
             dummy_basis.rotate(a=a, v=v, center=center, rotate_cell=rotate_cell)
             self.positions[index_list] = dummy_basis.positions[index_list]
 
+    def to_ase(self):
+        return pyiron_to_ase(self)
+
 
 class _CrystalStructure(Atoms):
     """

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -28,7 +28,8 @@ import numpy as np
 from pyiron_atomistics.atomistics.structure.factories.ase import AseFactory
 from pyiron_atomistics.atomistics.structure.factories.aimsgb import AimsgbFactory
 from pyiron_atomistics.atomistics.structure.pyironase import publication as publication_ase
-from pyiron_atomistics.atomistics.structure.atoms import CrystalStructure, ase_to_pyiron, Atoms
+from pyiron_atomistics.atomistics.structure.atoms import CrystalStructure, Atoms, \
+    ase_to_pyiron, pymatgen_to_pyiron, ovito_to_pyiron
 from pyiron_atomistics.atomistics.structure.periodic_table import PeriodicTable
 from pyiron_base import Settings, PyironFactory, deprecate
 import types
@@ -389,3 +390,13 @@ class StructureFactory(PyironFactory):
     @wraps(ase_to_pyiron)
     def from_ase(ase_atoms):
         return ase_to_pyiron(ase_atoms)
+
+    @staticmethod
+    @wraps(pymatgen_to_pyiron)
+    def from_ase(pymatgen_obj):
+        return pymatgen_to_pyiron(pymatgen_obj)
+
+    @staticmethod
+    @wraps(ovito_to_pyiron)
+    def from_ase(ovito_obj):
+        return ovito_to_pyiron(ovito_obj)

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -32,6 +32,7 @@ from pyiron_atomistics.atomistics.structure.atoms import CrystalStructure, ase_t
 from pyiron_atomistics.atomistics.structure.periodic_table import PeriodicTable
 from pyiron_base import Settings, PyironFactory, deprecate
 import types
+from functools import wraps
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
@@ -383,3 +384,8 @@ class StructureFactory(PyironFactory):
             add_if_dist=add_if_dist
         )
     aimsgb_build.__doc__ = AimsgbFactory.build.__doc__
+
+    @staticmethod
+    @wraps(ase_to_pyiron)
+    def from_ase(ase_atoms):
+        return ase_to_pyiron(ase_atoms)

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -393,10 +393,10 @@ class StructureFactory(PyironFactory):
 
     @staticmethod
     @wraps(pymatgen_to_pyiron)
-    def from_ase(pymatgen_obj):
+    def from_pymatgen(pymatgen_obj):
         return pymatgen_to_pyiron(pymatgen_obj)
 
     @staticmethod
     @wraps(ovito_to_pyiron)
-    def from_ase(ovito_obj):
+    def from_ovito(ovito_obj):
         return ovito_to_pyiron(ovito_obj)


### PR DESCRIPTION
`structure.to_ase()`, and `pr.create.structure.from_ase(some_ase_structure)` are now possible by simple bindings.