### PR TITLE
Extract get_structure to abstract Mixin

### DIFF
--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -616,18 +616,7 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         """
         return self.get_structure(iteration_step=-1)
 
-    def get_structure(self, iteration_step=-1, wrap_atoms=True):
-        """
-        Gets the structure from a given iteration step of the simulation (MD/ionic relaxation). For static calculations
-        there is only one ionic iteration step
-
-        Args:
-            iteration_step (int): Step for which the structure is requested
-            wrap_atoms (bool): True if the atoms are to be wrapped back into the unit cell
-
-        Returns:
-            pyiron.atomistics.structure.atoms.Atoms: The required structure
-        """
+    def _get_structure_impl(self, iteration_step=-1, wrap_atoms=True):
         if self.structure is None:
             raise AssertionError('Structure not set')
         snapshot = self.structure.copy()
@@ -636,7 +625,7 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
                 snapshot.cell = self.output.cells[iteration_step]
             except IndexError:
                 if wrap_atoms:
-                    raise IndexError('cell at step ', iteration_step, ' not found')
+                    raise IndexError('cell at step ', iteration_step, ' not found') from None
                 snapshot.cell = None
         if self.output.indices is not None:
             try:
@@ -653,9 +642,8 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
                 snapshot.positions += self.output.total_displacements[iteration_step]
         return snapshot
 
-    def get_number_of_structures(self):
+    def _number_of_structures_impl(self):
         return self.output.positions.shape[0]
-    get_number_of_structures.__doc__ = HasStructure.get_number_of_structures.__doc__
 
     def map(self, function, parameter_lst):
         master = self.create_job(

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -616,30 +616,30 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         """
         return self.get_structure(iteration_step=-1)
 
-    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, frame=-1, wrap_atoms=True):
         if self.structure is None:
             raise AssertionError('Structure not set')
         snapshot = self.structure.copy()
         if self.output.cells is not None:
             try:
-                snapshot.cell = self.output.cells[iteration_step]
+                snapshot.cell = self.output.cells[frame]
             except IndexError:
                 if wrap_atoms:
-                    raise IndexError('cell at step ', iteration_step, ' not found') from None
+                    raise IndexError('cell at step ', frame, ' not found') from None
                 snapshot.cell = None
         if self.output.indices is not None:
             try:
-                snapshot.indices = self.output.indices[iteration_step]
+                snapshot.indices = self.output.indices[frame]
             except IndexError:
                 pass
         if self.output.positions is not None:
             if wrap_atoms:
-                snapshot.positions = self.output.positions[iteration_step]
+                snapshot.positions = self.output.positions[frame]
                 snapshot.center_coordinates_in_unit_cell()
-            elif len(self.output.unwrapped_positions) > max([iteration_step, 0]):
-                snapshot.positions = self.output.unwrapped_positions[iteration_step]
+            elif len(self.output.unwrapped_positions) > max([frame, 0]):
+                snapshot.positions = self.output.unwrapped_positions[frame]
             else:
-                snapshot.positions += self.output.total_displacements[iteration_step]
+                snapshot.positions += self.output.total_displacements[frame]
         return snapshot
 
     def _number_of_structures(self):

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -616,7 +616,7 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         """
         return self.get_structure(iteration_step=-1)
 
-    def _get_structure_impl(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
         if self.structure is None:
             raise AssertionError('Structure not set')
         snapshot = self.structure.copy()
@@ -642,7 +642,7 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
                 snapshot.positions += self.output.total_displacements[iteration_step]
         return snapshot
 
-    def _number_of_structures_impl(self):
+    def _number_of_structures(self):
         return self.output.positions.shape[0]
 
     def map(self, function, parameter_lst):

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -9,6 +9,7 @@ import numpy as np
 import warnings
 
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
+from ..structure.has_structure import HasStructure
 from pyiron_base import GenericParameters, GenericMaster, GenericJob as GenericJobCore, deprecate
 
 try:
@@ -28,7 +29,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
-class AtomisticGenericJob(GenericJobCore):
+class AtomisticGenericJob(GenericJobCore, HasStructure):
     """
     Atomistic Generic Job class extends the Generic Job class with all the functionality to run jobs containing
     atomistic structures. From this class all specific atomistic Hamiltonians are derived. Therefore it should contain
@@ -651,6 +652,10 @@ class AtomisticGenericJob(GenericJobCore):
             else:
                 snapshot.positions += self.output.total_displacements[iteration_step]
         return snapshot
