### PR TITLE
Add callback function for LAMMPS

### DIFF
--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -243,7 +243,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         self._reset_interactive_run_command()
         self.interactive_structure_setter(self.structure)
 
-    def set_callback(self, function, n_call=1, n_apply=1):
+    def set_callback(self, function, n_call=1, n_apply=1, overload_internal_callback=False):
         """
         **********************
         *** Expert feature ***
@@ -255,6 +255,10 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             function (function): User-defined function that returns forces (see below)
             n_call (int): Make callback every `n_call` steps
             n_apply (int): Apply callback forces every `n_apply` steps
+            overload_internal_callback (bool): Whether to overload internal callback (see below).
+                Overloading the internal callback function will have the advantage that the code
+                will not need to do expensive copying, BUT it is extremely error-prone. Make
+                sure that the code works without overloading the internal callback function first.
 
         `function` must have the following form:
 
@@ -267,6 +271,27 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         current timestep and `nlocal` is the number of atoms on the current processor. `forces`
         must be of the shape `(n_atoms, 3)`. The total translational force will be eliminated
         inside pyiron.
+
+        If `overload_internal_callback` is set to `True`, then `function` must have the following
+        form:
+
+        ```
+        def function(ptr, timestep, nlocal, ids, x, fexternal):
+            your_evaluation
+        ```
+
+        with the following arguemnts:
+
+        - `ptr`: pointer provided by and simply passed back to external driver
+        - `timestep`: current LAMMPS timestep
+        - `nlocal`: # of atoms on this processor
+        - `ids`: list of atom IDs on this processor
+        - `x`: coordinates of atoms on this processor
+        - `fexternal`: forces to add to atoms on this processor
+
+        Note: Do NOT overwrite `fexternal`, because it points to the internal memory of LAMMPS and
+        therefore overwriting it will erase its functionality. E.g. DO `fexternal.fill(0)` and NOT
+        `fexternal = np.zeros_like(x)`.
 
         Example: Add random forces
 
@@ -293,6 +318,8 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         self.input.control['fix___callback'] = 'all external pf/callback {} {}'.format(
             n_call, n_apply
         )
+        if overload_internal_callback:
+            self._callback = function
 
     def _callback(self, caller, ntimestep, nlocal, tag, x, fext):
         tags = tag.flatten().argsort()

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -250,7 +250,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         **********************
 
         Set callback function that modifies forces.
-        
+
         Args:
             function (function): User-defined function that returns forces (see below)
             n_call (int): Make callback every `n_call` steps
@@ -264,7 +264,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             return forces
         ```
         where `positions` is the positions of all atoms on the local processor, `ntimestep` is the
-        current timestep and `nlocal` is the number of atoms on the current processor. `forces` 
+        current timestep and `nlocal` is the number of atoms on the current processor. `forces`
         must be of the shape `(n_atoms, 3)`. The total translational force will be eliminated
         inside pyiron.
 

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -319,7 +319,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         if not self.server.run_mode.interactive:
             raise AssertionError('Callback works only in interactive mode')
         self._user_fix_external = _FixExternal(function)
-        self.input.control['fix___fix_external'] = 'all external pf/fix_external {} {}'.format(
+        self.input.control['fix___fix_external'] = 'all external pf/callback {} {}'.format(
             n_call, n_apply
         )
         if overload_internal_fix_external:
@@ -411,7 +411,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             super(LammpsInteractive, self).run_if_interactive()
             self._reset_interactive_run_command()
             if self._user_fix_external is not None:
-                self._interactive_library.set_fix_external_fix_external(
+                self._interactive_library.set_fix_external_callback(
                     "fix_external", self._user_fix_external.fix_external
                 )
             counter = 0

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -269,7 +269,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         ```
         where `positions` is the positions of all atoms on the local processor, `ntimestep` is the
         current timestep and `nlocal` is the number of atoms on the current processor. `forces`
-        must be of the shape `(n_atoms, 3)`. The total translational force will be eliminated
+        must be of the shape `(n_atoms, 3)`. The net translational force will be eliminated
         inside pyiron.
 
         If `overload_internal_callback` is set to `True`, then `function` must have the following

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -298,7 +298,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         tags = tag.flatten().argsort()
         fext.fill(0)
         fext[tags] += self._user_callback(x[tags], ntimestep, nlocal)
-        fext -= np.mean(fext, axis=0)[np.newaxis, :]
+        fext -= np.mean(fext, axis=0)
 
     def calc_minimize(
             self,

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -305,7 +305,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         lmp = pr.create.job.Lammps('random_forces')
         lmp.structure = your_structure
         lmp.potential = your_potential
-        lmp.server.run_mode.interactive = True
+        lmp.interactive_open()
         lmp.set_callback(random_forces)
         lmp.calc_md()
         lmp.run()

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -317,7 +317,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
 
         Note: Do NOT overwrite `fexternal`, because it points to the internal memory of LAMMPS and
         therefore overwriting it will erase its functionality. E.g. DO `fexternal.fill(0)` and NOT
-        `fexternal = np.zeros_like(x)`. 
+        `fexternal = np.zeros_like(x)`.
         """
         if not self.server.run_mode.interactive:
             raise AssertionError('Callback works only in interactive mode')

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -268,7 +268,10 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         where `positions` is the positions of all atoms on the local processor, `ntimestep` is the
         current timestep and `nlocal` is the number of atoms on the current processor. `forces`
         must be of the shape `(n_atoms, 3)`. The total translational force will be eliminated
