### PR TITLE
Steinhardt interface

### DIFF
--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -67,7 +67,7 @@ class Analyse:
                 description: sklearn.cluster.AgglomerativeClustering
             id_list (list/numpy.ndarray): List of atoms for which the layers
                 should be considered.
-            wrap_atoms: TODO.
+            wrap_atoms (bool): Whether to consider periodic boundary conditions according to the box definition or not. If set to `False`, atoms lying on box boundaries are considered to belong to different layers, regardless of whether the box itself has the periodic boundary condition in this direction or not. If `planes` is not `None` and `wrap_atoms` is `True`, this tag has the same effect as calling `get_layers()` after calling `center_coordinates_in_unit_cell()`
             planes (list/numpy.ndarray): Planes along which the layers are calculated. Planes are
                 given in vectors, i.e. [1, 0, 0] gives the layers along the x-axis. Default planes
                 are orthogonal unit vectors: [[1, 0, 0], [0, 1, 0], [0, 0, 1]]. If you have a

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 from pyiron_base import Settings
-from sklearn.cluster import AgglomerativeClustering
+from sklearn.cluster import AgglomerativeClustering  # TODO: Handle sklearn in dependencies or wrap in import warning
 from scipy.sparse import coo_matrix
 from scipy.spatial import Voronoi
 from pyiron_atomistics.atomistics.structure.pyscal import get_steinhardt_parameter_structure, analyse_cna_adaptive, \
@@ -23,6 +23,7 @@ __date__ = "Sep 1, 2017"
 
 s = Settings()
 
+
 def get_average_of_unique_labels(labels, values):
     """
 
@@ -40,9 +41,10 @@ def get_average_of_unique_labels(labels, values):
     unique_labels = np.unique(labels)
     mat = coo_matrix((np.ones_like(labels), (labels, np.arange(len(labels)))))
     mean_values = np.asarray(mat.dot(np.asarray(values).reshape(len(labels), -1))/mat.sum(axis=1))
-    if np.prod(mean_values.shape).astype(int)==len(unique_labels):
+    if np.prod(mean_values.shape).astype(int) == len(unique_labels):
         return mean_values.flatten()
     return mean_values
+
 
 class Analyse:
     """ Class to analyse atom structure.  """
@@ -63,6 +65,7 @@ class Analyse:
                 description: sklearn.cluster.AgglomerativeClustering
             id_list (list/numpy.ndarray): List of atoms for which the layers
                 should be considered.
+            wrap_atoms: TODO.
             planes (list/numpy.ndarray): Planes along which the layers are calculated. Planes are
                 given in vectors, i.e. [1, 0, 0] gives the layers along the x-axis. Default planes
                 are orthogonal unit vectors: [[1, 0, 0], [0, 1, 0], [0, 0, 1]]. If you have a
@@ -93,7 +96,7 @@ class Analyse:
             )
             if id_list is not None:
                 id_list = np.arange(len(self._structure))[np.array(id_list)]
-                id_list = np.any(id_list[:,np.newaxis]==indices[np.newaxis,:], axis=0)
+                id_list = np.any(id_list[:, np.newaxis] == indices[np.newaxis, :], axis=0)
                 positions = positions[id_list]
                 indices = indices[id_list]
         else:
@@ -106,12 +109,12 @@ class Analyse:
             mat = np.asarray(planes).reshape(-1, 3)
             positions = np.einsum('ij,i,nj->ni', mat, 1/np.linalg.norm(mat, axis=-1), positions)
         layers = []
-        for ii,x in enumerate(positions.T):
+        for ii, x in enumerate(positions.T):
             cluster = AgglomerativeClustering(
                 linkage='complete',
                 n_clusters=None,
                 distance_threshold=distance_threshold
-            ).fit(x.reshape(-1,1))
+            ).fit(x.reshape(-1, 1))
             first_occurrences = np.unique(cluster.labels_, return_index=True)[1]
             permutation = x[first_occurrences].argsort().argsort()
             labels = permutation[cluster.labels_]
@@ -120,21 +123,21 @@ class Analyse:
                 scaled_positions = np.einsum(
                     'ji,nj->ni', np.linalg.inv(self._structure.cell), mean_positions
                 )
-                unique_inside_box = np.all(np.absolute(scaled_positions-0.5+1.0e-8)<0.5, axis=-1)
+                unique_inside_box = np.all(np.absolute(scaled_positions-0.5+1.0e-8) < 0.5, axis=-1)
                 arr_inside_box = np.any(
-                    labels[:,None]==np.unique(labels)[unique_inside_box][None,:], axis=-1
+                    labels[:, None] == np.unique(labels)[unique_inside_box][None, :], axis=-1
                 )
                 first_occurences = np.unique(indices[arr_inside_box], return_index=True)[1]
                 labels = labels[arr_inside_box]
                 labels -= np.min(labels)
                 labels = labels[first_occurences]
             layers.append(labels)
-        if planes is not None and len(np.asarray(planes).shape)==1:
+        if planes is not None and len(np.asarray(planes).shape) == 1:
             return np.asarray(layers).flatten()
         return np.vstack(layers).T
 
     def pyscal_steinhardt_parameter(self, neighbor_method="cutoff", cutoff=0, n_clusters=2,
-                                            q=(4, 6), averaged=False, clustering=True):
+                                    q=(4, 6), averaged=False, clustering=True):
         """
         Calculate Steinhardts parameters
 
