### PR TITLE
Lammps units

### DIFF
--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -467,7 +467,6 @@ class LammpsBase(AtomisticGenericJob):
             ]
             indices = [indices_i.tolist() for indices_i in h5md["/particles/all/indices/value"]]
         with self.project_hdf5.open("output/generic") as h5_file:
-            # Store after converting to pyiron units
             h5_file["forces"] = uc.convert_array_to_pyiron_units(np.array(forces), "forces")
             h5_file["positions"] = uc.convert_array_to_pyiron_units(np.array(positions), "positions")
             h5_file["steps"] = uc.convert_array_to_pyiron_units(np.array(steps), "steps")
@@ -610,7 +609,6 @@ class LammpsBase(AtomisticGenericJob):
                 # This is a hack for backward comparability
                 for k, v in df.items():
                     if k in generic_keys_lst:
-                        # Convert to pyiron units
                         array_quantity = np.array(v)
                         hdf_output[k] = uc.convert_array_to_pyiron_units(array_quantity, label=k)
                 # Store pressures as numpy arrays
@@ -1012,7 +1010,6 @@ class LammpsBase(AtomisticGenericJob):
                 output[kk.replace('c_', '')] = np.array([cc[kk] for cc in content], dtype=float)
             with self.project_hdf5.open("output/generic") as hdf_output:
                 for k, v in output.items():
-                    # Convert to pyiron units
                     hdf_output[k] = uc.convert_array_to_pyiron_units(v, label=k)
         else:
             warnings.warn("LAMMPS warning: No dump.out output file found.")

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -575,7 +575,6 @@ class LammpsBase(AtomisticGenericJob):
                     (df.Pxx, df.Pxy, df.Pxz, df.Pxy, df.Pyy, df.Pyz, df.Pxz, df.Pyz, df.Pzz),
                     axis=-1,
                 ).reshape(-1, 3, 3).astype('float64')
-
                 # Rotate pressures from Lammps frame to pyiron frame if necessary
                 rotation_matrix = self._prism.R.T
                 if np.matrix.trace(rotation_matrix) != 3:
@@ -586,7 +585,7 @@ class LammpsBase(AtomisticGenericJob):
                         ((df.columns.str.len() == 3) & df.columns.str.startswith("P"))
                     ]
                 )
-                pressure_dict["pressure"] = pressures
+                pressure_dict["pressures"] = pressures
             else:
                 warnings.warn("LAMMPS warning: log.lammps does not contain the required pressure values.")
             if 'mean_pressure[1]' in df.columns:
@@ -604,7 +603,6 @@ class LammpsBase(AtomisticGenericJob):
                     ]
                 )
                 pressure_dict["mean_pressures"] = pressures
-
             generic_keys_lst = list(h5_dict.values())
             # For unit conversion
             units_key_list = np.array(list(LAMMPS_UNIT_CONVERSIONS[self.input.control["units"]].keys()))

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -609,8 +609,7 @@ class LammpsBase(AtomisticGenericJob):
                 # This is a hack for backward comparability
                 for k, v in df.items():
                     if k in generic_keys_lst:
-                        array_quantity = np.array(v)
-                        hdf_output[k] = uc.convert_array_to_pyiron_units(array_quantity, label=k)
+                        hdf_output[k] = uc.convert_array_to_pyiron_units(np.array(v), label=k)
                 # Store pressures as numpy arrays
                 for key, val in pressure_dict.items():
                     hdf_output[key] = uc.convert_array_to_pyiron_units(val, label=key)

--- a/pyiron_atomistics/lammps/control.py
+++ b/pyiron_atomistics/lammps/control.py
@@ -8,7 +8,7 @@ import hashlib
 import numpy as np
 import warnings
 from pyiron_base import GenericParameters
