### PR TITLE
Update base.py

### DIFF
--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -983,7 +983,7 @@ class LammpsBase(AtomisticGenericJob):
                 pd.read_csv(
                     StringIO("\n".join(dump[llst:llen]).replace("ITEM: ATOMS ", "")),
                     delim_whitespace=True,
-                ).sort_values(by='id')
+                ).sort_values(by="id", ignore_index=True)
                 for llst, llen in zip(l_start, l_end)
             ]
 

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -983,7 +983,7 @@ class LammpsBase(AtomisticGenericJob):
                 pd.read_csv(
                     StringIO("\n".join(dump[llst:llen]).replace("ITEM: ATOMS ", "")),
                     delim_whitespace=True,
-                )
+                ).sort_values(by='id')
                 for llst, llen in zip(l_start, l_end)
             ]
 


### PR DESCRIPTION
Lammps may not keep the original order of the atom IDs (see e.g. https://matsci.org/t/atom-id-is-changing/31701). I experienced this when running reverse scaling where multple runs are appended. The following patch orders the atom IDs and thus guarantees that the order remains unchanged.