### PR TITLE
Save all VCSGC parameters in generic input

### DIFF
--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -786,7 +786,18 @@ class LammpsBase(AtomisticGenericJob):
                 mu[el] = 0.
 
         self._generic_input["calc_mode"] = "vcsgc"
+        self._generic_input["mu"] = mu
+        if target_concentration is not None:
+            self._generic_input["target_concentration"] = target_concentration
+            self._generic_input["kappa"] = kappa
+        self._generic_input["mc_step_interval"] = mc_step_interval
+        self._generic_input["swap_fraction"] = swap_fraction
         self._generic_input["temperature"] = temperature
+        self._generic_input["temperature_mc"] = temperature_mc
+        if window_size is not None:
+            self._generic_input["window_size"] = window_size
+        if window_moves is not None:
+            self._generic_input["window_moves"] = window_moves
         self._generic_input["n_ionic_steps"] = n_ionic_steps
         self._generic_input["n_print"] = n_print
         self._generic_input.remove_keys(["max_iter"])

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -506,7 +506,7 @@ class TestLammps(unittest.TestCase):
         self.job_vcsgc_input.calc_vcsgc(**args)
         self.assertEqual(self.job_vcsgc_input.input.control['fix___vcsgc'], input_string)
 
-        args['temperature_mc'] = 100.,
+        args['temperature_mc'] = 100.
         input_string = 'all sgcmc {0} {1} {2} {3} randseed {4}'.format(
             args['mc_step_interval'],
             args['swap_fraction'],

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -538,6 +538,17 @@ class TestLammps(unittest.TestCase):
         self.job_vcsgc_input.calc_vcsgc(**args)
         self.assertEqual(self.job_vcsgc_input.input.control['fix___vcsgc'], input_string)
 
+        self.job_vcsgc_input.to_hdf()
+        for k, v in args.items():
+            if k not in ("mu", "target_concentration", "mc_step_interval", "swap_fraction", "temperature_mc"):
+                continue
+            self.assertEqual(self.job_vcsgc_input._generic_input[k], v,
+                             f"Wrong value stored in generic input for parameter {k}!")
+            # decode saved GenericParameters manually...
+            data = self.job_vcsgc_input["input/generic/data_dict"]
+            self.assertEqual(data["Value"][data["Parameter"].index(k)], str(v),
+                             f"Wrong value stored in HDF for parameter {k}!")
+
     def test_calc_minimize_input(self):
         # Ensure that defaults match control defaults
         atoms = Atoms("Fe8", positions=np.zeros((8, 3)), cell=np.eye(3))
@@ -693,7 +704,6 @@ class TestLammps(unittest.TestCase):
 
         potential['Species'][0][0] = 'Al'
         self.job.potential = potential # shouldn't raise ValueError
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Several parameters to `calc_vcsgc` were not saved before, so… I just do that now.  This is helpful when doing pyiron tables on SGC jobs and you need to know e.g. the chemical potential.

Will convert from draft as soon as I tested it on the cluster.