### PR TITLE
remove_h5io_dependency

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -9,7 +9,6 @@ dependencies:
 - defusedxml =0.7.1
 - future =0.18.2
 - h5py =3.3.0
-- h5io = 0.1.2
 - matplotlib-base =3.4.3
 - mendeleev =0.9.0
 - numpy =1.21.4


### PR DESCRIPTION
I restricted the h5io dependency to the last known working version as a hot fix for our unittests. Until we fixed our issues this removes the dependency, again.