### PR TITLE
Make get_structure faster: Electric Boogaloo or avoiding database checks

### DIFF
--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -778,19 +778,19 @@ class GenericOutput(object):
 
     @property
     def cells(self):
-        return self._job["output/generic/cells"]
+        return self._job.project_hdf5["output/generic/cells"]
 
     @property
     def energy_pot(self):
-        return self._job["output/generic/energy_pot"]
+        return self._job.project_hdf5["output/generic/energy_pot"]
 
     @property
     def energy_tot(self):
-        return self._job["output/generic/energy_tot"]
+        return self._job.project_hdf5["output/generic/energy_tot"]
 
     @property
     def forces(self):
-        return self._job["output/generic/forces"]
+        return self._job.project_hdf5["output/generic/forces"]
 
     @property
     def force_max(self):
@@ -802,27 +802,27 @@ class GenericOutput(object):
 
     @property
     def positions(self):
-        return self._job["output/generic/positions"]
+        return self._job.project_hdf5["output/generic/positions"]
 
     @property
     def pressures(self):
-        return self._job["output/generic/pressures"]
+        return self._job.project_hdf5["output/generic/pressures"]
 
     @property
     def steps(self):
-        return self._job["output/generic/steps"]
+        return self._job.project_hdf5["output/generic/steps"]
 
     @property
     def temperature(self):
-        return self._job["output/generic/temperature"]
+        return self._job.project_hdf5["output/generic/temperature"]
 
     @property
     def computation_time(self):
-        return self._job["output/generic/computation_time"]
+        return self._job.project_hdf5["output/generic/computation_time"]
 
     @property
     def unwrapped_positions(self):
-        unwrapped_positions = self._job["output/generic/unwrapped_positions"]
+        unwrapped_positions = self._job.project_hdf5["output/generic/unwrapped_positions"]
         if unwrapped_positions is not None:
             return unwrapped_positions
         else:
@@ -830,11 +830,11 @@ class GenericOutput(object):
 
     @property
     def volume(self):
-        return self._job["output/generic/volume"]
+        return self._job.project_hdf5["output/generic/volume"]
 
     @property
     def indices(self):
-        return self._job["output/generic/indices"]
+        return self._job.project_hdf5["output/generic/indices"]
 
     @property
     def displacements(self):
@@ -891,7 +891,7 @@ class GenericOutput(object):
         return np.cumsum(self.displacements, axis=0)
 
     def __dir__(self):
-        hdf5_path = self._job["output/generic"]
+        hdf5_path = self._job.project_hdf5["output/generic"]
         if hdf5_path is not None:
             return hdf5_path.list_nodes()
         else:

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -4,6 +4,7 @@
 
 from ase.io import write as ase_write
 import copy
+from functools import wraps
 
 import numpy as np
 import warnings
@@ -771,24 +772,36 @@ structure=atoms # atoms, continue_final
 """
         self.load_string(file_content)
 
+def property_or_none(prop):
+    @wraps(prop)
+    def wrapped(obj):
+        try:
+            return prop(obj)
+        except ValueError:
+            return None
+    return wrapped
 
 class GenericOutput(object):
     def __init__(self, job):
         self._job = job
 
     @property
+    @property_or_none
     def cells(self):
         return self._job.project_hdf5["output/generic/cells"]
 
     @property
+    @property_or_none
     def energy_pot(self):
         return self._job.project_hdf5["output/generic/energy_pot"]
 
     @property
+    @property_or_none
     def energy_tot(self):
         return self._job.project_hdf5["output/generic/energy_tot"]
 
     @property
+    @property_or_none
     def forces(self):
         return self._job.project_hdf5["output/generic/forces"]
 
@@ -801,26 +814,32 @@ class GenericOutput(object):
         return np.linalg.norm(self.forces, axis=-1).max(axis=-1)
 
     @property
+    @property_or_none
     def positions(self):
         return self._job.project_hdf5["output/generic/positions"]
 
     @property
+    @property_or_none
     def pressures(self):
         return self._job.project_hdf5["output/generic/pressures"]
 
     @property
+    @property_or_none
     def steps(self):
         return self._job.project_hdf5["output/generic/steps"]
 
     @property
+    @property_or_none
     def temperature(self):
         return self._job.project_hdf5["output/generic/temperature"]
 
     @property
+    @property_or_none
     def computation_time(self):
         return self._job.project_hdf5["output/generic/computation_time"]
 
     @property
+    @property_or_none
     def unwrapped_positions(self):
         unwrapped_positions = self._job.project_hdf5["output/generic/unwrapped_positions"]
         if unwrapped_positions is not None:
@@ -829,10 +848,12 @@ class GenericOutput(object):
             return self._job.structure.positions+self.total_displacements
 
     @property
+    @property_or_none
     def volume(self):
         return self._job.project_hdf5["output/generic/volume"]
 
     @property
+    @property_or_none
     def indices(self):
         return self._job.project_hdf5["output/generic/indices"]
 
@@ -891,7 +912,7 @@ class GenericOutput(object):
         return np.cumsum(self.displacements, axis=0)
 
     def __dir__(self):
-        hdf5_path = self._job.project_hdf5["output/generic"]
+        hdf5_path = self._job["output/generic"]
         if hdf5_path is not None:
             return hdf5_path.list_nodes()
         else:

--- a/pyiron_atomistics/atomistics/job/interactive.py
+++ b/pyiron_atomistics/atomistics/job/interactive.py
@@ -423,7 +423,10 @@ class GenericInteractiveOutput(GenericOutput):
         Returns:
 
         """
-        fetched = self._job.project_hdf5["output/interactive/" + key]
+        try:
+            fetched = self._job.project_hdf5["output/interactive/" + key]
+        except ValueError:
+            fetched = None
         if fetched is None or len(fetched) == 0:
             fetched = getattr(super(), key)
         return fetched

--- a/pyiron_atomistics/atomistics/job/interactive.py
+++ b/pyiron_atomistics/atomistics/job/interactive.py
@@ -423,7 +423,7 @@ class GenericInteractiveOutput(GenericOutput):
         Returns:
 
         """
-        fetched = self._job["output/interactive/" + key]
+        fetched = self._job.project_hdf5["output/interactive/" + key]
         if fetched is None or len(fetched) == 0:
             fetched = getattr(super(), key)
         return fetched


### PR DESCRIPTION
`GenericOutput` and `GenericInteractiveOutput` used to index the job for properties stored in HDF5.  But indexing jobs you can also access child jobs, so this made a database connection every time you accessed a property.  This now accesses the job's HDF5 directly.

This saves another ~30%.