### PR TITLE
Get interstitials

### DIFF
--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -28,23 +28,20 @@ __date__ = "Sep 1, 2017"
 s = Settings()
 
 
-def get_mean_positions(positions, cell, pbc, labels=None):
+def get_mean_positions(positions, cell, pbc, labels):
     """
-    This function calculates the average position(-s) across periodic boundary conditions. If the
-    labels are specified, the positions are grouped accordingly.
+    This function calculates the average position(-s) across periodic boundary conditions according
+    to the labels
 
     Args:
         positions (numpy.ndarray (n, 3)): Coordinates to be averaged
         cell (numpy.ndarray (3, 3)): Cell dimensions
         pbc (numpy.ndarray (3,)): Periodic boundary conditions (in boolean)
-        labels (numpy.ndarray (n,)): (optional) labels according to which the atoms are
-            grouped
+        labels (numpy.ndarray (n,)): labels according to which the atoms are grouped
 
     Returns:
         (numpy.ndarray): mean positions
     """
-    if labels is None:
-        labels = np.zeros(len(positions)).astype(int)
     _, labels, counts = np.unique(labels, return_inverse=True, return_counts=True)
     mean_positions = positions[np.unique(labels, return_index=True)[1]]
     all_positions = positions-mean_positions[labels]

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -91,7 +91,7 @@ class Interstitials:
             neighboring atom sites/vertices.
         5. Kick out points with large neighbor distance variances; this eliminates "irregular"
             shaped interstitials
-        6. Cluster interstitial candidates to avoir point overlapping.
+        6. Cluster interstitial candidates to avoid point overlapping.
 
     The interstitial sites can be obtained through `get_positions`
 
@@ -274,7 +274,7 @@ class Interstitials:
                 neighboring atom sites/vertices.
             5. Kick out points with large neighbor distance variances; this eliminates "irregular"
                 shaped interstitials
-            6. Cluster interstitial candidates to avoir point overlapping.
+            6. Cluster interstitial candidates to avoid point overlapping.
 
         In complex structures (i.e. grain boundary, dislocation etc.), the default parameters
         should be chosen properly. In order to see other quantities, which potentially
@@ -298,7 +298,7 @@ class Interstitials:
         """
         Get variance of neighboring distances. Since interstitial sites are mostly in symmetric
         sites, the variance values tend to be small. In the case of fcc, both tetrahedral and
-        octahedral sites as well as tetrahedral sites in bcc should hvae the value of 0.
+        octahedral sites as well as tetrahedral sites in bcc should have the value of 0.
 
         Returns:
             (numpy.array (n,)) Variance values
@@ -412,7 +412,7 @@ class Analyse:
                 neighboring atom sites/vertices.
             5. Kick out points with large neighbor distance variances; this eliminates "irregular"
                 shaped interstitials
-            6. Cluster interstitial candidates to avoir point overlapping.
+            6. Cluster interstitial candidates to avoid point overlapping.
 
         In complex structures (i.e. grain boundary, dislocation etc.), the default parameters
         should be chosen properly. In order to see other quantities, which potentially
@@ -558,8 +558,8 @@ class Analyse:
                 - total : return number of atoms belonging to each structure
                 - numeric : return a per atom list of numbers- 0 for unknown,
                     1 fcc, 2 hcp, 3 bcc and 4 icosa
-                - str : return a per atom string of sructures
-            ovito_compatibility(bool): use ovito compatiblity mode
+                - str : return a per atom string of structures
+            ovito_compatibility(bool): use ovito compatibility mode
 
         Returns:
             (depends on `mode`)
@@ -588,8 +588,8 @@ class Analyse:
                 - total : return number of atoms belonging to each structure
                 - numeric : return a per atom list of numbers- 0 for unknown,
                     1 fcc, 2 hcp, 3 bcc and 4 icosa
-                - str : return a per atom string of sructures
-            ovito_compatibility(bool): use ovito compatiblity mode
+                - str : return a per atom string of structures
+            ovito_compatibility(bool): use ovito compatibility mode
 
         Returns:
             (depends on `mode`)
@@ -607,7 +607,7 @@ class Analyse:
         Args:
             epsilon (float): displacement to add to avoid wrapping of atoms at borders
             distance_threshold (float): distance below which two vertices are considered as one.
-                Agglomerative clustering algorith (sklearn) is employed. Final positions are given
+                Agglomerative clustering algorithm (sklearn) is employed. Final positions are given
                 as the average positions of clusters.
             width_buffer (float): width of the layer to be added to account for pbc.
 

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -42,12 +42,17 @@ def get_mean_positions(positions, cell, pbc, labels):
     Returns:
         (numpy.ndarray): mean positions
     """