-        inside pyiron.
+        inside pyiron. The fix then adds these forces to each atom in the box, once every
+        `n_apply` steps, similar to the way the fix addforce command works. Note that if
+        `n_call` > `n_apply`, the force values produced by one callback will persist, and be used
+        multiple times to update atom forces.
 
         Example: Add random forces
 

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -738,10 +738,29 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
 
 
 class _FixExternal:
+    """
+    Helper class to exploit `fix external`, which is one of the features of LAMMPS to modify
+    force of each atom. More info can be found on https://docs.lammps.org/fix_external.html
+
+    Inside pyiron, `fix_external()` is passed to LAMMPS, which is to be called during run. The
+    function arguments are given by LAMMPS -> DO NOT modify them.
+    """
     def __init__(self, function):
         self.function = function
 
-    def fix_external(self, caller, ntimestep, nlocal, tag, x, fext):
+    def fix_external(self, ptr, ntimestep, nlocal, tag, x, fext):
+        """
+        Args:
+            ptr: pointer provided by and simply passed back to external driver
+            timestep (int): current LAMMPS timestep
+            nlocal (numpy.ndarray): # of atoms on this processor
+            ids (numpy.ndarray): list of atom IDs on this processor
+            x (numpy.ndarray): coordinates of atoms on this processor
+            fexternal (numpy.ndarray): forces to add to atoms on this processor
+
+        `fexternal` points to the forces to be added in LAMMPS, i.e. its content can be modified
+        but not overwritten.
+        """
         tags = tag.flatten().argsort()
         fext.fill(0)
         fext[tags] += self.function(x[tags], ntimestep, nlocal)

--- a/tests/lammps/test_interactive.py
+++ b/tests/lammps/test_interactive.py
@@ -150,7 +150,7 @@ class TestLammpsInteractive(unittest.TestCase):
         self.job.server.run_mode.interactive = True
         self.job.set_fix_external(f)
         self.assertEqual(
-            self.job.input.control['fix___fix_external'], 'all external pf/fix external 1 1'
+            self.job.input.control['fix___fix_external'], 'all external pf/callback 1 1'
         )
         fext = np.zeros_like(v)
         self.job._user_fix_external.fix_external(None, 0, 0, np.arange(len(v)), self.job.structure.positions, fext)

--- a/tests/lammps/test_interactive.py
+++ b/tests/lammps/test_interactive.py
@@ -150,7 +150,7 @@ class TestLammpsInteractive(unittest.TestCase):
         self.job.server.run_mode.interactive = True
         self.job.set_fix_external(f)
         self.assertEqual(
-            self.job.input.control['fix___fix_external'], 'all external pf/fix_external 1 1'
+            self.job.input.control['fix___fix_external'], 'all external pf/fix external 1 1'
         )
         fext = np.zeros_like(v)
         self.job._user_fix_external.fix_external(None, 0, 0, np.arange(len(v)), self.job.structure.positions, fext)

--- a/tests/lammps/test_interactive.py
+++ b/tests/lammps/test_interactive.py
@@ -140,22 +140,22 @@ class TestLammpsInteractive(unittest.TestCase):
         self.assertTrue(("fix ensemble all box/relax x 10000.0 y 20000.0 xy 0.0 xz 0.0 couple none" in
                          self.minimize_job._interactive_library._command))
 
