### PR TITLE
Store shells in Neighbors Trajectory

### DIFF
--- a/pyiron_atomistics/atomistics/structure/neighbors.py
+++ b/pyiron_atomistics/atomistics/structure/neighbors.py
@@ -1087,7 +1087,7 @@ class NeighborsTrajectory(DataContainer):
         For trajectories with non constant amount of particles this array may contain -1 for invalid values, i.e. 
 
         Returns:
-            numpy.ndarray: An int array of dimension N_steps / stride x N_atoms x N_neighbors x 3
+            ndarray: An int array of dimension N_steps / stride x N_atoms x N_neighbors x 3
         """
         return self._flat_store.get_array_filled("shells")
 

--- a/pyiron_atomistics/atomistics/structure/neighbors.py
+++ b/pyiron_atomistics/atomistics/structure/neighbors.py
@@ -1036,6 +1036,7 @@ class NeighborsTrajectory(DataContainer):
         self._flat_store.add_array("indices", dtype=np.int64, shape=(num_neighbors,), per="element")
         self._flat_store.add_array("distances", dtype=np.float64, shape=(num_neighbors,), per="element")
         self._flat_store.add_array("vecs", dtype=np.float64, shape=(num_neighbors, 3), per="element")
+        self._flat_store.add_array("shells", dtype=np.int64, shape=(num_neighbors,), per="element")
         self._neighbor_indices = None
         self._neighbor_distances = None
         self._neighbor_vectors = None
@@ -1079,6 +1080,18 @@ class NeighborsTrajectory(DataContainer):
         return self._flat_store.get_array_filled("vecs")
 
     @property
+    def shells(self):
+        """
+        Neighbor shell indices (excluding itself) of each atom computed using the get_neighbors_traj() method.
+
+        For trajectories with non constant amount of particles this array may contain -1 for invalid values, i.e. 
+
+        Returns:
+            numpy.ndarray: An int array of dimension N_steps / stride x N_atoms x N_neighbors x 3
+        """
+        return self._flat_store.get_array_filled("shells")
+
+    @property
     def num_neighbors(self):
         """
         The maximum number of neighbors to be computed
@@ -1102,9 +1115,11 @@ def _get_neighbors(store, has_structure, num_neighbors=20, **kwargs):
         # Change the `allow_ragged` based on the changes in get_neighbors()
         neigh = struct.get_neighbors(num_neighbors=num_neighbors, allow_ragged=False, **kwargs)
         if i >= len(store):
-            store.add_chunk(len(struct), indices=neigh.indices, distances=neigh.distances, vecs=neigh.vecs)
+            store.add_chunk(len(struct),
+                            indices=neigh.indices, distances=neigh.distances, vecs=neigh.vecs, shells=neigh.shells)
         else:
             store.set_array("indices", i, neigh.indices)
             store.set_array("distances", i, neigh.distances)
             store.set_array("vecs", i, neigh.vecs)
+            store.set_array("shells", i, neigh.shells)
     return store.get_array_filled('indices'), store.get_array_filled('distances'), store.get_array_filled('vecs')


### PR DESCRIPTION
I've benchmarked this and it's only marginally slower to also compute the shells additionally (maybe ~5%), so I'm always adding this because I want it for my calculations.  If anyone thinks it's too much, I will make it configurable whether shells are included or not.