+    # Translate labels to integer enumeration (0, 1, 2, ... etc.) and get their counts
     _, labels, counts = np.unique(labels, return_inverse=True, return_counts=True)
+    # Get reference point for each unique label
     mean_positions = positions[np.unique(labels, return_index=True)[1]]
+    # Get displacement vectors from reference points to all other points for the same labels
     all_positions = positions-mean_positions[labels]
+    # Account for pbc
     all_positions = np.einsum('ji,nj->ni', np.linalg.inv(cell), all_positions)
     all_positions -= np.rint(all_positions)[:,pbc]
     all_positions = np.einsum('ji,nj->ni', cell, all_positions)
+    # Add average displacement vector of each label to the reference point
     np.add.at(mean_positions, labels, (all_positions.T/counts[labels]).T)
     return mean_positions
 

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -78,11 +78,45 @@ def get_average_of_unique_labels(labels, values):
 
 class Interstitials:
     """
-    Class to identify interstitial positions
+    Class to analyse interstitial sites
+
+    This class internally does the following steps:
+
+        1. Initialize grid points (or Voronoi vertices) which are considered as
+            interstitial site candidates.
+        2. Eliminate points within a distance from the nearest neighboring atoms as
+            given by `min_distance`
+        3. Initialize neighbor environment using `get_neighbors`
+        4. Shift interstitial candidates to the nearest symmetric points with respect to the
+            neighboring atom sites/vertices.
+        5. Kick out points with large neighbor distance variances
+        6. Cluster interstitial candidates to avoir point overlapping.
+
+    The interstitial sites can be obtained through `get_interstitials`
+
+    In complex structures (i.e. grain boundary, dislocation etc.), the default parameters
+    should be chosen properly. In order to see other quantities, which potentially
+    characterize interstitial sites, see the following functions from
+    `structure.analyse.interstitials`:
+
+        - `get_variance()`
+        - `get_distance()`
+        - `get_steinhardt_parameter()`
+        - `get_volume()`
+        - `get_area()`
     """
     def __init__(self, structure, n_gridpoints_per_angstrom=5, min_distance=1, use_voronoi=False):
         """
-        Class to identify interstitial positions
+        Args:
+            structure (pyiron_atomistics.atomistics.structure.atoms.Atoms): Reference structure
+            n_gridpoints_per_angstrom (int): Number of grid points per angstrom for the
+                initialization of the interstitial candidates. The finer the mesh (i.e. the larger
+                the value), the likelier it is to find the correct sites but then also it becomes
+                computationally more expensive. Ignored if `use_voronoi` is set to `True`
+            min_distance (float): Minimum distance from the nearest neighboring atoms to the
+                positions for them to be considered as interstitial site candidates.
+            use_voronoi (bool): Use Voronoi vertices for the initial interstitial candidate
+                positions instead of grid points.
         """
         self.min_distance = min_distance
         self.structure = structure
@@ -169,6 +203,52 @@ class Interstitials:
         n_iterations=2,
         eps=0.1,
     ):
