### PR TITLE
Only test murn

### DIFF
--- a/tests/atomistics/master/test_murnaghan.py
+++ b/tests/atomistics/master/test_murnaghan.py
@@ -69,7 +69,7 @@ class TestMurnaghan(TestWithProject):
         murn.remove()
         job_ser.remove()
 
-    def test_plot(self):
+    def test_fitting_routines(self):
         ref_job = self.project.create.job.Lammps('ref')
         murn = ref_job.create_job('Murnaghan', 'murn')
         murn.structure = self.basis
@@ -104,6 +104,16 @@ class TestMurnaghan(TestWithProject):
             murn.fit_birch_murnaghan()
             self.assertAlmostEqual(-90.72005405262217, murn.equilibrium_energy)
             self.assertAlmostEqual(448.41909755611437, murn.equilibrium_volume)
+
+        with self.subTest(msg="vinet"):
+            murn.fit_vinet()
+            self.assertAlmostEqual(-90.72000006839492, murn.equilibrium_energy)
+            self.assertAlmostEqual(448.40333840970357, murn.equilibrium_volume)
+
+        with self.subTest(msg='murnaghan'):
+            murn.fit_murnaghan()
+            self.assertAlmostEqual(-90.72018572197015, murn.equilibrium_energy)
+            self.assertAlmostEqual(448.4556825322108, murn.equilibrium_volume)
 
 
 if __name__ == "__main__":

--- a/tests/atomistics/master/test_murnaghan.py
+++ b/tests/atomistics/master/test_murnaghan.py
@@ -2,15 +2,16 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-import os
 import unittest
+
+import numpy as np
+
 from pyiron_atomistics.atomistics.structure.atoms import CrystalStructure
-from pyiron_base import Project
+from pyiron_base._tests import TestWithProject
 
 
 def convergence_goal(self, **qwargs):
     import numpy as np
-
     eps = 0.2
     if "eps" in qwargs:
         eps = qwargs["eps"]
@@ -25,21 +26,13 @@ def convergence_goal(self, **qwargs):
     return job_next
 
 
-class TestMurnaghan(unittest.TestCase):
+class TestMurnaghan(TestWithProject):
     @classmethod
     def setUpClass(cls):
-        cls.file_location = os.path.dirname(os.path.abspath(__file__))
-        cls.project = Project(os.path.join(cls.file_location, "test_murnaghan"))
+        super().setUpClass()
         cls.basis = CrystalStructure(
             element="Fe", bravais_basis="fcc", lattice_constant=3.5
         )
-        cls.project.remove_jobs_silently(recursive=True)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.file_location = os.path.dirname(os.path.abspath(__file__))
-        project = Project(os.path.join(cls.file_location, "test_murnaghan"))
-        project.remove(enable=True, enforce=True)
 
     def test_interactive_run(self):
         job = self.project.create_job('HessianJob', 'hessian')
@@ -75,6 +68,42 @@ class TestMurnaghan(unittest.TestCase):
 
         murn.remove()
         job_ser.remove()
+
+    def test_plot(self):
+        ref_job = self.project.create.job.Lammps('ref')
+        murn = ref_job.create_job('Murnaghan', 'murn')
+        murn.structure = self.basis
+        # mock murnaghan run with data from:
+        #   ref_job = pr.create.job.Lammps('Lammps')
+        #   ref_job.structure = pr.create_structure('Al','fcc', 4.0).repeat(3)
+        #   ref_job.potential = '1995--Angelo-J-E--Ni-Al-H--LAMMPS--ipr1'
+        #   murn = ref_job.create_job(ham.job_type.Murnaghan, 'murn')
+        #   murn.run()
+        energies = np.array([-88.23691773, -88.96842984, -89.55374317, -90.00642629,
+                             -90.33875009, -90.5618246, -90.68571886, -90.71957679,
+                             -90.67170222, -90.54964935, -90.36029582])
+        volume = np.array([388.79999999, 397.44, 406.08, 414.71999999,
+                           423.35999999, 431.99999999, 440.63999999, 449.27999999,
+                           457.92, 466.55999999, 475.19999999])
+        murn._hdf5["output/volume"] = volume
+        murn._hdf5["output/energy"] = energies
+        murn._hdf5["output/equilibrium_volume"] = 448.4033384110422
+        murn.status.finished = True
+
+        murn.plot(plt_show=False)
+        with self.subTest(msg="standard polynomial fit"):
+            self.assertAlmostEqual(-90.71969974284912, murn.equilibrium_energy)
+            self.assertAlmostEqual(448.1341230545222, murn.equilibrium_volume)
+
+        with self.subTest(msg="polynomial fit with fit_order = 2"):
+            murn.fit_polynomial(fit_order=2)
+            self.assertAlmostEqual(-90.76380033222287, murn.equilibrium_energy)
+            self.assertAlmostEqual(449.1529040727273, murn.equilibrium_volume)
+
+        with self.subTest(msg='birchmurnaghan'):
+            murn.fit_birch_murnaghan()
+            self.assertAlmostEqual(-90.72005405262217, murn.equilibrium_energy)
+            self.assertAlmostEqual(448.41909755611437, murn.equilibrium_volume)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This includes only the enhanced tests from PR #214, i.e. no changes to the code base which could crash the notebooks. If the error persists, we probably have a problem with the new [lammps release](https://github.com/lammps/lammps/releases).
