### PR TITLE
Document energy_pot_per_atom

### DIFF
--- a/pyiron_atomistics/lammps/control.py
+++ b/pyiron_atomistics/lammps/control.py
@@ -793,6 +793,9 @@ class LammpsControl(GenericParameters):
             raise NotImplementedError(key+' is not implemented')
 
     def energy_pot_per_atom(self):
+        """
+        Enable the output of atomic energies.  This will add an additional key 'energy_pot_per_atom' to the HDF output.
+        """
         if self['compute___energy_pot_per_atom'] is None:
             self['compute___energy_pot_per_atom'] = 'all pe/atom'
             self['dump___1'] += ' c_energy_pot_per_atom'


### PR DESCRIPTION
I'm not sure if the HDF output path should be "hard-coded" here, but I do think it's the crucial information needed here.

In general, I'd like that function to be more visible, but am a bit unsure where place it, any thoughts?