+
+    def get_number_of_structures(self):
+        return self.output.positions.shape[0]
+    get_number_of_structures.__doc__ = HasStructure.get_number_of_structures.__doc__
 
     def map(self, function, parameter_lst):
         master = self.create_job(

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -9,7 +9,7 @@ import numpy as np
 import warnings
 
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
-from ..structure.has_structure import HasStructure
+from pyiron_atomistics.atomistics.structure.has_structure import HasStructure
 from pyiron_base import GenericParameters, GenericMaster, GenericJob as GenericJobCore, deprecate
 
 try:

--- a/pyiron_atomistics/atomistics/job/sqs.py
+++ b/pyiron_atomistics/atomistics/job/sqs.py
@@ -180,19 +180,13 @@ class SQSJob(AtomisticGenericJob):
             return self._lst_of_struct
         else:
             return []
-    
-    def get_structure(self, iteration_step=-1, wrap_atoms=True):
-        """
-        Gets the structure from a given iteration step of the simulation (MD/ionic relaxation). For static calculations
-        there is only one ionic iteration step
-        Args:
-            iteration_step (int): Step for which the structure is requested
-            wrap_atoms (bool): True if the atoms are to be wrapped back into the unit cell
-        Returns:
-            pyiron.atomistics.structure.atoms.Atoms: The required structure
-        """
+
+    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
         return self.list_structures()[iteration_step]
-    
+
+    def _number_of_structures(self):
+        return len(self.list_structures())
+
     # This function is executed 
     def run_static(self):
         self._lst_of_struct, decmp, iterations, cycle_time = get_sqs_structures(

--- a/pyiron_atomistics/atomistics/job/sqs.py
+++ b/pyiron_atomistics/atomistics/job/sqs.py
@@ -181,8 +181,8 @@ class SQSJob(AtomisticGenericJob):
         else:
             return []
 
-    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
-        return self.list_structures()[iteration_step]
+    def _get_structure(self, frame=-1, wrap_atoms=True):
+        return self.list_structures()[frame]
 
     def _number_of_structures(self):
         return len(self.list_structures())

--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -11,7 +11,6 @@ import scipy.constants
 import warnings
 from pyiron_atomistics.atomistics.structure.atoms import Atoms, ase_to_pyiron
 from pyiron_atomistics.atomistics.master.parallel import AtomisticParallelMaster
-from ..structure.has_structure import HasStructure
 from pyiron_base import JobGenerator
 
 __author__ = "Joerg Neugebauer, Jan Janssen"

--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -827,7 +827,7 @@ class Murnaghan(AtomisticParallelMaster, HasStructure):
         if plt_show:
             plt.show()
 
-    def _get_structure_impl(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
         """
         Gives original structure or final one with equilibrium volume.
 
@@ -848,7 +848,7 @@ class Murnaghan(AtomisticParallelMaster, HasStructure):
         elif iteration_step == 0:
             return self.structure
 
-    def _number_of_structures_impl(self):
+    def _number_of_structures(self):
         if self.structure is None:
             return 0
         elif not self.status.finished:

--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -826,7 +826,7 @@ class Murnaghan(AtomisticParallelMaster):
         if plt_show:
             plt.show()
 
-    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, frame=-1, wrap_atoms=True):
         """
         Gives original structure or final one with equilibrium volume.
 
@@ -836,7 +836,7 @@ class Murnaghan(AtomisticParallelMaster):
         Returns:
             :class:`pyiron_atomistics.atomistics.structure.atoms.Atoms`: requested structure
         """
-        if iteration_step == 1:
+        if frame == 1:
             snapshot = self.structure.copy()
             old_vol = snapshot.get_volume()
             new_vol = self["output/equilibrium_volume"]
@@ -844,7 +844,7 @@ class Murnaghan(AtomisticParallelMaster):
             new_cell = snapshot.cell * k
             snapshot.set_cell(new_cell, scale_atoms=True)
             return snapshot
-        elif iteration_step == 0:
+        elif frame == 0:
             return self.structure
 
     def _number_of_structures(self):

--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -591,7 +591,7 @@ class EnergyVolumeFit(object):
 
 
 # ToDo: not all abstract methods implemented
-class Murnaghan(AtomisticParallelMaster, HasStructure):
+class Murnaghan(AtomisticParallelMaster):
     """
     Murnghan calculation to obtain the minimum energy volume and bulk modulus.
 

--- a/pyiron_atomistics/atomistics/master/parallel.py
+++ b/pyiron_atomistics/atomistics/master/parallel.py
@@ -41,10 +41,10 @@ class AtomisticParallelMaster(ParallelMaster, AtomisticGenericJob):
                 "A structure can only be set after a reference job has been assinged."
             )
 
-    def _get_structure_impl(self, iteration_step=0, wrap_atoms=True):
+    def _get_structure(self, iteration_step=0, wrap_atoms=True):
         return self.structure
 
-    def _number_of_structures_impl(self):
+    def _number_of_structures(self):
         return 1
 
 

--- a/pyiron_atomistics/atomistics/master/parallel.py
+++ b/pyiron_atomistics/atomistics/master/parallel.py
@@ -41,7 +41,7 @@ class AtomisticParallelMaster(ParallelMaster, AtomisticGenericJob):
                 "A structure can only be set after a reference job has been assinged."
             )
 
-    def _get_structure(self, iteration_step=0, wrap_atoms=True):
+    def _get_structure(self, frame=0, wrap_atoms=True):
         return self.structure
 
     def _number_of_structures(self):

--- a/pyiron_atomistics/atomistics/master/parallel.py
+++ b/pyiron_atomistics/atomistics/master/parallel.py
@@ -41,11 +41,11 @@ class AtomisticParallelMaster(ParallelMaster, AtomisticGenericJob):
                 "A structure can only be set after a reference job has been assinged."
             )
 
-    def get_structure(self, iteration_step=-1):
-        if iteration_step == 0:
-            return self.structure
-        else:
-            raise ValueError("iteration_step should be either 0.")
+    def _get_structure_impl(self, iteration_step=0, wrap_atoms=True):
+        return self.structure
+
+    def _number_of_structures_impl(self):
+        return 1
 
 
 class GenericOutput(OrderedDict):

