### PR TITLE
VASP doesn't save stresses to HDF when run on ISIF=2 (default)

### DIFF
--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -1946,6 +1946,7 @@ class Output:
                 vasprun_working = True
         if outcar_working:
             log_dict["temperature"] = self.outcar.parse_dict["temperatures"]
+            log_dict["stresses"] = self.outcar.parse_dict["stresses"]
             log_dict["pressures"] = self.outcar.parse_dict["pressures"]
             log_dict["elastic_constants"] = self.outcar.parse_dict["elastic_constants"]
             self.generic_output.dft_log_dict["n_elect"] = self.outcar.parse_dict[

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -2017,6 +2017,7 @@ class Output:
                 raise VaspCollectError("Error in parsing OUTCAR")
             log_dict["energy_tot"] = self.outcar.parse_dict["energies"]
             log_dict["temperature"] = self.outcar.parse_dict["temperatures"]
+            log_dict["stresses"] = self.outcar.parse_dict["stresses"]
             log_dict["pressures"] = self.outcar.parse_dict["pressures"]
             log_dict["forces"] = self.outcar.parse_dict["forces"]
             log_dict["positions"] = self.outcar.parse_dict["positions"]

--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -91,7 +91,7 @@ class Outcar(object):
         self.parse_dict["fermi_level"] = fermi_level
         self.parse_dict["scf_dipole_moments"] = scf_moments
         self.parse_dict["kin_energy_error"] = kin_energy_error
-        self.parse_dict["stresses"] = stresses
+        self.parse_dict["stresses"] = stresses * KBAR_TO_EVA
         self.parse_dict["irreducible_kpoints"] = irreducible_kpoints
         self.parse_dict["magnetization"] = magnetization
         self.parse_dict["final_magmoms"] = final_magmom_lst


### PR DESCRIPTION
I'm running some VASP calculations and would like to have the full stress tensor after the (static) calculation.  I've checked that my `OUTCAR` does contain the information.  (Let me know if you need an example, github doesn't let me upload tar archives).

I've traced the code and it seems we do parse the stresses, but then only save the averaged pressure.  I've modified that code in this PR to save also the stress to the `log_dict`, which I thought should be enough to get it into HDF5, but from my quick testing that doesn't seem to be the case.

Any ideas where to put this so it works?