### PR TITLE
Raise error on non-zero pressure

### DIFF
--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -963,8 +963,10 @@ class VaspBase(GenericDFTJob):
         else:
             if pressure == 0.0:
                 self.input.incar["ISIF"] = 3
-            else:
+            elif pressure is None:
                 self.input.incar["ISIF"] = 2
+            else:
+                raise ValueError("Non-zero pressure not supported!")
 
         if max_iter:
             electronic_steps = max_iter


### PR DESCRIPTION
If I read the vasp reference correctly more has to be done to set an external pressure, but the current code silently reverts back to fixed volume for `pressure != 0`, so I raise an error for now.