-import scipy.constants as spc
+from pyiron_atomistics.lammps.units import LAMMPS_UNIT_CONVERSIONS
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal, Jan Janssen"
 __copyright__ = (
@@ -20,96 +20,6 @@ __maintainer__ = "Sudarsan Surendralal"
 __email__ = "surendralal@mpie.de"
 __status__ = "production"
 __date__ = "Sep 1, 2017"
-
-
-# Conversion factors for transfroming pyiron units to Lammps units (alphabetical)
-AMU_TO_G = spc.atomic_mass * spc.kilo
-AMU_TO_KG = spc.atomic_mass
-ANG_PER_FS_TO_ANG_PER_PS = spc.pico / spc.femto
-ANG_PER_FS_TO_BOHR_PER_FS = spc.angstrom / spc.physical_constants['Bohr radius'][0]
-ANG_PER_FS_TO_CM_PER_S = (spc.angstrom / spc.femto) / spc.centi
-ANG_PER_FS_TO_M_PER_S = spc.angstrom / spc.femto
-ANG_TO_BOHR = spc.angstrom / spc.physical_constants['Bohr radius'][0]
-ANG_TO_CM = spc.angstrom / spc.centi
-ANG_TO_M = spc.angstrom
-EL_TO_COUL = spc.elementary_charge
-EV_PER_ANG_TO_DYNE = (spc.electron_volt / spc.angstrom) / spc.dyne
-EV_PER_ANG_TO_HA_PER_BOHR = spc.physical_constants["electron volt-hartree relationship"][0] * \
-                            spc.physical_constants['Bohr radius'][0] / spc.angstrom
-EV_PER_ANG_TO_KCAL_PER_MOL_ANG = spc.eV / (spc.kilo * spc.calorie / spc.N_A)
-EV_PER_ANG_TO_N = spc.electron_volt / spc.angstrom
-EV_TO_ERG = spc.electron_volt / spc.erg
-EV_TO_HA = spc.physical_constants["electron volt-hartree relationship"][0]
-EV_TO_J = spc.electron_volt
-EV_TO_KCAL_PER_MOL = spc.eV / (spc.kilo * spc.calorie / spc.N_A)
-FS_TO_PS = spc.femto / spc.pico
-FS_TO_S = spc.femto
-GPA_TO_ATM = spc.giga / spc.atm
-GPA_TO_BAR = spc.giga / spc.bar
-GPA_TO_BARYE = spc.giga / (spc.micro * spc.bar)  # "barye" = 1e-6 bar
-GPA_TO_PA = spc.giga
-
-# Conversions for most of the Lammps units to Pyiron units
-# Lammps units source doc: https://lammps.sandia.gov/doc/units.html
-# Pyrion units source doc: https://pyiron.readthedocs.io/en/latest/source/faq.html
-# At time of writing, not all these conversion factors are used, but may be helpful later.
-LAMMPS_UNIT_CONVERSIONS = {
-    "metal": {
-        "mass": 1.,
-        "distance": 1.,
-        "time": FS_TO_PS,
-        "energy": 1.,
-        "velocity": ANG_PER_FS_TO_ANG_PER_PS,
-        "force": 1.,
-        "temperature": 1.,
-        "pressure": GPA_TO_BAR,
-        "charge": 1.
-    },
-    "si": {
-        "mass": AMU_TO_KG,
-        "distance": ANG_TO_M,
-        "time": FS_TO_S,
-        "energy": EV_TO_J,
-        "velocity": ANG_PER_FS_TO_M_PER_S,
-        "force": EV_PER_ANG_TO_N,
-        "temperature": 1.,
-        "pressure": GPA_TO_PA,
-        "charge": EL_TO_COUL
-    },
-    "cgs": {
-        "mass": AMU_TO_G,
-        "distance": ANG_TO_CM,
-        "time": FS_TO_S,
-        "energy": EV_TO_ERG,
-        "velocity": ANG_PER_FS_TO_CM_PER_S,
-        "force": EV_PER_ANG_TO_DYNE,
-        "temperature": 1.,
-        "pressure": GPA_TO_BARYE,
-        "charge": 4.8032044e-10  # In statCoulombs, but these are deprecated and thus not in scipt.constants
-    },
-    "real": {
-        "mass": 1.,
-        "distance": 1.,
-        "time": 1.,
-        "energy": EV_TO_KCAL_PER_MOL,
-        "velocity": 1.,
-        "force": EV_PER_ANG_TO_KCAL_PER_MOL_ANG,
-        "temperature": 1.,
-        "pressure": GPA_TO_ATM,
-        "charge": 1.
-    },
-    "electron": {
-        "mass": 1.,
-        "distance": ANG_TO_BOHR,
-        "time": 1.,
-        "energy": EV_TO_HA,
-        "velocity": ANG_PER_FS_TO_BOHR_PER_FS,
-        "force": EV_PER_ANG_TO_HA_PER_BOHR,
-        "temperature": 1.,
-        "pressure": GPA_TO_PA,
-        "charge": 1.
-    },
-}
 
 
 class LammpsControl(GenericParameters):

--- a/pyiron_atomistics/lammps/units.py
+++ b/pyiron_atomistics/lammps/units.py
@@ -103,22 +103,28 @@ LAMMPS_UNIT_CONVERSIONS = {
     },
 }
 