--- a/pyiron_atomistics/atomistics/master/serial.py
+++ b/pyiron_atomistics/atomistics/master/serial.py
@@ -146,9 +146,9 @@ class SerialMaster(SerialMasterBase, AtomisticGenericJob):
                 "A structure can only be set after a start job has been assinged."
             )
 
-    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, frame=-1, wrap_atoms=True):
         return self.project.load(self.child_ids[-1]).get_structure(
-            iteration_step=iteration_step, wrap_atoms=wrap_atoms
+            frame=frame, wrap_atoms=wrap_atoms
         )
 
     def _number_of_structures(self):

--- a/pyiron_atomistics/atomistics/master/serial.py
+++ b/pyiron_atomistics/atomistics/master/serial.py
@@ -146,15 +146,13 @@ class SerialMaster(SerialMasterBase, AtomisticGenericJob):
                 "A structure can only be set after a start job has been assinged."
             )
 
-    def get_structure(self, iteration_step=-1):
-        """
+    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+        return self.project.load(self.child_ids[-1]).get_structure(
+            iteration_step=iteration_step, wrap_atoms=wrap_atoms
+        )
 
-        Returns:
-
-        """
+    def _number_of_structures(self):
         if len(self.child_ids) > 0:
-            return self.project.load(self.child_ids[-1]).get_structure(
-                iteration_step=iteration_step
-            )
+            return self.project.load(self.child_ids[-1])._number_of_structures()
         else:
-            return None
+            return 0

--- a/pyiron_atomistics/atomistics/structure/has_structure.py
+++ b/pyiron_atomistics/atomistics/structure/has_structure.py
@@ -24,11 +24,11 @@ class HasStructure(ABC):
     """
     Mixin for classes that have one or more structures attached to them.
 
-    Necessary overrides are :abstractmethod:`._get_structure_impl()` and
-    :abstractmethod:`._number_of_structures_impl()`.
+    Necessary overrides are :abstractmethod:`._get_structure()` and
+    :abstractmethod:`._number_of_structures()`.
 
     :method:`.get_structure()` checks that iteration_step is valid; implementations of
-    :abstractmethod:`._get_structure_impl()` therefore don't have to check it.
+    :abstractmethod:`._get_structure()` therefore don't have to check it.
 
     :method:`.get_number_of_structures()` may return zero, e.g. if there's no structure stored in the object yet or a
     job will compute this structure, but hasn't been run yet.
@@ -37,9 +37,9 @@ class HasStructure(ABC):
 
     >>> from pyiron_atomistics.atomistics.structure.atoms import Atoms
     >>> class Foo(HasStructure):
-    ...     def _get_structure_impl(self, iteration_step=-1, wrap_atoms=True):
+    ...     def _get_structure(self, iteration_step=-1, wrap_atoms=True):
     ...         return Atoms(symbols=['Fe'], positions=[[0,0,0]])
-    ...     def _number_of_structures_impl(self):
+    ...     def _number_of_structures(self):
     ...         return 1
 
     >>> f = Foo()
@@ -76,10 +76,10 @@ class HasStructure(ABC):
         if not (0 <= iteration_step < num_structures):
             raise IndexError(f"iteration_step {iteration_step} out of range [0, {num_structures}).")
 
-        return self._get_structure_impl(iteration_step=iteration_step, wrap_atoms=wrap_atoms)
+        return self._get_structure(iteration_step=iteration_step, wrap_atoms=wrap_atoms)
 
     @abstractmethod
-    def _get_structure_impl(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
         pass
 
     @property
@@ -87,10 +87,10 @@ class HasStructure(ABC):
         """
         `int`: maximum `iteration_step` + 1 that can be passed to :method:`.get_structure()`.
         """
-        return self._number_of_structures_impl()
+        return self._number_of_structures()
 
     @abstractmethod
-    def _number_of_structures_impl(self):
+    def _number_of_structures(self):
         pass
 
     def iter_structures(self, wrap_atoms=True):
@@ -105,4 +105,4 @@ class HasStructure(ABC):
             :class:`pyiron_atomistics.atomistitcs.structure.atoms.Atoms`: every structure attached to the object
         """
         for i in range(self.number_of_structures):
-            yield self._get_structure_impl(iteration_step=i, wrap_atoms=wrap_atoms)
+            yield self._get_structure(iteration_step=i, wrap_atoms=wrap_atoms)

--- a/pyiron_atomistics/atomistics/structure/has_structure.py
+++ b/pyiron_atomistics/atomistics/structure/has_structure.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 from abc import ABC, abstractmethod, abstractproperty
+from pyiron_base import deprecate
 
 """
 Mixin for classes that have one or more structures attached to them.
@@ -63,13 +64,15 @@ class HasStructure(ABC):
     True
     """
 
