### PR TITLE
updating binder/postBuild

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -5,10 +5,6 @@ pip install .
 jupyter nbextension install nglview --py --sys-prefix
 jupyter nbextension enable nglview --py --sys-prefix
 
-# ngl view for jupyter lab
-jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build
-jupyter labextension install nglview-js-widgets --minimize=False
-
 # clean up
 if [ -d "notebooks" ]; then
     mv notebooks/* .


### PR DESCRIPTION
since nglview=3.0.1, a separate installation of the corresponding jupyterlab extension via the post build script is no longer required. Therefore, the postbuild script is modified accordingly.