### PR TITLE
Properly implement HasStructure for StructureContainer

### DIFF
--- a/pyiron_atomistics/atomistics/job/structurecontainer.py
+++ b/pyiron_atomistics/atomistics/job/structurecontainer.py
@@ -126,6 +126,12 @@ class StructureContainer(AtomisticGenericJob):
     def collect_output(self):
         pass
 
+    def _number_of_structures(self):
+        return len(self._structure_lst)
+
+    def _get_structure(self, frame=-1, wrap_atoms=True):
+        return self._structure_lst[frame]
+
     def to_hdf(self, hdf = None, group_name = None):
         # skip any of the AtomisticGenericJob specific serialization, since we
         # handle the structures on our own and that method might just confuse


### PR DESCRIPTION
The inherited version from `AtomisticsGenericJob` simply doesn't work.  Most likely I'll remove the inheritance from it in an upcoming PR, since it does not behave like the usual "calculation" atomistic jobs at all anyway.