### PR TITLE
Cluster (atom) positions

### DIFF
--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -680,6 +680,8 @@ class Analyse:
         labels = DBSCAN(eps=eps, min_samples=1).fit_predict(extended_positions)
         coo = coo_matrix((labels, (np.arange(len(labels)), indices)))
         labels = coo.max(axis=0).toarray().flatten()
+        # make labels look nicer
+        labels = np.unique(labels, return_inverse=True)[1]
         mean_positions = get_mean_positions(
             positions, self._structure.cell, self._structure.pbc, labels
         )

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -8,7 +8,7 @@ from sklearn.cluster import AgglomerativeClustering, DBSCAN
 from scipy.sparse import coo_matrix
 from scipy.spatial import Voronoi
 from pyiron_atomistics.atomistics.structure.pyscal import get_steinhardt_parameter_structure, analyse_cna_adaptive, \
-    analyse_centro_symmetry, analyse_diamond_structure, analyse_voronoi_volume, pyiron_to_pyscal_system, analyse_find_solids
+    analyse_centro_symmetry, analyse_diamond_structure, analyse_voronoi_volume, analyse_find_solids
 from pyiron_atomistics.atomistics.structure.strain import Strain
 from pyiron_base.generic.util import Deprecator
 from scipy.spatial import ConvexHull
@@ -47,13 +47,13 @@ def get_mean_positions(positions, cell, pbc, labels):
     # Get reference point for each unique label
     mean_positions = positions[np.unique(labels, return_index=True)[1]]
     # Get displacement vectors from reference points to all other points for the same labels
-    all_positions = positions-mean_positions[labels]
+    all_positions = positions - mean_positions[labels]
     # Account for pbc
     all_positions = np.einsum('ji,nj->ni', np.linalg.inv(cell), all_positions)
-    all_positions[:,pbc] -= np.rint(all_positions)[:,pbc]
+    all_positions[:, pbc] -= np.rint(all_positions)[:, pbc]
     all_positions = np.einsum('ji,nj->ni', cell, all_positions)
     # Add average displacement vector of each label to the reference point
-    np.add.at(mean_positions, labels, (all_positions.T/counts[labels]).T)
+    np.add.at(mean_positions, labels, (all_positions.T / counts[labels]).T)
     return mean_positions
 
 
@@ -73,10 +73,11 @@ def get_average_of_unique_labels(labels, values):
     labels = np.unique(labels, return_inverse=True)[1]
     unique_labels = np.unique(labels)
     mat = coo_matrix((np.ones_like(labels), (labels, np.arange(len(labels)))))
-    mean_values = np.asarray(mat.dot(np.asarray(values).reshape(len(labels), -1))/mat.sum(axis=1))
+    mean_values = np.asarray(mat.dot(np.asarray(values).reshape(len(labels), -1)) / mat.sum(axis=1))
     if np.prod(mean_values.shape).astype(int) == len(unique_labels):
         return mean_values.flatten()
     return mean_values
+
 
 class Interstitials:
     """
@@ -107,7 +108,8 @@ class Interstitials:
         - `get_volumes()`
         - `get_areas()`
     """
