### PR TITLE
replace full output info in __str__ by chemical formula

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2031,9 +2031,6 @@ class Atoms(ASEAtoms):
     #     return len(self.indices)
 
     def __repr__(self):
-        return self.__str__()
-
-    def __str__(self):
         if len(self) == 0:
             return "[]"
         out_str = ""
@@ -2051,6 +2048,9 @@ class Atoms(ASEAtoms):
             out_str += "cell: \n"
             out_str += str(self.cell) + "\n"
         return out_str
+
+    def __str__(self):
+        return self.get_chemical_formula()
 
     def __setitem__(self, key, value):
         if isinstance(key, (int, np.integer)):

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -1558,6 +1558,14 @@ class TestAtoms(unittest.TestCase):
         structure = ase_to_pyiron(molecule('H2COH'))
         structure.set_dihedral(4, 0, 1, 2, angle=90)
 
+    def test_str_repr(self):
+        H2 = Atoms(positions=[3*[0], 3*[0.5]], cell=np.eye(3), elements=2*['H'], pbc=True)
+        self.assertEqual(
+            repr(H2),
+            'H: [0. 0. 0.]\nH: [0.5 0.5 0.5]\npbc: [ True  True  True]\ncell: \nCell([1.0, 1.0, 1.0])\n'
+        )
+        self.assertEqual(str(H2), 'H2')
+
     def test_cached_speed(self):
         """
         Creating atoms should be faster after the first time, due to caches in periodictable/mendeleev.


### PR DESCRIPTION
In order to exploit the feature [here](https://github.com/pyiron/pyiron_base/pull/561/files), I would like to suggest to largely simplify `__str__` in `Atoms` by replace the full info by the chemical formula. this allows us to set something like:

```python
job = pr.create.job.Lammps(('lammps', structure))
```