+# Define conversion for volumes based on distances
+for values in LAMMPS_UNIT_CONVERSIONS.values():
+    values["volume"] = values["distance"] ** 3
+
+
 # Hard coded list of all quantities we store in pyiron and the type of quantity it stores (Expand if necessary)
-conversion_dict = dict()
-conversion_dict["distance"] = ["positions", "cells", "unwrapped_positions"]
-conversion_dict["pressure"] = ["pressure", "pressures", "mean_pressures"]
-conversion_dict["volume"] = ["volume"]
-conversion_dict["time"] = ["time"]
-conversion_dict["energy"] = ["energy_tot", "energy_pot"]
-conversion_dict["temperature"] = ["temperature", "temperatures"]
-conversion_dict["velocity"] = ["velocity"]
-conversion_dict["mass"] = ["mass"]
-conversion_dict["charge"] = ["charges", "charge"]
+_conversion_dict = dict()
+_conversion_dict["distance"] = ["positions", "cells", "unwrapped_positions"]
+_conversion_dict["volume"] = ["volume", "volumes"]
+_conversion_dict["pressure"] = ["pressure", "pressures", "mean_pressures"]
+_conversion_dict["time"] = ["time"]
+_conversion_dict["energy"] = ["energy_tot", "energy_pot"]
+_conversion_dict["temperature"] = ["temperature", "temperatures"]
+_conversion_dict["velocity"] = ["velocity"]
+_conversion_dict["mass"] = ["mass"]
+_conversion_dict["charge"] = ["charges", "charge"]
+_conversion_dict["force"] = ["forces", "force"]
 
 
-# Reverse conversion_dict
+# Reverse _conversion_dict
 quantity_dict = dict()
-for key, val in conversion_dict.items():
+for key, val in _conversion_dict.items():
     for v in val:
         quantity_dict[v] = key
 
@@ -139,8 +145,8 @@ class UnitConverter:
         return self[quantity]
 
     def convert_array_to_pyiron_units(self, array, label):
-        if label in conversion_dict.keys():
-            return array * self.lammps_to_pyiron(conversion_dict[label])
+        if label in quantity_dict.keys():
+            return array * self.lammps_to_pyiron(quantity_dict[label])
         else:
             warnings.warn(message="Warning: Couldn't determine the LAMMPS to pyiron unit conversion type of quantity "
                                   "{}. Returning un-normalized quantity".format(label))