-    def __init__(self,
+    def __init__(
+        self,
         structure,
         num_neighbors,
         n_gridpoints_per_angstrom=5,
@@ -253,7 +255,7 @@ class Interstitials:
 
     def _create_gridpoints(self, n_gridpoints_per_angstrom=5):
         cell = self.structure.get_vertical_length()
-        n_points = (n_gridpoints_per_angstrom*cell).astype(int)
+        n_points = (n_gridpoints_per_angstrom * cell).astype(int)
         positions = np.meshgrid(*[np.linspace(0, 1, n_points[i], endpoint=False) for i in range(3)])
         positions = np.stack(positions, axis=-1).reshape(-1, 3)
         return np.einsum('ji,nj->ni', self.structure.cell, positions)
@@ -263,13 +265,13 @@ class Interstitials:
         self.positions = self.positions[neigh.distances.flatten() > min_distance]
 
     def _set_interstitials_to_high_symmetry_points(self):
-        self.positions = self.positions+np.mean(self.neigh.vecs, axis=-2)
+        self.positions = self.positions + np.mean(self.neigh.vecs, axis=-2)
         self.positions = self.structure.get_wrapped_coordinates(self.positions)
 
     def _kick_out_points(self, variance_buffer=0.01):
         variance = self.get_variances()
         min_var = variance.min()
-        self.positions = self.positions[variance < min_var+variance_buffer]
+        self.positions = self.positions[variance < min_var + variance_buffer]
 
     def _cluster_points(self, eps=0.1):
         if eps == 0:
@@ -331,6 +333,7 @@ class Interstitials:
             (numpy.array (n,)): Convex hull area of each site.
         """
         return np.array([h.area for h in self.hull])
+
 
 class Analyse:
     """ Class to analyse atom structure.  """
@@ -407,7 +410,7 @@ class Analyse:
         """
         if distance_threshold <= 0:
             raise ValueError('distance_threshold must be a positive float')
-        if id_list is not None and len(id_list)==0:
+        if id_list is not None and len(id_list) == 0:
             raise ValueError('id_list must contain at least one id')
         if wrap_atoms and planes is None:
             positions, indices = self._structure.get_extended_positions(
@@ -426,7 +429,7 @@ class Analyse:
                 positions = self._structure.get_wrapped_coordinates(positions)
         if planes is not None:
             mat = np.asarray(planes).reshape(-1, 3)
-            positions = np.einsum('ij,i,nj->ni', mat, 1/np.linalg.norm(mat, axis=-1), positions)
+            positions = np.einsum('ij,i,nj->ni', mat, 1 / np.linalg.norm(mat, axis=-1), positions)
         if cluster_method is None:
             cluster_method = AgglomerativeClustering(
                 linkage='complete',
@@ -444,7 +447,7 @@ class Analyse:
                 scaled_positions = np.einsum(
                     'ji,nj->ni', np.linalg.inv(self._structure.cell), mean_positions
                 )
-                unique_inside_box = np.all(np.absolute(scaled_positions-0.5+1.0e-8) < 0.5, axis=-1)
+                unique_inside_box = np.all(np.absolute(scaled_positions - 0.5 + 1.0e-8) < 0.5, axis=-1)
                 arr_inside_box = np.any(
                     labels[:, None] == np.unique(labels)[unique_inside_box][None, :], axis=-1
                 )
@@ -532,12 +535,13 @@ class Analyse:
         """    Calculate the Voronoi volume of atoms        """
         return analyse_voronoi_volume(atoms=self._structure)
 
-    def pyscal_find_solids(self, neighbor_method="cutoff",
+    def pyscal_find_solids(
+        self, neighbor_method="cutoff",
         cutoff=0, bonds=0.5,
         threshold=0.5, avgthreshold=0.6,
         cluster=False, q=6, right=True,
         return_sys=False,
-        ):
+    ):
         """
         Get the number of solids or the corresponding pyscal system.
         Calls necessary pyscal methods as described in https://pyscal.org/en/latest/methods/03_solidliquid.html.
@@ -557,7 +561,8 @@ class Analyse:
             int: number of solids,
             pyscal system: pyscal system when return_sys=True
         """
-        return analyse_find_solids(atoms=self._structure,
+        return analyse_find_solids(
+            atoms=self._structure,
             neighbor_method=neighbor_method,
             cutoff=cutoff, bonds=bonds,
             threshold=threshold,
@@ -591,7 +596,7 @@ class Analyse:
         >>> print(neigh.distances.min(axis=-1))
 
         """
-        voro = Voronoi(self._structure.get_extended_positions(width_buffer)+epsilon)
+        voro = Voronoi(self._structure.get_extended_positions(width_buffer) + epsilon)
         xx = voro.vertices
         if distance_threshold > 0:
             cluster = AgglomerativeClustering(
@@ -601,8 +606,8 @@ class Analyse:
             )
             cluster.fit(xx)
             xx = get_average_of_unique_labels(cluster.labels_, xx)
-        xx = xx[np.linalg.norm(xx-self._structure.get_wrapped_coordinates(xx, epsilon=0), axis=-1) < epsilon]
-        return xx-epsilon
+        xx = xx[np.linalg.norm(xx - self._structure.get_wrapped_coordinates(xx, epsilon=0), axis=-1) < epsilon]
+        return xx - epsilon
 
     def get_strain(self, ref_structure, num_neighbors=None, only_bulk_type=False):
         """
@@ -647,3 +652,18 @@ class Analyse:
             only_bulk_type=only_bulk_type
         ).strain
 
+    def cluster_positions(self, positions=None, eps=0.1, return_labels=False):
+        if positions is None:
+            positions = self._structure.positions
+        extended_positions, indices = self._structure.get_extended_positions(
+            eps, return_indices=True, positions=positions
+        )
+        labels = DBSCAN(eps=eps, min_samples=1).fit_predict(extended_positions)
+        coo = coo_matrix((labels, (np.arange(len(labels)), indices)))
+        labels = coo.max(axis=0).toarray().flatten()
+        mean_positions = get_mean_positions(
+            self._structure.positions, self._structure.cell, self._structure.pbc, labels
+        )
+        if return_labels:
+            return mean_positions, labels
+        return mean_positions

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -662,7 +662,7 @@ class Analyse:
         coo = coo_matrix((labels, (np.arange(len(labels)), indices)))
         labels = coo.max(axis=0).toarray().flatten()
         mean_positions = get_mean_positions(
-            self._structure.positions, self._structure.cell, self._structure.pbc, labels
+            positions, self._structure.cell, self._structure.pbc, labels
         )
         if return_labels:
             return mean_positions, labels

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -654,7 +654,29 @@ class Analyse:
 
     def cluster_positions(self, positions=None, eps=1, buffer_width=None, return_labels=False):
         """
-        Cluster positions according to the distances.
+        Cluster positions according to the distances. Clustering algorithm uses DBSCAN:
+
+        https://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html
+
+        Example I:
+
+        ```
+        analyse = Analyze(some_pyiron_structure)
+        positions = analyse.cluster_points(eps=2)
+        ```
+
+        This example should return the atom positions, if no two atoms lie within a distance of 2.
+        If there are at least two atoms which lie within a distance of 2, their entries will be
+        replaced by their mean position.
+
+        Example II:
+
+        ```
+        analyse = Analyze(some_pyiron_structure)
+        print(analyse.cluster_positions([3*[0.], 3*[1.]], eps=3))
+        ```
+
+        This returns `[0.5, 0.5, 0.5]` (if the cell is large enough)
 
         Args:
             positions (numpy.ndarray): Positions to consider. Default: atom positions
@@ -672,6 +694,7 @@ class Analyse:
         """
         if positions is None:
             positions = self._structure.positions
+        positions = np.array(positions)
         if buffer_width is None:
             buffer_width = eps
         extended_positions, indices = self._structure.get_extended_positions(

--- a/pyiron_atomistics/atomistics/structure/analyse.py
+++ b/pyiron_atomistics/atomistics/structure/analyse.py
@@ -652,11 +652,30 @@ class Analyse:
             only_bulk_type=only_bulk_type
         ).strain
 
-    def cluster_positions(self, positions=None, eps=0.1, return_labels=False):
+    def cluster_positions(self, positions=None, eps=1, buffer_width=None, return_labels=False):
+        """
+        Cluster positions according to the distances.
+
+        Args:
+            positions (numpy.ndarray): Positions to consider. Default: atom positions
+            eps (float): The maximum distance between two samples for one to be considered as in
+                the neighborhood of the other.
+            buffer_width (float): Buffer width to consider across the periodic boundary
+                conditions. If too small, it is possible that atoms that are meant to belong
+                together across PBC are missed. Default: Same as eps
+            return_labels (bool): Whether to return the labels given according to the grouping
+                together with the mean positions
+
+        Returns:
+            positions (numpy.ndarray): Mean positions
+            label (numpy.ndarray): Labels of the positions (returned when `return_labels = True`)
+        """
         if positions is None:
             positions = self._structure.positions
+        if buffer_width is None:
+            buffer_width = eps
         extended_positions, indices = self._structure.get_extended_positions(
-            eps, return_indices=True, positions=positions
+            buffer_width, return_indices=True, positions=positions
         )
         labels = DBSCAN(eps=eps, min_samples=1).fit_predict(extended_positions)
         coo = coo_matrix((labels, (np.arange(len(labels)), indices)))

--- a/tests/atomistics/structure/test_analyse.py
+++ b/tests/atomistics/structure/test_analyse.py
@@ -174,6 +174,12 @@ class TestAtoms(unittest.TestCase):
         self.assertLess(np.absolute(eps_yz-strain[:, 1, 2]).max(), 0.01)
         self.assertLess(np.absolute(eps_xz-strain[:, 0, 2]).max(), 0.01)
 
+    def test_cluster_positions(self): 
+        bulk = StructureFactory().ase.bulk('Fe', cubic=True)
+        self.assertEqual(len(bulk.analyse.cluster_positions()), len(bulk))
+        positions = np.append(bulk.positions, bulk.positions, axis=0)
+        self.assertEqual(len(bulk.analyse.cluster_positions(positions)), len(bulk))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/atomistics/structure/test_analyse.py
+++ b/tests/atomistics/structure/test_analyse.py
@@ -174,7 +174,7 @@ class TestAtoms(unittest.TestCase):
         self.assertLess(np.absolute(eps_yz-strain[:, 1, 2]).max(), 0.01)
         self.assertLess(np.absolute(eps_xz-strain[:, 0, 2]).max(), 0.01)
 
-    def test_cluster_positions(self): 
+    def test_cluster_positions(self):
         bulk = StructureFactory().ase.bulk('Fe', cubic=True)
         self.assertEqual(len(bulk.analyse.cluster_positions()), len(bulk))
         positions = np.append(bulk.positions, bulk.positions, axis=0)

--- a/tests/atomistics/structure/test_analyse.py
+++ b/tests/atomistics/structure/test_analyse.py
@@ -179,6 +179,10 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(len(bulk.analyse.cluster_positions()), len(bulk))
         positions = np.append(bulk.positions, bulk.positions, axis=0)
         self.assertEqual(len(bulk.analyse.cluster_positions(positions)), len(bulk))
+        self.assertEqual(
+            bulk.analyse.cluster_positions(np.zeros((2, 3)), return_labels=True)[1].tolist(),
+            [0, 0]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cluster points which lie close to each other, also considering PBC.

Super simple example:

```python
positions = atoms.analyse.cluster_points(eps=2)
```

This example should return the atom positions, if no two atoms lie within a distance of 2. If there are at least two atoms which lie within a distance of 2, their entries will be replaced by their mean position.