### PR TITLE
replace strain by master job name

### DIFF
--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -311,9 +311,8 @@ class MurnaghanJobGenerator(JobGenerator):
             parameter_lst.append([np.round(strain, 7), basis])
         return parameter_lst
 
-    @staticmethod
-    def job_name(parameter):
-        return "strain_" + str(parameter[0]).replace(".", "_")
+    def job_name(self, parameter):
+        return "{}_{}".format(self._master.job_name, parameter[0]).replace(".", "_")
 
     def modify_job(self, job, parameter):
         job.structure = parameter[1]
@@ -605,7 +604,7 @@ class Murnaghan(AtomisticParallelMaster):
     The minimum energy volume and bulk modulus are stored in `ref_job['output/equilibrium_volume']`
     and `ref_job['output/equilibrium_bulk_modulus/']`.
     """
-    def __init__(self, project, job_name="murnaghan"):
+    def __init__(self, project, job_name):
         """
 
         Args:


### PR DESCRIPTION
As all child jobs start with `strain_` it wasn't possible to see the content via `pr.load` whenever there were more than 1 Murnaghan job. Now it appends the name of the master job instead.

And I also removed the default job name because it makes little sense.