### PR TITLE
Make Methfessel Paxton default in SPHInX

### DIFF
--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -984,11 +984,11 @@ class SphinxBase(GenericDFTJob):
             if not isinstance(smearing, str):
                 raise ValueError("Smearing must be a string")
             if smearing.lower().startswith('meth'):
-                self.input.MethfesselPaxton = order 
+                self.input.MethfesselPaxton = order
                 if 'FermiDirac' in self.input.list_nodes():
                     del self.input['FermiDirac']
             elif smearing.lower().startswith('fermi'):
-                self.input.FermiDirac = order 
+                self.input.FermiDirac = order
                 if 'MethfesselPaxton' in self.input.list_nodes():
                     del self.input['MethfesselPaxton']
         if width is not None and width < 0:

--- a/tests/sphinx/test_base.py
+++ b/tests/sphinx/test_base.py
@@ -168,6 +168,7 @@ class TestSphinx(unittest.TestCase):
             'PAWHamiltonian {\n',
             '\tnEmptyStates = 6;\n',
             '\tekt = 0.2;\n',
+            '\tMethfesselPaxton = 1;\n',
             '\txc = PBE;\n',
             '\tspinPolarized;\n',
             '}\n',
@@ -386,6 +387,9 @@ class TestSphinx(unittest.TestCase):
             ValueError, self.sphinx_band_structure.set_occupancy_smearing, "fermi", -0.1
         )
         self.sphinx_band_structure.set_occupancy_smearing("fermi", 0.1)
+        self.assertTrue('FermiDirac' in self.sphinx_band_structure.input)
+        self.sphinx_band_structure.set_occupancy_smearing("methfessel", 0.1)
+        self.assertTrue('MethfesselPaxton' in self.sphinx_band_structure.input)
 
     def test_load_default_groups(self):
         backup  = self.sphinx_band_structure.structure.copy()


### PR DESCRIPTION
Since Methfessel-Paxton is now available in SPHInX I made it the default behaviour in pyiron.