-    def get_structure(self, iteration_step=-1, wrap_atoms=True):
+    @deprecate(iteration_step="use frame instead")
+    def get_structure(self, frame=-1, wrap_atoms=True, iteration_step=None):
         """
-        Gets the structure from a given iteration step of the simulation (MD/ionic relaxation). For static calculations
-        there is only one ionic iteration step.
+        Retrieve structure from object.  The number of available structures depends on the job and what kind of
+        calculation has been run on it, see :property:`.number_of_structures`.
 
         Args:
-            iteration_step (int): Step for which the structure is requested, if negative count from the back
+            frame (int): index of the structure requested, if negative count from the back
+            iteration_step (int): deprecated alias for frame
             wrap_atoms (bool): True if the atoms are to be wrapped back into the unit cell
 
         Returns:
@@ -78,13 +81,15 @@ class HasStructure(ABC):
         Raises:
             IndexError: if not -:property:`.number_of_structures` <= iteration_step < :property:`.number_of_structures`
         """
+        if iteration_step is not None:
+            frame = iteration_step
         num_structures = self.number_of_structures
-        if iteration_step < 0:
-            iteration_step += num_structures
-        if not (0 <= iteration_step < num_structures):
-            raise IndexError(f"iteration_step {iteration_step} out of range [-{num_structures}, {num_structures}).")
+        if frame < 0:
+            frame += num_structures
+        if not (0 <= frame < num_structures):
+            raise IndexError(f"iteration_step {frame} out of range [-{num_structures}, {num_structures}).")
 
-        return self._get_structure(iteration_step=iteration_step, wrap_atoms=wrap_atoms)
+        return self._get_structure(iteration_step=frame, wrap_atoms=wrap_atoms)
 
     @abstractmethod
     def _get_structure(self, iteration_step=-1, wrap_atoms=True):

