### PR TITLE
Re-add check for building the doc

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -9,3 +9,4 @@ dependencies:
   - Graphviz
   - sphinxcontrib-applehelp
   - seaborn
+  - jinja2 <3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,7 @@ jobs:
         python .ci_support/pyironconfig.py
         pip install --no-deps .
         conda env update --name test --file .ci_support/environment-docs.yml
+        conda list
     - name: Documentation
       shell: bash -l {0}
       run: ./.ci_support/build_docs.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Docs
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        python-version: 3.9
+        environment-file: .ci_support/environment.yml
+    - name: Setup
+      shell: bash -l {0}
+      run: |
+        python .ci_support/pyironconfig.py
+        pip install --no-deps .
+        conda env update --name test --file .ci_support/environment-docs.yml
+    - name: Documentation
+      shell: bash -l {0}
+      run: ./.ci_support/build_docs.sh

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ formats: []
 
 # Install pyiron from conda 
 conda:
-  environment: docs/environment.yml
+  environment: .ci_support/environment-docs.yml
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,4 +2,5 @@ channels:
 - conda-forge
 dependencies:
 - pyiron_atomistics
+- ipywidgets
 - nbsphinx

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,6 +1,0 @@
-channels:
-- conda-forge
-dependencies:
-- pyiron_atomistics
-- ipywidgets
-- nbsphinx


### PR DESCRIPTION
It seems we lost the check if the docs are building here and some changes here cause the docs test to fail [here](https://github.com/pyiron/pyiron/pull/1340#). 