+        """
+        Get potential interstitial positions
+
+        Args:
+            num_neighbors (int): Number of neighbors/vertices to consider for the interstitial
+                sites. By definition, tetrahedral sites should have 4 vertices and octahedral
+                sites 6.
+            variance_buffer (bool): Maximum permitted variance value (in distance unit) of the
+                neighbor distance values with respect to the minimum value found for each point.
+                It should be close to 0 for perfect crystals and slightly higher values for
+                structures containing defects.
+            n_iterations (int): Number of iterations for the shifting of the candidate positions
+                to the nearest symmetric positions with respect to `num_neighbors`. In most of the
+                cases, 1 is enough. In some rare cases (notably tetrahedral sites in bcc), it
+                should be at least 2. It is unlikely that it has to be larger than 2.
+            eps (float): Distance below which two interstitial candidate sites to be considered as
+                one site after the symmetrization of the points.
+            initialize_only (bool): Only initialize the grid points/Voronoi points and do not
+                initiate the symmetrization of interstitial candidate sites.
+
+        Returns:
+            ( (n, 3) numpy.ndarray) Interstitial candidate positions.
+
+        This function internally does the following steps:
+
+            1. Initialize grid points (or Voronoi vertices) which are considered as
+                interstitial site candidates.
+            2. Eliminate points within a distance from the nearest neighboring atoms as
+                given by `min_distance`
+            3. Initialize neighbor environment using `get_neighbors`
+            4. Shift interstitial candidates to the nearest symmetric points with respect to the
+                neighboring atom sites/vertices.
+            5. Kick out points with large neighbor distance variances
+            6. Cluster interstitial candidates to avoir point overlapping.
+
+        In complex structures (i.e. grain boundary, dislocation etc.), the default parameters
+        should be chosen properly. In order to see other quantities, which potentially
+        characterize interstitial sites, see the following functions from
+        `structure.analyse.interstitials`:
+
+            - `get_variance()`
+            - `get_distance()`
+            - `get_steinhardt_parameter()`
+            - `get_volume()`
+            - `get_area()`
+        """
         self.num_neighbors = num_neighbors
         for _ in range(n_iterations):
             self._set_interstitials_to_high_symmetry_points()

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -140,7 +140,7 @@ class Interstitials:
             n_iterations (int): Number of iterations for the shifting of the candidate positions
                 to the nearest symmetric positions with respect to `num_neighbors`. In most of the
                 cases, 1 is enough. In some rare cases (notably tetrahedral sites in bcc), it
-                should be at least 2. It is unlikely that it has to be larger than 2. Set 
+                should be at least 2. It is unlikely that it has to be larger than 2. Set
                 `n_iterations` to 0 if no shifting should take place.
             eps (float): Distance below which two interstitial candidate sites to be considered as
                 one site after the symmetrization of the points. Set `eps` to 0 if clustering should
@@ -170,7 +170,7 @@ class Interstitials:
         eps=0.1
     ):
         if use_voronoi:
-            self.positions = structure.analyse.get_voronoi_vertices()
+            self.positions = self.structure.analyse.get_voronoi_vertices()
         else:
             self.positions = self._create_gridpoints(
                 n_gridpoints_per_angstrom=n_gridpoints_per_angstrom

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -279,6 +279,8 @@ class Analyse:
             - `get_variance()`
             - `get_distance()`
             - `get_steinhardt_parameter()`
+            - `get_volume()`
+            - `get_area()`
         """
         self._interstitials = Interstitials(
             structure=self._structure,

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -80,7 +80,7 @@ def get_average_of_unique_labels(labels, values):
 
 class Interstitials:
     """
-    Class to locate interstitial sites
+    Class to search for interstitial sites
 
     This class internally does the following steps:
 
@@ -176,14 +176,14 @@ class Interstitials:
 
         BAD:
         ```
-        >>> neigh.positions[0][0] = x
+        >>> Interstitials.neigh.positions[0][0] = x
         ```
 
         GOOD:
         ```
-        >>> positions = neigh.positions
+        >>> positions = Interstitials.neigh.positions
         >>> positions[0][0] = x
-        >>> neigh.positions = positions
+        >>> Interstitialsneigh.positions = positions
         ```
 
         This is because in the first case related properties (most importantly the neighborhood
@@ -263,8 +263,6 @@ class Interstitials:
                 should be at least 2. It is unlikely that it has to be larger than 2.
             eps (float): Distance below which two interstitial candidate sites to be considered as
                 one site after the symmetrization of the points.
-            initialize_only (bool): Only initialize the grid points/Voronoi points and do not
-                initiate the symmetrization of interstitial candidate sites.
 
         Returns:
             ( (n, 3) numpy.ndarray) Interstitial candidate positions.
@@ -374,7 +372,6 @@ class Analyse:
         variance_buffer=0.01,
         n_iterations=2,
         eps=0.1,
-        initialize_only=False
     ):
         """
         Get potential interstitial positions
@@ -401,8 +398,6 @@ class Analyse:
                 should be at least 2. It is unlikely that it has to be larger than 2.
             eps (float): Distance below which two interstitial candidate sites to be considered as
                 one site after the symmetrization of the points.
-            initialize_only (bool): Only initialize the grid points/Voronoi points and do not
-                initiate the symmetrization of interstitial candidate sites.
 
         Returns:
             ( (n, 3) numpy.ndarray) Interstitial candidate positions.
@@ -437,8 +432,6 @@ class Analyse:
             min_distance=min_distance,
             use_voronoi=use_voronoi,
         )
-        if initialize_only:
-            return self.interstitials
         return self._interstitials.get_positions(
             num_neighbors=num_neighbors,
             variance_buffer=variance_buffer,

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -177,11 +177,27 @@ class Interstitials:
         return self.positions
 
     def get_variance(self):
-        """Get variance of neighboring distances."""
+        """
+        Get variance of neighboring distances. Since interstitial sites are mostly in symmetric
+        sites, the variance values tend to be small. In the case of fcc, both tetrahedral and
+        octahedral sites as well as tetrahedral sites in bcc should hvae the value of 0.
+
+        Returns:
+            (numpy.array (n,)) Variance values
+        """
         return np.std(self.neigh.distances, axis=-1)
 
     def get_distance(self, function_to_apply=np.min):
-        """Get per-position return values of a given function for the neighbors."""
+        """
+        Get per-position return values of a given function for the neighbors.
+
+        Args:
+            function_to_apply (function): Function to apply to the distance array. Default is
+                numpy.minimum
+
+        Returns:
+            (numpy.array (n,)) Function values on the distance array
+        """
         return function_to_apply(self.neigh.distances, axis=-1)
 
     def get_steinhardt_parameter(self, l):
@@ -195,11 +211,17 @@ class Interstitials:
         return self.neigh.get_steinhardt_parameter(l=l)
 
     def get_volume(self):
-        """Get convex hull volume of each site."""
+        """
+            Returns:
+                (numpy.array (n,)): Convex hull volume of each site.
+        """
         return np.array([h.volume for h in self.hull])
 
     def get_area(self):
-        """Get convex hull area of each site."""
+        """
+            Returns:
+                (numpy.array (n,)): Convex hull area of each site.
+        """
         return np.array([h.area for h in self.hull])
 
 

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -253,12 +253,10 @@ class Interstitials:
 
     def _create_gridpoints(self, n_gridpoints_per_angstrom=5):
         cell = self.structure.get_vertical_length()
-        gridpoints = (n_gridpoints_per_angstrom*cell).astype(int)
-        positions = [np.linspace(0, 1, gridpoints[i], endpoint=False) for i in range(3)]
-        positions = np.meshgrid(*positions)
-        return np.einsum(
-            'ji,nj->ni', self.structure.cell, np.stack(positions, axis=-1).reshape(-1, 3)
-        )
+        n_points = (n_gridpoints_per_angstrom*cell).astype(int)
+        positions = np.meshgrid(*[np.linspace(0, 1, n_points[i], endpoint=False) for i in range(3)])
+        positions = np.stack(positions, axis=-1).reshape(-1, 3)
+        return np.einsum('ji,nj->ni', self.structure.cell, positions)
 
     def _remove_too_close(self, min_distance=1):
         neigh = self.structure.get_neighborhood(self.positions, num_neighbors=1)

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -50,7 +50,7 @@ def get_mean_positions(positions, cell, pbc, labels):
     all_positions = positions-mean_positions[labels]
     # Account for pbc
     all_positions = np.einsum('ji,nj->ni', np.linalg.inv(cell), all_positions)
-    all_positions -= np.rint(all_positions)[:,pbc]
+    all_positions[:,pbc] -= np.rint(all_positions)[:,pbc]
     all_positions = np.einsum('ji,nj->ni', cell, all_positions)
     # Add average displacement vector of each label to the reference point
     np.add.at(mean_positions, labels, (all_positions.T/counts[labels]).T)

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -81,6 +81,9 @@ class Interstitials:
     Class to identify interstitial positions
     """
     def __init__(self, structure, n_gridpoints_per_angstrom=5, min_distance=1, use_voronoi=False):
+        """
+        Class to identify interstitial positions
+        """
         self.min_distance = min_distance
         self.structure = structure
         if use_voronoi:
@@ -153,7 +156,6 @@ class Interstitials:
             eps, return_indices=True, positions=self.positions
         )
         labels = DBSCAN(eps=eps, min_samples=1).fit_predict(extended_positions)