@@ -242,6 +245,5 @@ class Analyse:
             )
             cluster.fit(xx)
             xx = get_average_of_unique_labels(cluster.labels_, xx)
-        xx = xx[np.linalg.norm(xx-self._structure.get_wrapped_coordinates(xx, epsilon=0), axis=-1)<epsilon]
+        xx = xx[np.linalg.norm(xx-self._structure.get_wrapped_coordinates(xx, epsilon=0), axis=-1) < epsilon]
         return xx-epsilon
-

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -67,7 +67,11 @@ class Analyse:
                 description: sklearn.cluster.AgglomerativeClustering
             id_list (list/numpy.ndarray): List of atoms for which the layers
                 should be considered.
-            wrap_atoms (bool): Whether to consider periodic boundary conditions according to the box definition or not. If set to `False`, atoms lying on box boundaries are considered to belong to different layers, regardless of whether the box itself has the periodic boundary condition in this direction or not. If `planes` is not `None` and `wrap_atoms` is `True`, this tag has the same effect as calling `get_layers()` after calling `center_coordinates_in_unit_cell()`
+            wrap_atoms (bool): Whether to consider periodic boundary conditions according to the box definition or not.
+                If set to `False`, atoms lying on opposite box boundaries are considered to belong to different layers,
+                regardless of whether the box itself has the periodic boundary condition in this direction or not.
+                If `planes` is not `None` and `wrap_atoms` is `True`, this tag has the same effect as calling
+                `get_layers()` after calling `center_coordinates_in_unit_cell()`
             planes (list/numpy.ndarray): Planes along which the layers are calculated. Planes are
                 given in vectors, i.e. [1, 0, 0] gives the layers along the x-axis. Default planes
                 are orthogonal unit vectors: [[1, 0, 0], [0, 1, 0], [0, 0, 1]]. If you have a

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -142,16 +142,16 @@ class Analyse:
         Calculate Steinhardts parameters
 
         Args:
-            neighbor_method (str) : can be ['cutoff', 'voronoi']
-            cutoff (float) : can be 0 for adaptive cutoff or any other value
-            n_clusters (int) : number of clusters for K means clustering
-            q (list) : can be from 2-12, the required q values to be calculated
-            averaged (bool) : If True, calculates the averaged versions of the parameter
-            clustering (bool) : If True, cluster based on the q values
+            neighbor_method (str) : can be ['cutoff', 'voronoi']. (Default is 'cutoff'.)
+            cutoff (float) : Can be 0 for adaptive cutoff or any other value. (Default is 0, adaptive.)
+            n_clusters (int) : number of clusters for K means clustering. (Default is 2.)
+            q (list) : Values can be integers from 2-12, the required q values to be calculated. (Default is (4, 6).)
+            averaged (bool) : If True, calculates the averaged versions of the parameter. (Default is False.)
+            clustering (bool) : If True, cluster based on the q values and return cluster indices. (Default is True.)
 
         Returns:
-            list: calculated q parameters
-
+            numpy.ndarray: (number of q's, number of atoms) shaped array of q parameters
+            numpy.ndarray: If `clustering=True`, an additional per-atom array of cluster ids is also returned
         """
         return get_steinhardt_parameter_structure(
             self._structure, neighbor_method=neighbor_method, cutoff=cutoff, n_clusters=n_clusters,

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -137,18 +137,17 @@ class Analyse:
         return np.vstack(layers).T
 
     def pyscal_steinhardt_parameter(self, neighbor_method="cutoff", cutoff=0, n_clusters=2,
-                                    q=None, averaged=False, clustering=True):
+                                    q=None, averaged=False):
         """
         Calculate Steinhardts parameters
 
         Args:
             neighbor_method (str) : can be ['cutoff', 'voronoi']. (Default is 'cutoff'.)
             cutoff (float) : Can be 0 for adaptive cutoff or any other value. (Default is 0, adaptive.)
-            n_clusters (int) : number of clusters for K means clustering. (Default is 2.)
+            n_clusters (int/None) : Number of clusters for K means clustering or None to not cluster. (Default is 2.)
             q (list) : Values can be integers from 2-12, the required q values to be calculated. (Default is None, which
                 uses (4, 6).)
             averaged (bool) : If True, calculates the averaged versions of the parameter. (Default is False.)
-            clustering (bool) : If True, cluster based on the q values and return cluster indices. (Default is True.)
 
         Returns:
             numpy.ndarray: (number of q's, number of atoms) shaped array of q parameters
@@ -156,7 +155,7 @@ class Analyse:
         """
         return get_steinhardt_parameter_structure(
             self._structure, neighbor_method=neighbor_method, cutoff=cutoff, n_clusters=n_clusters,
-            q=q, averaged=averaged, clustering=clustering
+            q=q, averaged=averaged
         )
 
     def pyscal_cna_adaptive(self, mode="total", ovito_compatibility=False):

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -9,6 +9,8 @@ from scipy.sparse import coo_matrix
 from scipy.spatial import Voronoi
 from pyiron_atomistics.atomistics.structure.pyscal import get_steinhardt_parameter_structure, analyse_cna_adaptive, \
     analyse_centro_symmetry, analyse_diamond_structure, analyse_voronoi_volume
+from pyiron_base.generic.util import Deprecator
+deprecate = Deprecator()
 
 __author__ = "Joerg Neugebauer, Sam Waseda"
 __copyright__ = (
@@ -136,8 +138,9 @@ class Analyse:
             return np.asarray(layers).flatten()
         return np.vstack(layers).T
 
+    @deprecate(arguments={"clustering": "use n_clusters=None instead of clustering=False."})
     def pyscal_steinhardt_parameter(self, neighbor_method="cutoff", cutoff=0, n_clusters=2,
-                                    q=None, averaged=False):
+                                    q=None, averaged=False, clustering=None):
         """
         Calculate Steinhardts parameters
 
@@ -155,7 +158,7 @@ class Analyse:
         """
         return get_steinhardt_parameter_structure(
             self._structure, neighbor_method=neighbor_method, cutoff=cutoff, n_clusters=n_clusters,
-            q=q, averaged=averaged
+            q=q, averaged=averaged, clustering=clustering
         )
 
     def pyscal_cna_adaptive(self, mode="total", ovito_compatibility=False):

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -137,7 +137,7 @@ class Analyse:
         return np.vstack(layers).T
 
     def pyscal_steinhardt_parameter(self, neighbor_method="cutoff", cutoff=0, n_clusters=2,
-                                    q=(4, 6), averaged=False, clustering=True):
+                                    q=None, averaged=False, clustering=True):
         """
         Calculate Steinhardts parameters
 
@@ -145,7 +145,8 @@ class Analyse:
             neighbor_method (str) : can be ['cutoff', 'voronoi']. (Default is 'cutoff'.)
             cutoff (float) : Can be 0 for adaptive cutoff or any other value. (Default is 0, adaptive.)
             n_clusters (int) : number of clusters for K means clustering. (Default is 2.)
-            q (list) : Values can be integers from 2-12, the required q values to be calculated. (Default is (4, 6).)
+            q (list) : Values can be integers from 2-12, the required q values to be calculated. (Default is None, which
+                uses (4, 6).)
             averaged (bool) : If True, calculates the averaged versions of the parameter. (Default is False.)
             clustering (bool) : If True, cluster based on the q values and return cluster indices. (Default is True.)
 

--- a/pyiron_atomistics/atomistics/structure/pyscal.py
+++ b/pyiron_atomistics/atomistics/structure/pyscal.py
@@ -23,7 +23,7 @@ s = Settings()
 
 
 def get_steinhardt_parameter_structure(atoms, neighbor_method="cutoff", cutoff=0, n_clusters=2,
-                                       q=None, averaged=False, clustering=True):
+                                       q=None, averaged=False):
     """
     Calculate Steinhardts parameters
 
@@ -31,11 +31,10 @@ def get_steinhardt_parameter_structure(atoms, neighbor_method="cutoff", cutoff=0
         atoms (Atoms): The structure to analyse.
         neighbor_method (str) : can be ['cutoff', 'voronoi']. (Default is 'cutoff'.)
         cutoff (float) : Can be 0 for adaptive cutoff or any other value. (Default is 0, adaptive.)
-        n_clusters (int) : number of clusters for K means clustering. (Default is 2.)
+        n_clusters (int/None) : Number of clusters for K means clustering or None to not cluster. (Default is 2.)
         q (list) : Values can be integers from 2-12, the required q values to be calculated. (Default is None, which
             uses (4, 6).)
         averaged (bool) : If True, calculates the averaged versions of the parameter. (Default is False.)
-        clustering (bool) : If True, cluster based on the q values and return cluster indices. (Default is True.)
 
     Returns:
         numpy.ndarray: (number of q's, number of atoms) shaped array of q parameters
@@ -64,7 +63,7 @@ def get_steinhardt_parameter_structure(atoms, neighbor_method="cutoff", cutoff=0
         averaged=averaged
     ))
 
-    if clustering:
+    if n_clusters is not None:
         cl = cluster.KMeans(
             n_clusters=n_clusters
         )

--- a/pyiron_atomistics/atomistics/structure/pyscal.py
+++ b/pyiron_atomistics/atomistics/structure/pyscal.py
@@ -28,17 +28,17 @@ def get_steinhardt_parameter_structure(atoms, neighbor_method="cutoff", cutoff=0
     Calculate Steinhardts parameters
 
     Args:
-        atoms: Atoms object
-        neighbor_method (str) : can be ['cutoff', 'voronoi']
-        cutoff (float) : can be 0 for adaptive cutoff or any other value
-        n_clusters (int) : number of clusters for K means clustering
-        q (list) : can be from 2-12, the required q values to be calculated
-        averaged (bool) : If True, calculates the averaged versions of the parameter
-        clustering (bool) : If True, cluster based on the q values
+        atoms (Atoms): The structure to analyse.
+        neighbor_method (str) : can be ['cutoff', 'voronoi']. (Default is 'cutoff'.)
+        cutoff (float) : Can be 0 for adaptive cutoff or any other value. (Default is 0, adaptive.)
+        n_clusters (int) : number of clusters for K means clustering. (Default is 2.)
+        q (list) : Values can be integers from 2-12, the required q values to be calculated. (Default is (4, 6).)
+        averaged (bool) : If True, calculates the averaged versions of the parameter. (Default is False.)
+        clustering (bool) : If True, cluster based on the q values and return cluster indices. (Default is True.)
 
     Returns:
-        q (list) : calculated q parameters
-
+        numpy.ndarray: (number of q's, number of atoms) shaped array of q parameters
+        numpy.ndarray: If `clustering=True`, an additional per-atom array of cluster ids is also returned
     """
     s.publication_add(publication())
     sys = pc.System()
@@ -57,17 +57,17 @@ def get_steinhardt_parameter_structure(atoms, neighbor_method="cutoff", cutoff=0
         averaged=averaged
     )
 
-    sysq = sys.get_qvals(
+    sysq = np.array(sys.get_qvals(
         q,
         averaged=averaged
-    )
+    ))
 
     if clustering:
         cl = cluster.KMeans(
             n_clusters=n_clusters
         )
 
-        ind = cl.fit(list(zip(*sysq))).labels_ == 0
+        ind = cl.fit(list(zip(*sysq))).labels_
         return sysq, ind
     else:
         return sysq

--- a/pyiron_atomistics/atomistics/structure/pyscal.py
+++ b/pyiron_atomistics/atomistics/structure/pyscal.py
@@ -23,7 +23,7 @@ s = Settings()
 
 
 def get_steinhardt_parameter_structure(atoms, neighbor_method="cutoff", cutoff=0, n_clusters=2,
-                                       q=(4, 6), averaged=False, clustering=True):
+                                       q=None, averaged=False, clustering=True):
     """
     Calculate Steinhardts parameters
 
@@ -32,7 +32,8 @@ def get_steinhardt_parameter_structure(atoms, neighbor_method="cutoff", cutoff=0
         neighbor_method (str) : can be ['cutoff', 'voronoi']. (Default is 'cutoff'.)
         cutoff (float) : Can be 0 for adaptive cutoff or any other value. (Default is 0, adaptive.)
         n_clusters (int) : number of clusters for K means clustering. (Default is 2.)
-        q (list) : Values can be integers from 2-12, the required q values to be calculated. (Default is (4, 6).)
+        q (list) : Values can be integers from 2-12, the required q values to be calculated. (Default is None, which
+            uses (4, 6).)
         averaged (bool) : If True, calculates the averaged versions of the parameter. (Default is False.)
         clustering (bool) : If True, cluster based on the q values and return cluster indices. (Default is True.)
 
@@ -41,6 +42,7 @@ def get_steinhardt_parameter_structure(atoms, neighbor_method="cutoff", cutoff=0
         numpy.ndarray: If `clustering=True`, an additional per-atom array of cluster ids is also returned
     """
     s.publication_add(publication())