--- a/pyiron_atomistics/atomistics/structure/has_structure.py
+++ b/pyiron_atomistics/atomistics/structure/has_structure.py
@@ -46,7 +46,7 @@ class HasStructure(ABC):
     ...         .. method:: get_structure
     ...             returns structure with single Fe atom at (0, 0, 0)
     ...     '''
-    ...     def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+    ...     def _get_structure(self, frame=-1, wrap_atoms=True):
     ...         return Atoms(symbols=['Fe'], positions=[[0,0,0]])
     ...     def _number_of_structures(self):
     ...         return 1
@@ -87,7 +87,7 @@ class HasStructure(ABC):
         if frame < 0:
             frame += num_structures
         if not (0 <= frame < num_structures):
-            raise IndexError(f"iteration_step {frame} out of range [-{num_structures}, {num_structures}).")
+            raise IndexError(f"argument frame {frame} out of range [-{num_structures}, {num_structures}).")
 
         return self._get_structure(frame=frame, wrap_atoms=wrap_atoms)
 

--- a/pyiron_atomistics/atomistics/structure/has_structure.py
+++ b/pyiron_atomistics/atomistics/structure/has_structure.py
@@ -61,20 +61,20 @@ class HasStructure(ABC):
         there is only one ionic iteration step.
 
         Args:
-            iteration_step (int): Step for which the structure is requested
+            iteration_step (int): Step for which the structure is requested, if negative count from the back
             wrap_atoms (bool): True if the atoms are to be wrapped back into the unit cell
 
         Returns:
             :class:`pyiron_atomistics.atomistics.structure.atoms.Atoms`: the requested structure
 
         Raises:
-            IndexError: if not 0 < iteration_step < :property:`.number_of_structures`
+            IndexError: if not -:property:`.number_of_structures` <= iteration_step < :property:`.number_of_structures`
         """
         num_structures = self.number_of_structures
         if iteration_step < 0:
             iteration_step += num_structures
         if not (0 <= iteration_step < num_structures):
-            raise IndexError(f"iteration_step {iteration_step} out of range [0, {num_structures}).")
+            raise IndexError(f"iteration_step {iteration_step} out of range [-{num_structures}, {num_structures}).")
 
         return self._get_structure(iteration_step=iteration_step, wrap_atoms=wrap_atoms)
 

--- a/pyiron_atomistics/atomistics/structure/has_structure.py
+++ b/pyiron_atomistics/atomistics/structure/has_structure.py
@@ -89,10 +89,10 @@ class HasStructure(ABC):
         if not (0 <= frame < num_structures):
             raise IndexError(f"iteration_step {frame} out of range [-{num_structures}, {num_structures}).")
 
-        return self._get_structure(iteration_step=frame, wrap_atoms=wrap_atoms)
+        return self._get_structure(frame=frame, wrap_atoms=wrap_atoms)
 
     @abstractmethod
-    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, frame=-1, wrap_atoms=True):
         pass
 
     @property
@@ -118,4 +118,4 @@ class HasStructure(ABC):
             :class:`pyiron_atomistics.atomistitcs.structure.atoms.Atoms`: every structure attached to the object
         """
         for i in range(self.number_of_structures):
-            yield self._get_structure(iteration_step=i, wrap_atoms=wrap_atoms)
+            yield self._get_structure(frame=i, wrap_atoms=wrap_atoms)

--- a/pyiron_atomistics/atomistics/structure/has_structure.py
+++ b/pyiron_atomistics/atomistics/structure/has_structure.py
@@ -1,0 +1,91 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from abc import ABC, abstractmethod
+
+"""
+Mixin for classes that have one or more structures attached to them.
+"""
+
+__author__ = "Marvin Poul"
+__copyright__ = (
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Marvin Poul"
+__email__ = "poul@mpie.de"
+__status__ = "production"
+__date__ = "Apr 22, 2021"
+
+
+class HasStructure(ABC):
+    """
+    Mixin for classes that have one or more structures attached to them.
+
+    Necessary overrides are :method:`.get_structure()` and :method:`.get_number_of_structures()`.
+
+    :method:`.get_number_of_structures()` may return zero, e.g. if there's no structure stored in the object yet or a
+    job will compute this structure, but hasn't been run yet.
+
+    The example below shows how to implement this mixin and how to check whether an object derives from it
+
+    >>> from pyiron_atomistics.atomistics.structure.atoms import Atoms
+    >>> class Foo(HasStructure):
+    ...     def get_structure(self, iteration_step=-1, wrap_atoms=True):
+    ...         return Atoms(symbols=['Fe'], positions=[[0,0,0]])
+    ...     def get_number_of_structures(self):
+    ...         return 1
+
+    >>> f = Foo()
+    >>> for s in f.iter_structures():
+    ...     print(s)
+    Fe: [0. 0. 0.]
+    pbc: [False False False]
+    cell: 
+    Cell([0.0, 0.0, 0.0])
+    <BLANKLINE>
+
+    >>> isinstance(f, HasStructure)
+    True
+    """
+
+    @abstractmethod
+    def get_structure(self, iteration_step=-1, wrap_atoms=True):
+        """
+        Gets the structure from a given iteration step of the simulation (MD/ionic relaxation). For static calculations
+        there is only one ionic iteration step
+
+        Args:
+            iteration_step (int): Step for which the structure is requested
+            wrap_atoms (bool): True if the atoms are to be wrapped back into the unit cell
+
+        Returns:
+            :class:`pyiron_atomistics.atomistics.structure.atoms.Atoms`: the requested structure
+        """
+        pass
+
+    @abstractmethod
+    def get_number_of_structures(self):
+        """
+        Gives the maximum `iteration_step` that can be passed to :method:`.get_structure()`.
+
+        Returns:
+            `int`: number of structures attached to this object
+        """
+        pass
+
+    def iter_structures(self, wrap_atoms=True):
+        """
+        Iterate over all structures in this object.
+
+        Args:
+            wrap_atoms (bool): True if the atoms are to be wrapped back into the unit cell; passed to
+                               :method:`.get_structure()`
+
+        Yields:
+            :class:`pyiron_atomistics.atomistitcs.structure.atoms.Atoms`: every structure attached to the object
+        """
+        for i in range(self.get_number_of_structures()):
+            yield self.get_structure(iteration_step=i, wrap_atoms=wrap_atoms)

--- a/pyiron_atomistics/atomistics/structure/has_structure.py
+++ b/pyiron_atomistics/atomistics/structure/has_structure.py
@@ -33,10 +33,18 @@ class HasStructure(ABC):
     :method:`.get_number_of_structures()` may return zero, e.g. if there's no structure stored in the object yet or a
     job will compute this structure, but hasn't been run yet.
 
+    Sub classes that wish to document special behavior of their implementation of :method:`.get_structure` may do so by
+    adding documention to it in the "Methods:" sub section of their class docstring.
+
     The example below shows how to implement this mixin and how to check whether an object derives from it
 
     >>> from pyiron_atomistics.atomistics.structure.atoms import Atoms
     >>> class Foo(HasStructure):
+    ...     '''
+    ...     Methods:
+    ...         .. method:: get_structure
+    ...             returns structure with single Fe atom at (0, 0, 0)
+    ...     '''
     ...     def _get_structure(self, iteration_step=-1, wrap_atoms=True):
     ...         return Atoms(symbols=['Fe'], positions=[[0,0,0]])
     ...     def _number_of_structures(self):

--- a/pyiron_atomistics/dft/job/generic.py
+++ b/pyiron_atomistics/dft/job/generic.py
@@ -150,11 +150,11 @@ class GenericDFTJob(AtomisticGenericJob):
             raise AssertionError()
         self._generic_input["fix_symmetry"] = boolean
 
-    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, frame=-1, wrap_atoms=True):
         snapshot = super(GenericDFTJob, self)._get_structure(
-            iteration_step=iteration_step, wrap_atoms=wrap_atoms
+            frame=frame, wrap_atoms=wrap_atoms
         )
-        spins = self.get_magnetic_moments(iteration_step=iteration_step)
+        spins = self.get_magnetic_moments(iteration_step=frame)
         if spins is not None:
             snapshot.set_initial_magnetic_moments(spins)
         return snapshot

--- a/pyiron_atomistics/dft/job/generic.py
+++ b/pyiron_atomistics/dft/job/generic.py
@@ -150,8 +150,8 @@ class GenericDFTJob(AtomisticGenericJob):
             raise AssertionError()
         self._generic_input["fix_symmetry"] = boolean
 
-    def _get_structure_impl(self, iteration_step=-1, wrap_atoms=True):
-        snapshot = super(GenericDFTJob, self)._get_structure_impl(
+    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+        snapshot = super(GenericDFTJob, self)._get_structure(
             iteration_step=iteration_step, wrap_atoms=wrap_atoms
         )
         spins = self.get_magnetic_moments(iteration_step=iteration_step)

--- a/pyiron_atomistics/dft/job/generic.py
+++ b/pyiron_atomistics/dft/job/generic.py
@@ -150,18 +150,8 @@ class GenericDFTJob(AtomisticGenericJob):
             raise AssertionError()
         self._generic_input["fix_symmetry"] = boolean
 
-    def get_structure(self, iteration_step=-1, wrap_atoms=True):
-        """
-        Gets the structure from a given iteration step of the simulation (MD/ionic relaxation). For static calculations
-        there is only one ionic iteration step
-        Args:
-            iteration_step (int): Step for which the structure is requested
-            wrap_atoms (bool): True if the atoms are to be wrapped back into the unit cell
-
-        Returns:
-            pyiron.atomistics.structure.atoms.Atoms: The required structure
-        """
-        snapshot = super(GenericDFTJob, self).get_structure(
+    def _get_structure_impl(self, iteration_step=-1, wrap_atoms=True):
+        snapshot = super(GenericDFTJob, self)._get_structure_impl(
             iteration_step=iteration_step, wrap_atoms=wrap_atoms
         )
         spins = self.get_magnetic_moments(iteration_step=iteration_step)

--- a/pyiron_atomistics/dft/master/murnaghan_dft.py
+++ b/pyiron_atomistics/dft/master/murnaghan_dft.py
@@ -54,7 +54,7 @@ class MurnaghanDFT(Murnaghan):
         else:
             return None
 
-    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, frame=-1, wrap_atoms=True):
         # base class makes sure we only get called when self.structure is set already
         snapshot = self.structure.copy()
         old_vol = snapshot.get_volume()

--- a/pyiron_atomistics/dft/master/murnaghan_dft.py
+++ b/pyiron_atomistics/dft/master/murnaghan_dft.py
@@ -54,7 +54,7 @@ class MurnaghanDFT(Murnaghan):
         else:
             return None
 
-    def _get_structure_impl(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
         # base class makes sure we only get called when self.structure is set already
         snapshot = self.structure.copy()
         old_vol = snapshot.get_volume()

--- a/pyiron_atomistics/dft/master/murnaghan_dft.py
+++ b/pyiron_atomistics/dft/master/murnaghan_dft.py
@@ -54,20 +54,14 @@ class MurnaghanDFT(Murnaghan):
         else:
             return None
 
-    def get_structure(self, iteration_step=-1):
-        """
-
-        Returns: Structure with equilibrium volume
-
-        """
-        if not (iteration_step == -1):
-            raise AssertionError()
-        if not (self.structure is not None):
-            raise AssertionError()
+    def _get_structure_impl(self, iteration_step=-1, wrap_atoms=True):
+        # base class makes sure we only get called when self.structure is set already
         snapshot = self.structure.copy()
         old_vol = snapshot.get_volume()
         new_vol = self["output/equilibrium_volume"]
         k = (new_vol / old_vol) ** (1.0 / 3.0)
         new_cell = snapshot.cell * k
         snapshot.set_cell(new_cell, scale_atoms=True)
+        if wrap_atoms:
+            snapshot.center_coordinates_in_unit_cell()
         return snapshot

--- a/pyiron_atomistics/gpaw/pyiron_ase.py
+++ b/pyiron_atomistics/gpaw/pyiron_ase.py
@@ -222,24 +222,14 @@ class AseJob(GenericInteractive):
             self._logger.debug("Generic library: indices changed!")
             self.interactive_indices_setter(self._structure_current.indices)
 
-    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
-        """
-        Gets the structure from a given iteration step of the simulation (MD/ionic relaxation). For static calculations
-        there is only one ionic iteration step
-        Args:
-            iteration_step (int): Step for which the structure is requested
-            wrap_atoms (bool):
-
-        Returns:
-            atomistics.structure.atoms.Atoms object
-        """
+    def _get_structure(self, frame=-1, wrap_atoms=True):
         if (
             self.server.run_mode.interactive
             or self.server.run_mode.interactive_non_modal
         ):
             # Warning: We only copy symbols, positions and cell information - no tags.
             if self.output.indices is not None and len(self.output.indices) != 0:
-                indices = self.output.indices[iteration_step]
+                indices = self.output.indices[frame]
             else:
                 return None
             if len(self._interactive_species_lst) == 0:
@@ -250,19 +240,19 @@ class AseJob(GenericInteractive):
                 el_lst = self._interactive_species_lst.tolist()
             if indices is not None:
                 if wrap_atoms:
-                    positions = self.output.positions[iteration_step]
+                    positions = self.output.positions[frame]
                 else:
-                    if len(self.output.unwrapped_positions) > max([iteration_step, 0]):
-                        positions = self.output.unwrapped_positions[iteration_step]
+                    if len(self.output.unwrapped_positions) > max([frame, 0]):
+                        positions = self.output.unwrapped_positions[frame]
                     else:
                         positions = (
-                            self.output.positions[iteration_step]
-                            + self.output.total_displacements[iteration_step]
+                            self.output.positions[frame]
+                            + self.output.total_displacements[frame]
                         )
                 atoms = Atoms(
                     symbols=np.array([el_lst[el] for el in indices]),
                     positions=positions,
-                    cell=self.output.cells[iteration_step],
+                    cell=self.output.cells[frame],
                     pbc=self.structure.pbc,
                 )
                 # Update indicies to match the indicies in the cache.
@@ -276,7 +266,7 @@ class AseJob(GenericInteractive):
                 and len(self.get("output/generic/cells")) != 0
             ):
                 return super()._get_structure(
-                    iteration_step=iteration_step, wrap_atoms=wrap_atoms
+                    frame=frame, wrap_atoms=wrap_atoms
                 )
             else:
                 return None

--- a/pyiron_atomistics/gpaw/pyiron_ase.py
+++ b/pyiron_atomistics/gpaw/pyiron_ase.py
@@ -222,7 +222,7 @@ class AseJob(GenericInteractive):
             self._logger.debug("Generic library: indices changed!")
             self.interactive_indices_setter(self._structure_current.indices)
 
-    def get_structure(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
         """
         Gets the structure from a given iteration step of the simulation (MD/ionic relaxation). For static calculations
         there is only one ionic iteration step
@@ -275,7 +275,7 @@ class AseJob(GenericInteractive):
                 self.get("output/generic/cells") is not None
                 and len(self.get("output/generic/cells")) != 0
             ):
-                return super(AseJob, self).get_structure(
+                return super()._get_structure(
                     iteration_step=iteration_step, wrap_atoms=wrap_atoms
                 )
             else:

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -51,9 +51,9 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         self._prism = UnfoldingPrism(structure.cell)
         GenericInteractive.structure.fset(self, structure)
 
-    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, frame=-1, wrap_atoms=True):
         return super(GenericInteractive, self)._get_structure(
-            iteration_step=iteration_step, wrap_atoms=wrap_atoms
+            frame=frame, wrap_atoms=wrap_atoms
         )
 
     def _number_of_structures(self):

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -51,10 +51,13 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         self._prism = UnfoldingPrism(structure.cell)
         GenericInteractive.structure.fset(self, structure)
 
-    def get_structure(self, iteration_step=-1, wrap_atoms=True):
-        return super(GenericInteractive, self).get_structure(
+    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+        return super(GenericInteractive, self)._get_structure(
             iteration_step=iteration_step, wrap_atoms=wrap_atoms
         )
+
+    def _number_of_structures(self):
+        return super(GenericInteractive, self)._number_of_structures()
 
     def _interactive_lib_command(self, command):
         self._logger.debug("Lammps library: " + command)

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -51,14 +51,6 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         self._prism = UnfoldingPrism(structure.cell)
         GenericInteractive.structure.fset(self, structure)
 
-    def _get_structure(self, frame=-1, wrap_atoms=True):
-        return super(GenericInteractive, self)._get_structure(
-            frame=frame, wrap_atoms=wrap_atoms
-        )
-
-    def _number_of_structures(self):
-        return super(GenericInteractive, self)._number_of_structures()
-
     def _interactive_lib_command(self, command):
         self._logger.debug("Lammps library: " + command)
         self._interactive_library.command(command)

--- a/pyiron_atomistics/sphinx/interactive.py
+++ b/pyiron_atomistics/sphinx/interactive.py
@@ -51,9 +51,9 @@ class SphinxInteractive(SphinxBase, GenericInteractive):
                 element_lst=structure.get_species_symbols().tolist()
             )
 
-    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, frame=-1, wrap_atoms=True):
         return GenericInteractive._get_structure(
-            self, iteration_step=iteration_step, wrap_atoms=wrap_atoms
+            self, frame=frame, wrap_atoms=wrap_atoms
         )
 
     def interactive_energy_tot_getter(self):

--- a/pyiron_atomistics/sphinx/interactive.py
+++ b/pyiron_atomistics/sphinx/interactive.py
@@ -51,8 +51,8 @@ class SphinxInteractive(SphinxBase, GenericInteractive):
                 element_lst=structure.get_species_symbols().tolist()
             )
 
-    def get_structure(self, iteration_step=-1, wrap_atoms=True):
-        return GenericInteractive.get_structure(
+    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+        return GenericInteractive._get_structure(
             self, iteration_step=iteration_step, wrap_atoms=wrap_atoms
         )
 

--- a/pyiron_atomistics/testing/randomatomistic.py
+++ b/pyiron_atomistics/testing/randomatomistic.py
@@ -397,6 +397,9 @@ class AtomisticExampleJob(ExampleJob, GenericInteractive):
         except IndexError:
             return self.structure
 
+    def _number_of_structures(self):
+        return max(1, super()._number_of_structures())
+
     @structure.setter
     def structure(self, structure):
         """

--- a/pyiron_atomistics/testing/randomatomistic.py
+++ b/pyiron_atomistics/testing/randomatomistic.py
@@ -389,9 +389,9 @@ class AtomisticExampleJob(ExampleJob, GenericInteractive):
         """
         return self._structure
 
-    def get_structure(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
         try:
-            return super(AtomisticExampleJob, self).get_structure(
+            return super()._get_structure(
                 iteration_step=iteration_step, wrap_atoms=wrap_atoms
             )
         except IndexError:

--- a/pyiron_atomistics/testing/randomatomistic.py
+++ b/pyiron_atomistics/testing/randomatomistic.py
@@ -389,10 +389,10 @@ class AtomisticExampleJob(ExampleJob, GenericInteractive):
         """
         return self._structure
 
-    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, frame=-1, wrap_atoms=True):
         try:
             return super()._get_structure(
-                iteration_step=iteration_step, wrap_atoms=wrap_atoms
+                frame=frame, wrap_atoms=wrap_atoms
             )
         except IndexError:
             return self.structure

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -57,14 +57,14 @@ class VaspInteractive(VaspBase, GenericInteractive):
             "interactive_enforce_structure_reset() is not implemented!"
         )
 
-    def _get_structure_impl(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
         if (
             self.server.run_mode.interactive
             or self.server.run_mode.interactive_non_modal
         ):
-            return super(GenericInteractive, self)._get_structure_impl(iteration_step=iteration_step, wrap_atoms=wrap_atoms)
+            return super(GenericInteractive, self)._get_structure(iteration_step=iteration_step, wrap_atoms=wrap_atoms)
         else:
-            return super(VaspBase, self)._get_structure_impl(iteration_step=iteration_step, wrap_atoms=wrap_atoms)
+            return super(VaspBase, self)._get_structure(iteration_step=iteration_step, wrap_atoms=wrap_atoms)
 
     def interactive_close(self):
         if self.interactive_is_activated():

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -57,26 +57,14 @@ class VaspInteractive(VaspBase, GenericInteractive):
             "interactive_enforce_structure_reset() is not implemented!"
         )
 
-    def get_structure(self, iteration_step=-1, wrap_atoms=True):
-        """
-        Gets the structure from a given iteration step of the simulation (MD/ionic relaxation). For static calculations
-        there is only one ionic iteration step
-        Args:
-            iteration_step (int): Step for which the structure is requested
-            wrap_atoms (bool): True if the atoms are to be wrapped back into the unit cell
-
-        Returns:
-            pyiron.atomistics.structure.atoms.Atoms: The required structure
-        """
+    def _get_structure_impl(self, iteration_step=-1, wrap_atoms=True):
         if (
             self.server.run_mode.interactive
             or self.server.run_mode.interactive_non_modal
         ):
-            structure = GenericInteractive.get_structure(self, iteration_step=iteration_step, wrap_atoms=wrap_atoms)
+            return super(GenericInteractive, self)._get_structure_impl(iteration_step=iteration_step, wrap_atoms=wrap_atoms)
         else:
-            structure = VaspBase.get_structure(self, iteration_step=iteration_step, wrap_atoms=wrap_atoms)
-
-        return structure
+            return super(VaspBase, self)._get_structure_impl(iteration_step=iteration_step, wrap_atoms=wrap_atoms)
 
     def interactive_close(self):
         if self.interactive_is_activated():

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -57,14 +57,14 @@ class VaspInteractive(VaspBase, GenericInteractive):
             "interactive_enforce_structure_reset() is not implemented!"
         )
 
-    def _get_structure(self, iteration_step=-1, wrap_atoms=True):
+    def _get_structure(self, frame=-1, wrap_atoms=True):
         if (
             self.server.run_mode.interactive
             or self.server.run_mode.interactive_non_modal
         ):
-            return super(GenericInteractive, self)._get_structure(iteration_step=iteration_step, wrap_atoms=wrap_atoms)
+            return super(GenericInteractive, self)._get_structure(frame=frame, wrap_atoms=wrap_atoms)
         else:
-            return super(VaspBase, self)._get_structure(iteration_step=iteration_step, wrap_atoms=wrap_atoms)
+            return super(VaspBase, self)._get_structure(frame=frame, wrap_atoms=wrap_atoms)
 
     def interactive_close(self):
         if self.interactive_is_activated():

--- a/tests/atomistics/master/test_murnaghan.py
+++ b/tests/atomistics/master/test_murnaghan.py
@@ -53,6 +53,10 @@ class TestMurnaghan(unittest.TestCase):
         murn.run()
         self.assertAlmostEqual(self.basis.get_volume(), murn['output/equilibrium_volume'])
 
+        optimal = murn.get_structure()
+        self.assertAlmostEqual(optimal.get_volume(), murn['output/equilibrium_volume'],
+                               msg="Output of get_structure should have equilibrium volume")
+
     def test_run(self):
         job = self.project.create_job(
             'AtomisticExampleJob', "job_test"
@@ -68,6 +72,7 @@ class TestMurnaghan(unittest.TestCase):
         murn.input['num_points'] = 3
         murn.run()
         self.assertTrue(murn.status.finished)
+
         murn.remove()
         job_ser.remove()
 


### PR DESCRIPTION
A number of our classes define a `get_structure` with consistent semantics, but there was no one place for its definition.  I pulled it out into an ABC and added two other methods 

```python
number_of_structures
iter_structures
```

where the first gives the maximum "iteration_step" that can be passed to `get_structure` and the other just iterates over all structures.   Previously you would (and our code indeed does) check the size of the cells/positions array in the output of an atomistic job, but that's not so OOP.

On the implementation side, I've added extra methods

```python
_number_of_structures_impl
_get_structure_imp
```

that sub classes should override instead of the ones above, because that guarantees stable interfaces and correct docstrings.

Rationale: I want to have a common and guaranteed interface of obtaining structures from objects, for use in the structure/training container.  Both when adding structures to the container where something like

```python
container.include(job)
```

would be nice to have, but also when adding jobs to potential fitting jobs, I want structure/training containers to behave as the other atomistic jobs.

WIP: renaming all the previously defined `get_structures` to `_get_structure_impl` and deriving from `HasStructure`.

Christmas Wishlist: We also have a `structure` property, that I'd like to see on this class, but I thought touching `get_structure` is intrusive enough for now.