### PR TITLE
Add automatic labeling for integration tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+integration:
+- notebooks/integration/*

--- a/.github/workflows/label_integration.yml
+++ b/.github/workflows/label_integration.yml
@@ -1,0 +1,23 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: Automatic Labeler
+on: 
+  pull_request:
+      branches: [ master ]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/notebooks/integration/interactive_units.ipynb
+++ b/notebooks/integration/interactive_units.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebooks compares the outputs from two static LAMMPS jobs one of which is an interactive job. This is to ensure that the outputs from interactive and non-interactive jobs are consistent."
+    "This notebooks compares outputs from two static LAMMPS jobs one of which is an interactive job. This is to ensure that the outputs from interactive and non-interactive jobs are consistent."
    ]
   },
   {


### PR DESCRIPTION
This should add the label 'integration' to all PRs that modify
integration notebooks.

Imo this makes #352 unnecessary.

(Was fighting with github for a bit in there, hope no one got spammed too much.) 