+    q = (4, 6) if q is None else q
     sys = pc.System()
     sys.read_inputfile(
         pyiron_atomistics.atomistics.structure.atoms.pyiron_to_ase(atoms),

--- a/pyiron_atomistics/atomistics/structure/pyscal.py
+++ b/pyiron_atomistics/atomistics/structure/pyscal.py
@@ -7,6 +7,8 @@ from pyiron_base import Settings
 import pyiron_atomistics.atomistics.structure.atoms
 import pyscal.core as pc
 from sklearn import cluster
+from pyiron_base.generic.util import Deprecator
+deprecate = Deprecator()
 
 __author__ = "Sarath Menon, Jan Janssen"
 __copyright__ = (
@@ -22,8 +24,9 @@ __date__ = "Nov 6, 2019"
 s = Settings()
 
 
+@deprecate(arguments={"clustering": "use n_clusters=None instead of clustering=False."})
 def get_steinhardt_parameter_structure(atoms, neighbor_method="cutoff", cutoff=0, n_clusters=2,
-                                       q=None, averaged=False):
+                                       q=None, averaged=False, clustering=None):
     """
     Calculate Steinhardts parameters
 
@@ -42,6 +45,8 @@ def get_steinhardt_parameter_structure(atoms, neighbor_method="cutoff", cutoff=0
     """
     s.publication_add(publication())
     q = (4, 6) if q is None else q
+    if clustering == False:
+        n_clusters = None
     sys = pc.System()
     sys.read_inputfile(
         pyiron_atomistics.atomistics.structure.atoms.pyiron_to_ase(atoms),

--- a/tests/atomistics/structure/test_pyscal.py
+++ b/tests/atomistics/structure/test_pyscal.py
@@ -29,7 +29,13 @@ class Testpyscal(TestWithCleanProject):
         sysp.read_inputfile(self.structure, format="ase")
         self.assertEqual(len(sysp.atoms), 256)
 
-    def test_steinhardt_parameters(self):
+    def test_steinhardt_parameters_returns(self):
+        self.assertEqual(2, len(pas.get_steinhardt_parameter_structure(self.structure)),
+                         msg='Expected default return value to be a tuple of qs and cluster indices.')
+        self.assertIsInstance(pas.get_steinhardt_parameter_structure(self.structure, clustering=False), np.ndarray,
+                              msg='Expected just the qs when no clustering is used.')
+
+    def test_steinhardt_parameters_qs(self):
         """
         Test the calculation of Steinhardts parameters
         """
@@ -38,15 +44,11 @@ class Testpyscal(TestWithCleanProject):
 
         qtest = np.random.randint(2, 13, size=2)
 
-        self.assertEqual(2, len(pas.get_steinhardt_parameter_structure(self.structure)),
-                         msg='Expected default return value to be a tuple of qs and cluster indices.')
-        self.assertIsInstance(pas.get_steinhardt_parameter_structure(self.structure, clustering=False), np.ndarray,
-                              msg='Expected just the qs when no clustering is used.')
-
         qs, _ = pas.get_steinhardt_parameter_structure(self.structure, cutoff=0, n_clusters=2, q=qtest)
         for c, q in enumerate(qs):
             self.assertLess(np.abs(np.mean(q) - perfect_vals[qtest[c]-2]), 1E-3)
 
+    def test_steinhardt_parameters_clustering(self):
         noisy_structure = self.structure.copy()
         noisy_structure.positions += 0.5 * np.random.rand(*noisy_structure.positions.shape)
         n_clusters = 3

--- a/tests/atomistics/structure/test_pyscal.py
+++ b/tests/atomistics/structure/test_pyscal.py
@@ -32,7 +32,7 @@ class Testpyscal(TestWithCleanProject):
     def test_steinhardt_parameters_returns(self):
         self.assertEqual(2, len(pas.get_steinhardt_parameter_structure(self.structure)),
                          msg='Expected default return value to be a tuple of qs and cluster indices.')
-        self.assertIsInstance(pas.get_steinhardt_parameter_structure(self.structure, clustering=False), np.ndarray,
+        self.assertIsInstance(pas.get_steinhardt_parameter_structure(self.structure, n_clusters=None), np.ndarray,
                               msg='Expected just the qs when no clustering is used.')
 
     def test_steinhardt_parameters_qs(self):

--- a/tests/atomistics/structure/test_pyscal.py
+++ b/tests/atomistics/structure/test_pyscal.py
@@ -42,6 +42,12 @@ class Testpyscal(TestWithCleanProject):
         for c, q in enumerate(qs):
             self.assertLess(np.abs(np.mean(q) - perfect_vals[qtest[c]-2]), 1E-3)
 
+        noisy_structure = self.structure.copy()
+        noisy_structure.positions += 0.5 * np.random.rand(*noisy_structure.positions.shape)
+        n_clusters = 3
+        _, inds = pas.get_steinhardt_parameter_structure(noisy_structure, n_clusters=n_clusters)
+        self.assertEqual(n_clusters, len(np.unique(inds)), msg='Expected to find one label for each cluster.')
+
     def test_centrosymmetry(self):
         csm = pas.analyse_centro_symmetry(self.structure, num_neighbors=12)
         self.assertLess(np.mean(csm), 1E-5)

--- a/tests/atomistics/structure/test_pyscal.py
+++ b/tests/atomistics/structure/test_pyscal.py
@@ -38,6 +38,11 @@ class Testpyscal(TestWithCleanProject):
 
         qtest = np.random.randint(2, 13, size=2)
 
+        self.assertEqual(2, len(pas.get_steinhardt_parameter_structure(self.structure)),
+                         msg='Expected default return value to be a tuple of qs and cluster indices.')
+        self.assertIsInstance(pas.get_steinhardt_parameter_structure(self.structure, clustering=False), np.ndarray,
+                              msg='Expected just the qs when no clustering is used.')
+
         qs, _ = pas.get_steinhardt_parameter_structure(self.structure, cutoff=0, n_clusters=2, q=qtest)
         for c, q in enumerate(qs):
             self.assertLess(np.abs(np.mean(q) - perfect_vals[qtest[c]-2]), 1E-3)


### PR DESCRIPTION
The pyscal Steinhardt docs were incomplete in the return values. In the process of updating the docs I also made it return numpy arrays, stopped recasting the clustering values as a boolean (as this casting negates most of the benefit from `n_clusters>2`), and streamlined the input by deprecating the boolean `clustering` arg (just set `n_clusters=None`) instead. Tests were updated alongside this.

The one thing I'm still really unhappy with is that the docstring is manually duplicated. We should be able to get around this with `functools.wraps`, but I want to do that separately -- I think we should be able to do this for all the pyscal routines that basically just pops off the `atoms` argument line. Easier to do once we subdivide the `Analyze` object to have a `Pyscal` attribute, IMO.