### PR TITLE
Add optional method to allow non-integer frames

### DIFF
--- a/pyiron_atomistics/atomistics/structure/has_structure.py
+++ b/pyiron_atomistics/atomistics/structure/has_structure.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 from abc import ABC, abstractmethod, abstractproperty
+import numbers
 from pyiron_base import deprecate
 
 """
@@ -87,7 +88,7 @@ class HasStructure(ABC):
         """
         if iteration_step is not None:
             frame = iteration_step
-        if not isinstance(frame, int):
+        if not isinstance(frame, numbers.Integral):
             try:
                 frame = self._translate_frame(frame)
             except NotImplementedError:

--- a/pyiron_atomistics/atomistics/structure/has_structure.py
+++ b/pyiron_atomistics/atomistics/structure/has_structure.py
@@ -15,7 +15,7 @@ __copyright__ = (
     "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
-__version__ = "1.0"
+__version__ = "1.1"
 __maintainer__ = "Marvin Poul"
 __email__ = "poul@mpie.de"
 __status__ = "production"


### PR DESCRIPTION
Adds an optional method to `HasStructure`.

Some sub classes may not only have integer ids associated to structures,
but also (string) names.  They can override _translate_frame to enable
such behavior.

I want this for the new structure list we're working on [here](https://github.com/pyiron/pyiron_contrib/pull/148) and for the `TrainingContainer`.