### PR TITLE
Remove unused properties in NeighborsTrajectory

### DIFF
--- a/pyiron_atomistics/atomistics/structure/neighbors.py
+++ b/pyiron_atomistics/atomistics/structure/neighbors.py
@@ -1036,9 +1036,6 @@ class NeighborsTrajectory(DataContainer):
         self._flat_store.add_array("distances", dtype=np.float64, shape=(num_neighbors,), per="element")
         self._flat_store.add_array("vecs", dtype=np.float64, shape=(num_neighbors, 3), per="element")
         self._flat_store.add_array("shells", dtype=np.int64, shape=(num_neighbors,), per="element")
-        self._neighbor_indices = None
-        self._neighbor_distances = None
-        self._neighbor_vectors = None
         self._num_neighbors = num_neighbors
         self._get_neighbors_kwargs = kwargs
         self.has_structure = has_structure


### PR DESCRIPTION
Just cosmetic, I simply forgot to delete the old variables.