### PR TITLE
No impossible warnings

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -3139,10 +3139,6 @@ def ase_to_pyiron(ase_obj):
         pyiron.atomistics.structure.atoms.Atoms: The equivalent pyiron structure
 
     """
-    try:
-        import ase
-    except ImportError:
-        raise ValueError("ASE package not yet installed")
     element_list = ase_obj.get_chemical_symbols()
     cell = ase_obj.cell
     positions = ase_obj.get_positions()
@@ -3183,10 +3179,7 @@ def ase_to_pyiron(ase_obj):
 
 
 def pyiron_to_ase(pyiron_obj):
-    try:
-        from pyiron_atomistics.atomistics.structure.pyironase import ASEAtoms
-    except ImportError:
-        raise ValueError("ASE package not yet installed")
+    from pyiron_atomistics.atomistics.structure.pyironase import ASEAtoms
     element_list = pyiron_obj.get_parent_symbols()
     cell = pyiron_obj.cell
     positions = pyiron_obj.positions

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -21,6 +21,7 @@ from pyiron_atomistics.atomistics.structure.periodic_table import (
     ChemicalElement
 )
 from pyiron_base import Settings, deprecate, deprecate_soon
+from pyiron_atomistics.atomistics.structure.pyironase import publication
 
 from scipy.spatial import cKDTree, Voronoi
 import spglib
@@ -3179,7 +3180,6 @@ def ase_to_pyiron(ase_obj):
 
 
 def pyiron_to_ase(pyiron_obj):
-    from pyiron_atomistics.atomistics.structure.pyironase import ASEAtoms
     element_list = pyiron_obj.get_parent_symbols()
     cell = pyiron_obj.cell
     positions = pyiron_obj.positions

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -22,6 +22,7 @@ from pyiron_atomistics.atomistics.structure.periodic_table import (
 )
 from pyiron_base import Settings, deprecate, deprecate_soon
 from pyiron_atomistics.atomistics.structure.pyironase import publication
+from pymatgen.io.ase import AseAtomsAdaptor
 
 from scipy.spatial import cKDTree, Voronoi
 import spglib
@@ -3238,10 +3239,6 @@ def pymatgen_to_pyiron(pymatgen_obj):
     Returns:
         pyiron atoms object
     """
-    try:
-        from pymatgen.io.ase import AseAtomsAdaptor
-    except ImportError:
-        raise ValueError("PyMatGen package not yet installed")
     return ase_to_pyiron(AseAtomsAdaptor().get_atoms(structure=pymatgen_obj))
 
 
@@ -3255,10 +3252,6 @@ def pyiron_to_pymatgen(pyiron_obj):
     Returns:
         pymatgen atoms object
     """
-    try:
-        from pymatgen.io.ase import AseAtomsAdaptor
-    except ImportError:
-        raise ValueError("PyMatGen package not yet installed")
     ase_atoms = pyiron_to_ase(pyiron_obj)
     _check_if_simple_atoms(atoms=ase_atoms)
     return AseAtomsAdaptor().get_structure(atoms=ase_atoms, cls=None)

--- a/pyiron_atomistics/atomistics/structure/pyironase.py
+++ b/pyiron_atomistics/atomistics/structure/pyironase.py
@@ -2,12 +2,7 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-import sys
-
-try:
-    from ase.atoms import Atoms as ASEAtoms
-except ImportError:
-    pass
+from ase.atoms import Atoms as ASEAtoms
 
 __author__ = "Joerg Neugebauer"
 __copyright__ = (

--- a/pyiron_atomistics/atomistics/structure/pyironase.py
+++ b/pyiron_atomistics/atomistics/structure/pyironase.py
@@ -2,8 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from ase.atoms import Atoms as ASEAtoms
-
 __author__ = "Joerg Neugebauer"
 __copyright__ = (
     "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "


### PR DESCRIPTION
`ase` is in our dependencies, so I stopped wrapping its importation in a `try/except`.

Also, when should we add the ASE paper to our publication list? Before it was only when `pyiron_to_ase` is used. I would rather suggest that given how heavily `Atoms` relies on `ase.Atoms` we should use it whenever a structure is created!

Thus, I simply import the publication right in `atoms.py`, so it shows up in the list whenever a project uses structures. I'm going to leave this as draft until I get feedback on that behaviour, e.g. at the Friday meeting.