### PR TITLE
increase default number of empty states

### DIFF
--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1211,9 +1211,9 @@ class SphinxBase(GenericDFTJob):
         if self.input["EmptyStates"] == "auto":
             if self._spin_enabled:
                 self.input["EmptyStates"] = int(
-                    1.5 * len(self.structure) + 3)
+                    1.5 * len(self.structure) + 10)
             else:
-                self.input["EmptyStates"] = int(len(self.structure) + 3)
+                self.input["EmptyStates"] = int(len(self.structure) + 10)
 
         if not self.input.sphinx.basis.read_only:
             self.load_basis_group()


### PR DESCRIPTION
I realized that in many of my Fe calculations the number of empty states was not sufficient. Since having too many is far less problematic than too few, I increased them by 7.