--- a/pyiron_atomistics/lammps/units.py
+++ b/pyiron_atomistics/lammps/units.py
@@ -1,0 +1,103 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import scipy.constants as spc
+
+__author__ = "Joerg Neugebauer, Sudarsan Surendralal, Jan Janssen"
+__copyright__ = (
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+
+
+# Conversion factors for transfroming pyiron units to Lammps units (alphabetical)
+
+AMU_TO_G = spc.atomic_mass * spc.kilo
+AMU_TO_KG = spc.atomic_mass
+ANG_PER_FS_TO_ANG_PER_PS = spc.pico / spc.femto
+ANG_PER_FS_TO_BOHR_PER_FS = spc.angstrom / spc.physical_constants['Bohr radius'][0]
+ANG_PER_FS_TO_CM_PER_S = (spc.angstrom / spc.femto) / spc.centi
+ANG_PER_FS_TO_M_PER_S = spc.angstrom / spc.femto
+ANG_TO_BOHR = spc.angstrom / spc.physical_constants['Bohr radius'][0]
+ANG_TO_CM = spc.angstrom / spc.centi
+ANG_TO_M = spc.angstrom
+EL_TO_COUL = spc.elementary_charge
+EV_PER_ANG_TO_DYNE = (spc.electron_volt / spc.angstrom) / spc.dyne
+EV_PER_ANG_TO_HA_PER_BOHR = spc.physical_constants["electron volt-hartree relationship"][0] * \
+                            spc.physical_constants['Bohr radius'][0] / spc.angstrom
+EV_PER_ANG_TO_KCAL_PER_MOL_ANG = spc.eV / (spc.kilo * spc.calorie / spc.N_A)
+EV_PER_ANG_TO_N = spc.electron_volt / spc.angstrom
+EV_TO_ERG = spc.electron_volt / spc.erg
+EV_TO_HA = spc.physical_constants["electron volt-hartree relationship"][0]
+EV_TO_J = spc.electron_volt
+EV_TO_KCAL_PER_MOL = spc.eV / (spc.kilo * spc.calorie / spc.N_A)
+FS_TO_PS = spc.femto / spc.pico
+FS_TO_S = spc.femto
+GPA_TO_ATM = spc.giga / spc.atm
+GPA_TO_BAR = spc.giga / spc.bar
+GPA_TO_BARYE = spc.giga / (spc.micro * spc.bar)  # "barye" = 1e-6 bar
+GPA_TO_PA = spc.giga
+
+# Conversions for most of the Lammps units to Pyiron units
+# Lammps units source doc: https://lammps.sandia.gov/doc/units.html
+# Pyrion units source doc: https://pyiron.readthedocs.io/en/latest/source/faq.html
+# At time of writing, not all these conversion factors are used, but may be helpful later.
+
+LAMMPS_UNIT_CONVERSIONS = {
+    "metal": {
+        "mass": 1.,
+        "distance": 1.,
+        "time": FS_TO_PS,
+        "energy": 1.,
+        "velocity": ANG_PER_FS_TO_ANG_PER_PS,
+        "force": 1.,
+        "temperature": 1.,
+        "pressure": GPA_TO_BAR,
+        "charge": 1.
+    },
+    "si": {
+        "mass": AMU_TO_KG,
+        "distance": ANG_TO_M,
+        "time": FS_TO_S,
+        "energy": EV_TO_J,
+        "velocity": ANG_PER_FS_TO_M_PER_S,
+        "force": EV_PER_ANG_TO_N,
+        "temperature": 1.,
+        "pressure": GPA_TO_PA,
+        "charge": EL_TO_COUL
+    },
+    "cgs": {
+        "mass": AMU_TO_G,
+        "distance": ANG_TO_CM,
+        "time": FS_TO_S,
+        "energy": EV_TO_ERG,
+        "velocity": ANG_PER_FS_TO_CM_PER_S,
+        "force": EV_PER_ANG_TO_DYNE,
+        "temperature": 1.,
+        "pressure": GPA_TO_BARYE,
+        "charge": 4.8032044e-10  # In statCoulombs, but these are deprecated and thus not in scipt.constants
+    },
+    "real": {
+        "mass": 1.,
+        "distance": 1.,
+        "time": 1.,
+        "energy": EV_TO_KCAL_PER_MOL,
+        "velocity": 1.,
+        "force": EV_PER_ANG_TO_KCAL_PER_MOL_ANG,
+        "temperature": 1.,
+        "pressure": GPA_TO_ATM,
+        "charge": 1.
+    },
+    "electron": {
+        "mass": 1.,
+        "distance": ANG_TO_BOHR,
+        "time": 1.,
+        "energy": EV_TO_HA,
+        "velocity": ANG_PER_FS_TO_BOHR_PER_FS,
+        "force": EV_PER_ANG_TO_HA_PER_BOHR,
+        "temperature": 1.,
+        "pressure": GPA_TO_PA,
+        "charge": 1.
+    },
+}

--- a/pyiron_atomistics/lammps/units.py
+++ b/pyiron_atomistics/lammps/units.py
@@ -130,7 +130,6 @@ for key, val in _conversion_dict.items():
 
 
 class UnitConverter:
-
     """This is a class to aid conversion of physical quantities between LAMMPS and pyiron units."""
 
     def __init__(self, units):

--- a/pyiron_atomistics/lammps/units.py
+++ b/pyiron_atomistics/lammps/units.py
@@ -131,7 +131,19 @@ for key, val in _conversion_dict.items():
 
 class UnitConverter:
 
+    """
+    This is a class to aid conversion of physical quantities between LAMMPS and pyiron units.
+
+    """
+
     def __init__(self, units):
+        """
+        Initialize the class by specifiying the type of lammps units used
+
+        Args:
+            units (str): The type of LAMMPS units used (eg. metal, real, cgs, lj, etc.)
+
+        """
         self._units = units
         self._dict = LAMMPS_UNIT_CONVERSIONS[self._units]
 
@@ -139,12 +151,45 @@ class UnitConverter:
         return self._dict[quantity]
 
     def lammps_to_pyiron(self, quantity):
+        """
+        Get the conversion factor for a given physical quantity to be converted from LAMMPS to pyiron units
+
+        Args:
+            quantity (str): The physical quantity (must be a key in the dictionary `_conversion_dict`)
+
+        Returns:
+
+            float: The conversion factor
+
+        """
         return 1. / self[quantity]
 
     def pyiron_to_lammps(self, quantity):
+        """
+        Get the conversion factor for a given physical quantity to be converted from pyiron to LAMMPS units
+
+        Args:
+            quantity (str): The physical quantity (must be a key in the dictionary `_conversion_dict`)
+
+        Returns:
+
+            float: The conversion factor
+
+        """
         return self[quantity]
 
     def convert_array_to_pyiron_units(self, array, label):
+        """
+        Convert a labelled numpy array into pyiron units based on the physical quantity the label corresponds to
+
+        Args:
+            array (numpy.ndarray): The array to be converted
+            label (str): The label of the quantity (must be a key in the dictionary `quantity_dict`)
+
+        Returns:
+            numpy.ndarray: The array after conversion
+
+        """
         if label in quantity_dict.keys():
             return array * self.lammps_to_pyiron(quantity_dict[label])
         else:

--- a/pyiron_atomistics/lammps/units.py
+++ b/pyiron_atomistics/lammps/units.py
@@ -131,10 +131,7 @@ for key, val in _conversion_dict.items():
 
 class UnitConverter:
 
-    """
-    This is a class to aid conversion of physical quantities between LAMMPS and pyiron units.
-
-    """
+    """This is a class to aid conversion of physical quantities between LAMMPS and pyiron units."""
 
     def __init__(self, units):
         """
@@ -148,6 +145,15 @@ class UnitConverter:
         self._dict = LAMMPS_UNIT_CONVERSIONS[self._units]
 
     def __getitem__(self, quantity):
+        """
+        Get quantity from `_dict`
+
+        Args:
+            quantity (str): The physical quantity
+
+        Returns:
+            float: The conversion factor
+        """
         return self._dict[quantity]
 
     def lammps_to_pyiron(self, quantity):

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -11,7 +11,7 @@ from pyiron_base import Project, ProjectHDFio
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.lammps.lammps import Lammps
 from pyiron_atomistics.lammps.base import LammpsStructure, UnfoldingPrism
-from pyiron_atomistics.lammps.control import LAMMPS_UNIT_CONVERSIONS
+from pyiron_atomistics.lammps.units import LAMMPS_UNIT_CONVERSIONS
 import ase.units as units
 
 

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -251,7 +251,7 @@ class TestLammps(unittest.TestCase):
             "positions",
             "forces",
             "cells",
-            "pressures",
+            "pressure",
             "unwrapped_positions",
         ]
         with self.job_water.project_hdf5.open("output/generic") as h_gen:

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -323,7 +323,10 @@ class TestLammps(unittest.TestCase):
         self.assertTrue(
             np.allclose(self.job_water_dump["output/generic/forces"], forces / LAMMPS_UNIT_CONVERSIONS["real"]["force"])
         )
-        self.assertEqual(round(self.job_water_dump["output/generic/energy_tot"][-1], 4), -256.1287)
+        self.assertEqual(self.job_water_dump["output/generic/energy_tot"][-1], -5906.46836142123 /
+                         LAMMPS_UNIT_CONVERSIONS["real"]["energy"])
+        self.assertEqual(self.job_water_dump["output/generic/pressure"][-2][0, 0], 515832.570508186 /
+                         LAMMPS_UNIT_CONVERSIONS["real"]["pressure"])
 
         self.job_water_dump.write_traj(filename="test.xyz",
                                        file_format="xyz")

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -321,8 +321,10 @@ class TestLammps(unittest.TestCase):
             )
         )
         self.assertTrue(
-            np.allclose(self.job_water_dump["output/generic/forces"], forces)
+            np.allclose(self.job_water_dump["output/generic/forces"], forces / LAMMPS_UNIT_CONVERSIONS["real"]["force"])
         )
+        self.assertEqual(round(self.job_water_dump["output/generic/energy_tot"][-1], 4), -256.1287)
+
         self.job_water_dump.write_traj(filename="test.xyz",
                                        file_format="xyz")
         atom_indices = self.job_water_dump.structure.select_index("H")

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -251,7 +251,7 @@ class TestLammps(unittest.TestCase):
             "positions",
             "forces",
             "cells",
-            "pressure",
+            "pressures",
             "unwrapped_positions",
         ]
         with self.job_water.project_hdf5.open("output/generic") as h_gen:
@@ -325,8 +325,9 @@ class TestLammps(unittest.TestCase):
         )
         self.assertEqual(self.job_water_dump["output/generic/energy_tot"][-1], -5906.46836142123 /
                          LAMMPS_UNIT_CONVERSIONS["real"]["energy"])
-        self.assertEqual(self.job_water_dump["output/generic/pressure"][-2][0, 0], 515832.570508186 /
-                         LAMMPS_UNIT_CONVERSIONS["real"]["pressure"])
+
+        self.assertAlmostEqual(self.job_water_dump["output/generic/pressures"][-2][0, 0], 515832.570508186 /
+                         LAMMPS_UNIT_CONVERSIONS["real"]["pressure"], 2)
 
         self.job_water_dump.write_traj(filename="test.xyz",
                                        file_format="xyz")

--- a/tests/lammps/test_control.py
+++ b/tests/lammps/test_control.py
@@ -5,7 +5,8 @@
 import numpy as np
 from scipy.spatial.transform import Rotation
 import unittest
-from pyiron_atomistics.lammps.control import LammpsControl, LAMMPS_UNIT_CONVERSIONS
+from pyiron_atomistics.lammps.control import LammpsControl
+from pyiron_atomistics.lammps.units import LAMMPS_UNIT_CONVERSIONS
 
 
 class TestLammps(unittest.TestCase):


### PR DESCRIPTION
Implemented proper conversion of LAMMPS output into pyiron units on parsing. Made the following changes

1. Conversion factors defined in a new file `units.py`
2. Avoiding unnecessary conversion of numpy array to list before storing
