### PR TITLE
remove tree-internal periodic boundary detection

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -1397,23 +1397,11 @@ class Atoms(ASEAtoms):
             cutoff_radius=cutoff_radius,
             width_buffer=width_buffer,
         )
-        if (width<0.5*np.min(self.cell.diagonal())
-                and np.isclose(np.linalg.norm(self.cell-np.eye(3)*self.cell.diagonal()), 0)
-                and np.all(self.pbc)
-                and cutoff_radius==np.inf):
-            neigh._cell = self.cell.diagonal()
-            extended_positions = self.get_extended_positions(
-                0,
-                return_indices=False,
-                norm_order=norm_order
-            ).copy()
-            extended_positions -= neigh._cell*np.floor(extended_positions/neigh._cell)
-        else:
-            extended_positions, neigh._wrapped_indices = self.get_extended_positions(
-                width, return_indices=True, norm_order=norm_order
-            )
-            neigh._extended_positions = extended_positions
-        neigh._tree = cKDTree(extended_positions, boxsize=neigh._cell)
+        extended_positions, neigh._wrapped_indices = self.get_extended_positions(
+            width, return_indices=True, norm_order=norm_order
+        )
+        neigh._extended_positions = extended_positions
+        neigh._tree = cKDTree(extended_positions)
         if get_tree:
             return neigh
         positions = self.positions

--- a/pyiron_atomistics/atomistics/structure/neighbors.py
+++ b/pyiron_atomistics/atomistics/structure/neighbors.py
@@ -62,7 +62,6 @@ class Tree:
         self._extended_positions = None
         self._wrapped_indices = None
         self._allow_ragged = False
-        self._cell = None
         self._extended_indices = None
         self._ref_structure = ref_structure.copy()
         self.wrap_positions = False
@@ -92,7 +91,6 @@ class Tree:
         new_neigh._extended_positions = self._extended_positions
         new_neigh._wrapped_indices = self._wrapped_indices
         new_neigh._allow_ragged = self._allow_ragged
-        new_neigh._cell = self._cell
         new_neigh._extended_indices = self._extended_indices
         new_neigh.wrap_positions = self.wrap_positions
         new_neigh._tree = self._tree
@@ -376,8 +374,6 @@ class Tree:
                 self._extended_indices[distances<np.inf]
             ]
             vectors[distances==np.inf] = np.array(3*[np.inf])
-            if self._cell is not None:
-                vectors[distances<np.inf] -= self._cell*np.rint(vectors[distances<np.inf]/self._cell)
         elif self.vecs is not None:
             vectors = self.vecs
         else:


### PR DESCRIPTION
The internal algorithm of `cKDTree` for the periodic boundary conditions was removed, because:

- It was not faster (even actually slower)
- It was applied in very few cases (neighbour search width smaller than half the smallest box length, orthogonal box etc.)
- `cKDTree` raises error if there's an atom which lies outside of the box, which happens every now and then due to python precision.

The third point was the main one for me to remove this feature, but anyway there was no obvious advantage from both the practical point of view (meaning computation time) and the programmer friendliness (meaning it was applied only in a small number of cases).