### PR TITLE
interactive_prepare

### DIFF
--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -292,12 +292,18 @@ class VaspInteractive(VaspBase, GenericInteractive):
             self.server.run_mode.interactive
             or self.server.run_mode.interactive_non_modal
         ):
-            self._check_incar_parameter(parameter="INTERACTIVE", value=True)
-            self._check_incar_parameter(parameter="IBRION", value=-1)
-            self._check_incar_parameter(parameter="POTIM", value=0.0)
-            self._check_incar_parameter(parameter="NSW", value=np.iinfo(np.int32).max - 1)
-            self._check_incar_parameter(parameter="ISYM", value=0)
+            self.interactive_prepare()
         super(VaspInteractive, self)._run_if_new(debug=debug)
+
+    def interactive_prepare(self):
+        """
+        Modifies/adds tags in the INCAR file that make it possible to run the VASP interactively
+        """
+        self._check_incar_parameter(parameter="INTERACTIVE", value=True)
+        self._check_incar_parameter(parameter="IBRION", value=-1)
+        self._check_incar_parameter(parameter="POTIM", value=0.0)
+        self._check_incar_parameter(parameter="NSW", value=np.iinfo(np.int32).max - 1)
+        self._check_incar_parameter(parameter="ISYM", value=0)
 
     def convergence_check(self):
         """

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -297,7 +297,7 @@ class VaspInteractive(VaspBase, GenericInteractive):
 
     def interactive_prepare(self):
         """
-        Modifies/adds tags in the INCAR file that make it possible to run the VASP interactively
+        Modifies/adds tags in the INCAR file that make it possible to run VASP interactively
         """
         self._check_incar_parameter(parameter="INTERACTIVE", value=True)
         self._check_incar_parameter(parameter="IBRION", value=-1)


### PR DESCRIPTION
The modification/addition of tags to the INCAR file in `VaspInteractive` when `run_mode.interactive = True` is only done when the `run` method is called. This creates an issue when I define a `VaspInteractive` reference job, and then make a copy of it WITHOUT running the reference job -- the copy gets the original, unmodified INCAR file. This PR is a workaround. The user calls a new method, `interactive_prepare()` (could change the name to `interactive_initialize()`), should the user need to copy the reference job without having to run it, so the copy gets the correct INCAR file.