### PR TITLE
Write POSCAR in direct coordinate when selective dynamics is on

### DIFF
--- a/pyiron_atomistics/vasp/structure.py
+++ b/pyiron_atomistics/vasp/structure.py
@@ -106,6 +106,7 @@ def write_poscar(structure, filename="POSCAR", write_species=True, cartesian=Tru
         f.write(endline)
         if "selective_dynamics" in structure.get_tags():
             selec_dyn = True
+	    cartesian = False
             f.write("Selective dynamics" + endline)
         sorted_coords = list()
         selec_dyn_lst = list()

--- a/pyiron_atomistics/vasp/structure.py
+++ b/pyiron_atomistics/vasp/structure.py
@@ -106,7 +106,7 @@ def write_poscar(structure, filename="POSCAR", write_species=True, cartesian=Tru
         f.write(endline)
         if "selective_dynamics" in structure.get_tags():
             selec_dyn = True
-	    cartesian = False
+            cartesian = False
             f.write("Selective dynamics" + endline)
         sorted_coords = list()
         selec_dyn_lst = list()


### PR DESCRIPTION
When I run a vasp job with POSCAR written in cartesian coordinates vasp returns the following warning message:

"using selective dynamics as specified on POSCAR
WARNING: If single coordinates had been selected the selection of coordinates
is made according to the corresponding d i r e c t coordinates!
Don't support selection of single cartesian coordinates -- sorry ..."

Hence, I would like to write POSCAR in direct coordinates when selective dynamics is on.