### PR TITLE
Grain thickness

### DIFF
--- a/pyiron_atomistics/_tests.py
+++ b/pyiron_atomistics/_tests.py
@@ -1,0 +1,59 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+"""
+Classes to help developers avoid code duplication when writing tests for pyiron.
+
+TODO:
+    This is just a direct copy of the same file in pyiron_base. As soon as sub-module Project objects
+    actually *update* the Project class (e.g. with new functionality on the create attribute) then this
+    module can be removed and the module directly from base can be used.
+"""
+
+import unittest
+from os.path import split, join
+from os import remove
+from pyiron_atomistics.project import Project
+from abc import ABC
+from inspect import getfile
+
+__author__ = "Liam Huber"
+__copyright__ = (
+    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "0.0"
+__maintainer__ = "Liam Huber"
+__email__ = "huber@mpie.de"
+__status__ = "development"
+__date__ = "Mar 23, 2021"
+
+
+class TestWithProject(unittest.TestCase, ABC):
+    """
+    Tests that start and remove a project for their suite.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.project_path = getfile(cls)[:-3].replace("\\", "/")
+        cls.file_location, cls.project_name = split(cls.project_path)
+        cls.project = Project(cls.project_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.remove(enable=True)
+        try:
+            remove(join(cls.file_location, "pyiron.log"))
+        except FileNotFoundError:
+            pass
+
+
+class TestWithCleanProject(TestWithProject, ABC):
+    """
+    Tests that start and remove a project for their suite, and remove jobs from the project for each test.
+    """
+
+    def tearDown(self):
+        self.project.remove_jobs_silently(recursive=True)

--- a/pyiron_atomistics/atomistics/structure/factories/aimsgb.py
+++ b/pyiron_atomistics/atomistics/structure/factories/aimsgb.py
@@ -52,7 +52,9 @@ class AimsgbFactory:
             initial_struct,
             to_primitive=False,
             delete_layer='0b0t0b0t',
-            add_if_dist=0.0
+            add_if_dist=0.0,
+            uc_a=1,
+            uc_b=1
     ):
         """
         Generate a grain boundary structure based on the aimsgb.GrainBoundary module.
@@ -73,13 +75,15 @@ class AimsgbFactory:
                            Default value is add_if_dist=0.0
             to_primitive : To generate primitive or non-primitive GB structure. Default value is
                             to_primitive=False
+            uc_a (int): Number of unit cell of grain A. Default to 1.
+            uc_b (int): Number of unit cell of grain B. Default to 1.
 
         Returns:
             :class:`.Atoms`: final grain boundary structure
         """
         basis_pymatgen = pyiron_to_pymatgen(initial_struct)
         grain_init = Grain(basis_pymatgen.lattice, basis_pymatgen.species, basis_pymatgen.frac_coords)
-        gb_obj = GrainBoundary(axis=axis, sigma=sigma, plane=plane, initial_struct=grain_init)
+        gb_obj = GrainBoundary(axis=axis, sigma=sigma, plane=plane, initial_struct=grain_init, uc_a=uc_a, uc_b=uc_b)
 
         return pymatgen_to_pyiron(gb_obj.build_gb(to_primitive=to_primitive, delete_layer=delete_layer,
                                                   add_if_dist=add_if_dist))

--- a/tests/atomistics/structure/factories/test_aimsgb.py
+++ b/tests/atomistics/structure/factories/test_aimsgb.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from pyiron_atomistics._tests import TestWithProject
+from pyiron_atomistics.atomistics.structure.factories.aimsgb import AimsgbFactory
+
+
+class TestAimsgbFactory(TestWithProject):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.fcc_basis = cls.project.create.structure.bulk('Al', cubic=True)
+        cls.factory = AimsgbFactory()
+
+    def test_grain_thickness(self):
+        axis = [0, 0, 1]
+        sigma = 5
+        plane = [1, 2, 0]
+        gb1 = self.factory.build(axis, sigma, plane, self.fcc_basis)  # Default thicknesses expected to be 1
+        uc_a, uc_b = 2, 3  # Make grains thicker
+        gb2 = self.factory.build(axis, sigma, plane, self.fcc_basis, uc_a=uc_a, uc_b=uc_b)
+        self.assertEqual(
+            ((uc_a + uc_b)/2)*len(gb1), len(gb2),
+            msg="Expected structure to be bigger in proportion to grain thickness"
+        )


### PR DESCRIPTION
Add kwargs to the aimsgb binding so we can specify the thickness of grains (in terms of the unit cell provided). 

Note that structural repetitions *inside* the GB plane are already trivially easy with the `repeat` call to structures. It's just the thickness that was not possible.