-    def test_callback(self):
+    def test_fix_external(self):
         def f(x, nt, nl):
             return np.linspace(0, 1, np.prod(x.shape)).reshape(-1, 3)
         v = f(self.job.structure.positions, None, None)
         v -= np.mean(v, axis=0)
         self.job.server.run_mode.modal = True
-        self.assertRaises(AssertionError, self.job.set_callback, f)
+        self.assertRaises(AssertionError, self.job.set_fix_external, f)
         self.job.server.run_mode.interactive = True
-        self.job.set_callback(f)
+        self.job.set_fix_external(f)
         self.assertEqual(
-            self.job.input.control['fix___callback'], 'all external pf/callback 1 1'
+            self.job.input.control['fix___fix_external'], 'all external pf/fix_external 1 1'
         )
         fext = np.zeros_like(v)
-        self.job._user_callback.callback(None, 0, 0, np.arange(len(v)), self.job.structure.positions, fext)
+        self.job._user_fix_external.fix_external(None, 0, 0, np.arange(len(v)), self.job.structure.positions, fext)
         self.assertTrue(np.allclose(v, fext))
-        del self.job.input.control['fix___callback']
+        del self.job.input.control['fix___fix_external']
 
 
 if __name__ == "__main__":

--- a/tests/lammps/test_interactive.py
+++ b/tests/lammps/test_interactive.py
@@ -73,7 +73,7 @@ class TestLammpsInteractive(unittest.TestCase):
         )
         self.job._structure_previous = atoms.copy()
         self.job._structure_current = atoms.copy()
-        self.job._structure_previous.cell[1,0] += 0.01
+        self.job._structure_previous.cell[1, 0] += 0.01
         self.job.interactive_cells_setter(self.job._structure_current.cell)
         self.assertEqual(
             self.job._interactive_library._command[-1],
@@ -81,7 +81,7 @@ class TestLammpsInteractive(unittest.TestCase):
         )
         self.job._structure_previous = atoms.copy()
         self.job._structure_current = atoms.copy()
-        self.job._structure_current.cell[1,0] += 0.01
+        self.job._structure_current.cell[1, 0] += 0.01
         self.job.interactive_cells_setter(self.job._structure_current.cell)
         self.assertEqual(
             self.job._interactive_library._command[-2],
@@ -153,7 +153,7 @@ class TestLammpsInteractive(unittest.TestCase):
             self.job.input.control['fix___callback'], 'all external pf/callback 1 1'
         )
         fext = np.zeros_like(v)
-        self.job._callback(None, 0, 0, np.arange(len(v)), self.job.structure.positions, fext)
+        self.job._user_callback.callback(None, 0, 0, np.arange(len(v)), self.job.structure.positions, fext)
         self.assertTrue(np.allclose(v, fext))
         del self.job.input.control['fix___callback']
 


### PR DESCRIPTION
`callback` is one of the features of LAMMPS which makes it extremely efficient while being still very interactive. In short, you can append a function that returns forces which are then added to the total forces calculated in LAMMPS. You can find more info on [this page](https://docs.lammps.org/fix_external.html).

Example I: Add random forces

```python
def random_forces(x, *args):
    return 0.1 * np.random.randn(*x.shape)

lmp = pr.create_job('Lammps', 'random_forces')
lmp.structure = pr.create.structure.bulk('Ni', cubic=True).repeat(3)
lmp.server.run_mode.interactive = True
lmp.set_callback(random_forces)
lmp.calc_md()
lmp.run()
lmp.interactive_close()
```

Example II: Push H in (1, 1, 1)-direction

```python
class CallBack:
    def __init__(self, job):
        self.job = job

    def push_hydrogen(self, x, *args):
        f = np.zeros_like(self.job.structure.positions)
        f[self.job.structure.select_index('H')[0]] = np.array(3*[0.5])
        return f

lmp = pr.create_job('Lammps', 'push_hydrogen')
lmp.structure = pr.create.structure.bulk('Ni', cubic=True).repeat(3)
lmp.structure += pr.create.structure.atoms(
    elements=['H'], positions=[lmp.structure.analyse.get_voronoi_vertices()[0]]
)
callback = CallBack(lmp)
lmp.server.run_mode.interactive = True
lmp.set_callback(callback.push_hydrogen)
lmp.calc_md()
lmp.run()
lmp.interactive_close()
```