### PR TITLE
Only force skew when tensions are applied

### DIFF
--- a/pyiron_atomistics/lammps/control.py
+++ b/pyiron_atomistics/lammps/control.py
@@ -449,8 +449,8 @@ class LammpsControl(GenericParameters):
                         pressure_string += " {0} {1} {1} {2}".format(
                             coord, value, pressure_damping_timescale
                         )
-                    if ii > 2:
-                        self._force_skewed = True
+                        if ii > 2:
+                            self._force_skewed = True
 
             if langevin:  # NPT(Langevin)
                 fix_ensemble_str = "all nph" + pressure_string


### PR DESCRIPTION
`calc_md` forced triclinic boxes if non-isotropic pressures were set, like `(None, 0, None)`. This is not necessary (and inconsistent with `calc_minimize`), so I fixed it.  I suppose the `if` just slipped indentations.