-        x = get_average_of_unique_labels(labels, extended_positions)
         coo = coo_matrix((labels, (np.arange(len(labels)), indices)))
         labels = coo.max(axis=0).toarray().flatten()
         self.positions = get_mean_positions(
@@ -175,11 +177,11 @@ class Interstitials:
         return self.positions
 
     def get_variance(self):
-        """Get variance of neighboring distances"""
+        """Get variance of neighboring distances."""
         return np.std(self.neigh.distances, axis=-1)
 
     def get_distance(self, function_to_apply=np.min):
-        """Get per-position return values of a given function for the neighbors"""
+        """Get per-position return values of a given function for the neighbors."""
         return function_to_apply(self.neigh.distances, axis=-1)
 
     def get_steinhardt_parameter(self, l):
@@ -193,11 +195,11 @@ class Interstitials:
         return self.neigh.get_steinhardt_parameter(l=l)
 
     def get_volume(self):
-        """Get convex hull volume of each site"""
+        """Get convex hull volume of each site."""
         return np.array([h.volume for h in self.hull])
 
     def get_area(self):
-        """Get convex hull area of each site"""
+        """Get convex hull area of each site."""
         return np.array([h.area for h in self.hull])
 
 

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -272,7 +272,8 @@ class Interstitials:
             3. Initialize neighbor environment using `get_neighbors`
             4. Shift interstitial candidates to the nearest symmetric points with respect to the
                 neighboring atom sites/vertices.
-            5. Kick out points with large neighbor distance variances
+            5. Kick out points with large neighbor distance variances; this eliminates "irregular"
+                shaped interstitials
             6. Cluster interstitial candidates to avoir point overlapping.
 
         In complex structures (i.e. grain boundary, dislocation etc.), the default parameters
@@ -409,7 +410,8 @@ class Analyse:
             3. Initialize neighbor environment using `get_neighbors`
             4. Shift interstitial candidates to the nearest symmetric points with respect to the
                 neighboring atom sites/vertices.
-            5. Kick out points with large neighbor distance variances
+            5. Kick out points with large neighbor distance variances; this eliminates "irregular"
+                shaped interstitials
             6. Cluster interstitial candidates to avoir point overlapping.
 
         In complex structures (i.e. grain boundary, dislocation etc.), the default parameters

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -201,11 +201,13 @@ class Interstitials:
         return self._hull
 
     def _create_gridpoints(self, n_gridpoints_per_angstrom=5):
-        cell = self.structure.cell.diagonal()
+        cell = self.structure.get_vertical_length()
         gridpoints = (n_gridpoints_per_angstrom*cell).astype(int)
-        positions = [np.linspace(0, cell[i], gridpoints[i], endpoint=False) for i in range(3)]
+        positions = [np.linspace(0, 1, gridpoints[i], endpoint=False) for i in range(3)]
         positions = np.meshgrid(*positions)
-        return np.stack(positions, axis=-1).reshape(-1, 3)
+        return np.einsum(
+            'ji,nj->ni', self.structure.cell, np.stack(positions, axis=-1).reshape(-1, 3)
+        )
 
     def _remove_too_close(self):
         neigh = self.structure.get_neighborhood(self.positions, num_neighbors=1)

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -4,7 +4,6 @@
 
 import numpy as np
 from pyiron_base import Settings
-# TODO: Handle sklearn in dependencies or wrap in import warning
 from sklearn.cluster import AgglomerativeClustering, DBSCAN
 from scipy.sparse import coo_matrix
 from scipy.spatial import Voronoi

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -1195,6 +1195,9 @@ class Atoms(ASEAtoms):
         For a cell `[[1, 1, 0], [0, 1, 0], [0, 0, 1]]`, this function returns
         `[[1, 0, 0], [0, 0.70710678, 0], [0, 0, 1]]` because the first cell vector is projected on
         the vector vertical to the yz-plane (as well as the y component on the xz-plane).
+
+        Args:
+            norm_order (int): Norm order (cf. numpy.linalg.norm)
         """
         return np.linalg.det(self.cell)/np.linalg.norm(
             np.cross(np.roll(self.cell, -1, axis=0), np.roll(self.cell, 1, axis=0)),

--- a/tests/atomistics/structure/test_analyse.py
+++ b/tests/atomistics/structure/test_analyse.py
@@ -69,7 +69,7 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(len(basis.analyse.get_voronoi_vertices(distance_threshold=2)), 1)
 
     def test_get_interstitials_bcc(self):
-        bcc = StructureFactory().ase_bulk('Fe', cubic=True)
+        bcc = StructureFactory().ase.bulk('Fe', cubic=True)
         x_octa_ref = bcc.positions[:,None,:]+0.5*bcc.cell[None,:,:]
         x_octa_ref = x_octa_ref.reshape(-1, 3)
         x_octa_ref = bcc.get_wrapped_coordinates(x_octa_ref)
@@ -86,7 +86,7 @@ class TestAtoms(unittest.TestCase):
         )
 
     def test_get_interstitials_fcc(self):
-        fcc = StructureFactory().ase_bulk('Al', cubic=True)
+        fcc = StructureFactory().ase.bulk('Al', cubic=True)
         a_0 = fcc.cell[0,0]
         x_tetra_ref = 0.25*a_0*np.ones(3)*np.array([[1],[-1]])+fcc.positions[:,None,:]
         x_tetra_ref = fcc.get_wrapped_coordinates(x_tetra_ref).reshape(-1, 3)
@@ -102,11 +102,26 @@ class TestAtoms(unittest.TestCase):
         self.assertAlmostEqual(
             np.linalg.norm(x_octa_ref[:,None,:]-x_octa[None,:,:], axis=-1).min(axis=0).sum(), 0
         )
-        self.assertTrue(np.allclose(fcc.analyse.interstitials.get_areas(), a_0**2*np.sqrt(3)))
-        self.assertTrue(np.allclose(fcc.analyse.interstitials.get_volumes(), a_0**3/6))
-        self.assertTrue(np.allclose(fcc.analyse.interstitials.get_distances(), a_0/2))
-        self.assertTrue(np.all(fcc.analyse.interstitials.get_steinhardt_parameters(4)>0))
-        self.assertAlmostEqual(fcc.analyse.interstitials.get_variances().sum(), 0)
+        self.assertTrue(
+            np.allclose(fcc.analyse.interstitials.get_areas(), a_0**2*np.sqrt(3)),
+            msg='Convex hull area comparison with analytical value failed'
+        )
+        self.assertTrue(
+            np.allclose(fcc.analyse.interstitials.get_volumes(), a_0**3/6),
+            msg='Convex hull volume comparison with analytical value failed'
+        )
+        self.assertTrue(
+            np.allclose(fcc.analyse.interstitials.get_distances(), a_0/2),
+            msg='Distance comparison with analytical value failed'
+        )
+        self.assertTrue(
+            np.all(fcc.analyse.interstitials.get_steinhardt_parameters(4)>0),
+            msg='Illegal Steinhardt parameter'
+        )
+        self.assertAlmostEqual(
+            fcc.analyse.interstitials.get_variances().sum(), 0,
+            msg='Distance variance in FCC must be 0'
+        )
 
 
 if __name__ == "__main__":

--- a/tests/atomistics/structure/test_analyse.py
+++ b/tests/atomistics/structure/test_analyse.py
@@ -102,11 +102,11 @@ class TestAtoms(unittest.TestCase):
         self.assertAlmostEqual(
             np.linalg.norm(x_octa_ref[:,None,:]-x_octa[None,:,:], axis=-1).min(axis=0).sum(), 0
         )
-        self.assertTrue(np.allclose(fcc.analyse.interstitials.get_area(), a_0**2*np.sqrt(3)))
-        self.assertTrue(np.allclose(fcc.analyse.interstitials.get_volume(), a_0**3/6))
-        self.assertTrue(np.allclose(fcc.analyse.interstitials.get_distance(), a_0/2))
-        self.assertTrue(np.all(fcc.analyse.interstitials.get_steinhardt_parameter(4)>0))
-        self.assertAlmostEqual(fcc.analyse.interstitials.get_variance().sum(), 0)
+        self.assertTrue(np.allclose(fcc.analyse.interstitials.get_areas(), a_0**2*np.sqrt(3)))
+        self.assertTrue(np.allclose(fcc.analyse.interstitials.get_volumes(), a_0**3/6))
+        self.assertTrue(np.allclose(fcc.analyse.interstitials.get_distances(), a_0/2))
+        self.assertTrue(np.all(fcc.analyse.interstitials.get_steinhardt_parameters(4)>0))
+        self.assertAlmostEqual(fcc.analyse.interstitials.get_variances().sum(), 0)
 
 
 if __name__ == "__main__":

--- a/tests/atomistics/structure/test_analyse.py
+++ b/tests/atomistics/structure/test_analyse.py
@@ -73,16 +73,20 @@ class TestAtoms(unittest.TestCase):
         x_octa_ref = bcc.positions[:,None,:]+0.5*bcc.cell[None,:,:]
         x_octa_ref = x_octa_ref.reshape(-1, 3)
         x_octa_ref = bcc.get_wrapped_coordinates(x_octa_ref)
-        x_octa = bcc.analyse.get_interstitials(num_neighbors=6)
-        self.assertEqual(len(x_octa), len(x_octa_ref))
+        int_octa = bcc.analyse.get_interstitials(num_neighbors=6)
+        self.assertEqual(len(int_octa.positions), len(x_octa_ref))
         self.assertAlmostEqual(
-            np.linalg.norm(x_octa_ref[:,None,:]-x_octa[None,:,:], axis=-1).min(axis=0).sum(), 0
+            np.linalg.norm(
+                x_octa_ref[:,None,:]-int_octa.positions[None,:,:], axis=-1
+            ).min(axis=0).sum(), 0
         )
-        x_tetra = bcc.analyse.get_interstitials(num_neighbors=4)
+        int_tetra = bcc.analyse.get_interstitials(num_neighbors=4)
         x_tetra_ref = bcc.get_wrapped_coordinates(bcc.analyse.get_voronoi_vertices())
-        self.assertEqual(len(x_tetra), len(x_tetra_ref))
+        self.assertEqual(len(int_tetra.positions), len(x_tetra_ref))
         self.assertAlmostEqual(
-            np.linalg.norm(x_tetra_ref[:,None,:]-x_tetra[None,:,:], axis=-1).min(axis=0).sum(), 0
+            np.linalg.norm(
+                x_tetra_ref[:,None,:]-int_tetra.positions[None,:,:], axis=-1
+            ).min(axis=0).sum(), 0
         )
 
     def test_get_interstitials_fcc(self):
@@ -90,36 +94,38 @@ class TestAtoms(unittest.TestCase):
         a_0 = fcc.cell[0,0]
         x_tetra_ref = 0.25*a_0*np.ones(3)*np.array([[1],[-1]])+fcc.positions[:,None,:]
         x_tetra_ref = fcc.get_wrapped_coordinates(x_tetra_ref).reshape(-1, 3)
-        x_tetra = fcc.analyse.get_interstitials(num_neighbors=4)
-        self.assertEqual(len(x_tetra), len(x_tetra_ref))
+        int_tetra = fcc.analyse.get_interstitials(num_neighbors=4)
+        self.assertEqual(len(int_tetra.positions), len(x_tetra_ref))
         self.assertAlmostEqual(
-            np.linalg.norm(x_tetra_ref[:,None,:]-x_tetra[None,:,:], axis=-1).min(axis=0).sum(), 0
+            np.linalg.norm(
+                x_tetra_ref[:,None,:]-int_tetra.positions[None,:,:], axis=-1
+            ).min(axis=0).sum(), 0
         )
         x_octa_ref = 0.5*a_0*np.array([1, 0, 0])+fcc.positions
         x_octa_ref = fcc.get_wrapped_coordinates(x_octa_ref)
-        x_octa = fcc.analyse.get_interstitials(num_neighbors=6)
-        self.assertEqual(len(x_octa), len(x_octa_ref))
+        int_octa = fcc.analyse.get_interstitials(num_neighbors=6)
+        self.assertEqual(len(int_octa.positions), len(x_octa_ref))
         self.assertAlmostEqual(
-            np.linalg.norm(x_octa_ref[:,None,:]-x_octa[None,:,:], axis=-1).min(axis=0).sum(), 0
+            np.linalg.norm(x_octa_ref[:,None,:]-int_octa.positions[None,:,:], axis=-1).min(axis=0).sum(), 0
         )
         self.assertTrue(
-            np.allclose(fcc.analyse.interstitials.get_areas(), a_0**2*np.sqrt(3)),
+            np.allclose(int_octa.get_areas(), a_0**2*np.sqrt(3)),
             msg='Convex hull area comparison with analytical value failed'
         )
         self.assertTrue(
-            np.allclose(fcc.analyse.interstitials.get_volumes(), a_0**3/6),
+            np.allclose(int_octa.get_volumes(), a_0**3/6),
             msg='Convex hull volume comparison with analytical value failed'
         )
         self.assertTrue(
-            np.allclose(fcc.analyse.interstitials.get_distances(), a_0/2),
+            np.allclose(int_octa.get_distances(), a_0/2),
             msg='Distance comparison with analytical value failed'
         )
         self.assertTrue(
-            np.all(fcc.analyse.interstitials.get_steinhardt_parameters(4)>0),
+            np.all(int_octa.get_steinhardt_parameters(4)>0),
             msg='Illegal Steinhardt parameter'
         )
         self.assertAlmostEqual(
-            fcc.analyse.interstitials.get_variances().sum(), 0,
+            int_octa.get_variances().sum(), 0,
             msg='Distance variance in FCC must be 0'
         )
 

--- a/tests/atomistics/structure/test_analyse.py
+++ b/tests/atomistics/structure/test_analyse.py
@@ -102,9 +102,9 @@ class TestAtoms(unittest.TestCase):
         self.assertAlmostEqual(
             np.linalg.norm(x_octa_ref[:,None,:]-x_octa[None,:,:], axis=-1).min(axis=0).sum(), 0
         )
-        self.assertTrue(np.all(fcc.analyse.interstitials.get_area()>0))
-        self.assertTrue(np.all(fcc.analyse.interstitials.get_volume()>0))
-        self.assertTrue(np.all(fcc.analyse.interstitials.get_distance()>0))
+        self.assertTrue(np.allclose(fcc.analyse.interstitials.get_area(), a_0**2*np.sqrt(3)))
+        self.assertTrue(np.allclose(fcc.analyse.interstitials.get_volume(), a_0**3/6))
+        self.assertTrue(np.allclose(fcc.analyse.interstitials.get_distance(), a_0/2))
         self.assertTrue(np.all(fcc.analyse.interstitials.get_steinhardt_parameter(4)>0))
         self.assertAlmostEqual(fcc.analyse.interstitials.get_variance().sum(), 0)
 


### PR DESCRIPTION
        This function internally does the following steps:

            1. Initialize grid points (or Voronoi vertices) which are considered as
                interstitial site candidates.
            2. Eliminate points within a distance from the nearest neighboring atoms as
                given by `min_distance`
            3. Initialize neighbor environment using `get_neighbors`
            4. Shift interstitial candidates to the nearest symmetric points with respect to the
                neighboring atom sites/vertices.
            5. Kick out points with large neighbor distance variances
            6. Cluster interstitial candidates to avoir point overlapping.

        In complex structures (i.e. grain boundary, dislocation etc.), the default parameters
        should be chosen properly. In order to see other quantities, which potentially
        characterize interstitial sites, see the following functions from
        `structure.analyse.interstitials`:

            - `get_variance()`
            - `get_distance()`
            - `get_steinhardt_parameter()`
            - `get_volume()`
            - `get_area()`
