### PR TITLE
Phonopy options

### DIFF
--- a/pyiron_atomistics/atomistics/master/phonopy.py
+++ b/pyiron_atomistics/atomistics/master/phonopy.py
@@ -16,7 +16,7 @@ from phonopy.file_IO import write_FORCE_CONSTANTS
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.atomistics.master.parallel import AtomisticParallelMaster
 from pyiron_atomistics.atomistics.structure.phonopy import publication as phonopy_publication
-from pyiron_base import JobGenerator, Settings
+from pyiron_base import JobGenerator, Settings, ImportAlarm
 
 __author__ = "Jan Janssen, Yury Lysogorskiy"
 __copyright__ = (
@@ -522,4 +522,11 @@ class PhonopyJob(AtomisticParallelMaster):
             raise ValueError("Phonopy reference jobs should be static calculations, but got {}".format(
                 self.ref_job._generic_input["calc_mode"]
             ))
+        if self.input["number_of_snapshots"] is not None:
+            with ImportAlarm(
+                    "Phonopy with random snapshot displacement relies on the alm module but this unavailable. Please "
+                    "ensure your python environment contains alm, e.g. by running `conda install -c conda-forge alm`."
+                    "Note: at time of writing alm is only available for Linux and OSX systems."
+            ) as import_alarm:
+                import alm
         super().validate_ready_to_run()

--- a/pyiron_atomistics/atomistics/master/phonopy.py
+++ b/pyiron_atomistics/atomistics/master/phonopy.py
@@ -529,5 +529,5 @@ class PhonopyJob(AtomisticParallelMaster):
                     "Note: at time of writing alm is only available for Linux and OSX systems."
             ) as import_alarm:
                 import alm
-                import_alarm.warn_if_failed()
+            import_alarm.warn_if_failed()
         super().validate_ready_to_run()

--- a/pyiron_atomistics/atomistics/master/phonopy.py
+++ b/pyiron_atomistics/atomistics/master/phonopy.py
@@ -529,4 +529,5 @@ class PhonopyJob(AtomisticParallelMaster):
                     "Note: at time of writing alm is only available for Linux and OSX systems."
             ) as import_alarm:
                 import alm
+                import_alarm.warn_if_failed()
         super().validate_ready_to_run()

--- a/tests/atomistics/master/test_phonopy.py
+++ b/tests/atomistics/master/test_phonopy.py
@@ -24,7 +24,7 @@ class TestPhonopy(TestWithCleanProject):
         job.set_force_constants(1)
         # phono.run() # removed because somehow it's extremely slow
 
-    def test_run(self):
+    def test_number_of_snapshots(self):
         basis = self.project.create.structure.bulk('Al', cubic=True)
         job = self.project.create.job.HessianJob('job_test')
         job.set_reference_structure(basis)
@@ -32,7 +32,7 @@ class TestPhonopy(TestWithCleanProject):
 
         interaction_range = np.min(np.linalg.norm(basis.cell.array, axis=0)) - 1e-8
 
-        phono = self.project.create.job.PhonopyJob('phono1')
+        phono = self.project.create.job.PhonopyJob('phono')
         phono.ref_job = job
         phono.input['interaction_range'] = interaction_range
         phono.input['number_of_snapshots'] = 1

--- a/tests/atomistics/master/test_phonopy.py
+++ b/tests/atomistics/master/test_phonopy.py
@@ -2,35 +2,18 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-import os
-import unittest
-from pyiron_atomistics.atomistics.structure.atoms import CrystalStructure
-from pyiron_base import Project
+from pyiron_atomistics._tests import TestWithCleanProject
 
 
-
-class TestPhonopy(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.file_location = os.path.dirname(os.path.abspath(__file__))
-        cls.project = Project(os.path.join(cls.file_location, "test_phonopy"))
-        cls.project.remove_jobs_silently(recursive=True)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.file_location = os.path.dirname(os.path.abspath(__file__))
-        cls.project.remove(enable=True, enforce=True)
+class TestPhonopy(TestWithCleanProject):
 
     def test_run(self):
-        job = self.project.create_job(
-            'HessianJob', "job_test"
-        )
-        basis = CrystalStructure(
-            element="Fe", bravais_basis="bcc", lattice_constant=2.85
-        )
+        job = self.project.create.job.HessianJob('job_test')
+        basis = self.project.create.structure.bulk('Fe')
         basis.set_initial_magnetic_moments([2]*len(basis))
         job.set_reference_structure(basis)
-        phono = job.create_job("PhonopyJob", "phono")
+        phono = self.project.create.job.PhonopyJob('phono')
+        phono.ref_job = job
         structure = phono.list_structures()[0]
         magmoms = structure.get_initial_magnetic_moments()
         self.assertAlmostEqual(sum(magmoms-2), 0)
@@ -41,17 +24,11 @@ class TestPhonopy(unittest.TestCase):
         # phono.run() # removed because somehow it's extremely slow
 
     def test_non_static_ref_job(self):
-        structure = CrystalStructure(
-            element="Al", bravais_basis="fcc", lattice_constant=4.5
-        )
-        phon_ref_job = self.project.create_job('Lammps', 'ref_job')
-        phon_ref_job.structure = structure
+        phon_ref_job = self.project.create.job.Lammps('ref_job')
+        phon_ref_job.structure = self.project.create.structure.bulk('Al', a=4.5)
         phon_ref_job.potential = phon_ref_job.list_potentials()[0]
         phon_ref_job.calc_minimize()
-        phonopy_job = self.project.create_job("PhonopyJob",'phonopy_job')
+        phonopy_job = self.project.create.job.PhonopyJob('phonopy_job')
         phonopy_job.ref_job = phon_ref_job
         with self.assertRaises(ValueError):
             phonopy_job.validate_ready_to_run()
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
`PhonopyJob` now accepts as input `number_of_snapshots`, which is an argument of the same name for the underlying `phonopy` object's `generate_displacement` method. Instead of using symmetry arguments for building up a displacement set, it just makes a collection of random displacements.

I ran into trouble with large, low-symmetry defect structures wanting to make thousands of displacements. Since I only need a rough approximation of the harmonic behaviour as a reference point for a thermodynamic integration run, I want to be able to choose how many displacement frames I take -- thankfully phonopy has exactly a way to do this and it just needed to be exposed.

Currently it relies on the `alm` package. This is available on conda forge already, but only for OSX and Linux. @pmrv, could you please briefly review to see if I'm using `ImportAlarm` appropriately and whether you have any clever ideas about including this as an optional dependency? I think we talked about that topic at a recent pyiron meeting.

@raynol-dsouza if you could take a look at the actual phonopy stuff itself that would be great. I hope it will be useful for you too.