### PR TITLE
add assertion test to symmetry permutation

### DIFF
--- a/pyiron_atomistics/atomistics/structure/symmetry.py
+++ b/pyiron_atomistics/atomistics/structure/symmetry.py
@@ -77,11 +77,10 @@ class Symmetry(dict):
         of the `m`-th atom, then the returned array should have the same number in `(n, i)` and
         `(m, j)`
         """
-        random_vectors = np.random.random(self._structure.positions.shape)
-        all_vec = np.einsum('nij,nmj->min', self.rotations, random_vectors[self.permutations])
+        ladder = np.arange(np.prod(self._structure.positions.shape)).reshape(-1, 3)
+        all_vec = np.einsum('nij,nmj->min', self.rotations, ladder[self.permutations])
         vec_abs_flat = np.absolute(all_vec).reshape(np.prod(self._structure.positions.shape), -1)
-        vec_round = np.round(vec_abs_flat, decimals=10)
-        vec_sorted = np.sort(vec_round, axis=-1)
+        vec_sorted = np.sort(vec_abs_flat, axis=-1)
         enum = np.unique(vec_sorted, axis=0, return_inverse=True)[1]
         return enum.reshape(-1, 3)
 

--- a/pyiron_atomistics/atomistics/structure/symmetry.py
+++ b/pyiron_atomistics/atomistics/structure/symmetry.py
@@ -172,7 +172,7 @@ class Symmetry(dict):
         for any `n` with respect to the box symmetry (`n < n_symmetry`).
         """
         if self._permutations is None:
-            scaled_positions = self._structure.get_scaled_positions(wrap=False)
+            scaled_positions = self._structure.get_scaled_positions()
             tree = cKDTree(scaled_positions)
             positions = np.einsum(
                 'nij,kj->nki',
@@ -180,7 +180,7 @@ class Symmetry(dict):
                 scaled_positions
             ) + self['translations'][:, None, :]
             positions -= np.floor(positions + self.epsilon)
-            distances, self._permutations = tree.query(positions)[1]
+            distances, self._permutations = tree.query(positions)
             if not np.allclose(distances, 0):
                 raise AssertionError('Neighbor search failed')
             self._permutations = self._permutations.argsort(axis=-1)

--- a/pyiron_atomistics/atomistics/structure/symmetry.py
+++ b/pyiron_atomistics/atomistics/structure/symmetry.py
@@ -172,7 +172,10 @@ class Symmetry(dict):
         for any `n` with respect to the box symmetry (`n < n_symmetry`).
         """
         if self._permutations is None:
-            scaled_positions = self._structure.get_scaled_positions()
+            scaled_positions = self._structure.get_scaled_positions(wrap=False)
+            scaled_positions[..., self._structure.pbc] -= np.floor(
+                scaled_positions[..., self._structure.pbc] + self.epsilon
+            )
             tree = cKDTree(scaled_positions)
             positions = np.einsum(
                 'nij,kj->nki',

--- a/pyiron_atomistics/atomistics/structure/symmetry.py
+++ b/pyiron_atomistics/atomistics/structure/symmetry.py
@@ -70,6 +70,22 @@ class Symmetry(dict):
         return self['equivalent_atoms']
 
     @property
+    def arg_equivalent_vectors(self):
+        """
+        Get 3d vector components which are equivalent under symmetry operation. For example, if
+        the `i`-direction (`i = x, y, z`) of the `n`-th atom is equivalent to the `j`-direction
+        of the `m`-th atom, then the returned array should have the same number in `(n, i)` and
+        `(m, j)`
+        """
+        random_vectors = np.random.random(self._structure.positions.shape)
+        all_vec = np.einsum('nij,nmj->min', self.rotations, random_vectors[self.permutations])
+        vec_abs_flat = np.absolute(all_vec).reshape(np.prod(self._structure.positions.shape), -1)
+        vec_round = np.round(vec_abs_flat, decimals=10)
+        vec_sorted = np.sort(vec_round, axis=-1)
+        enum = np.unique(vec_sorted, axis=0, return_inverse=True)[1]
+        return enum.reshape(-1, 3)
+
+    @property
     def rotations(self):
         """
         All rotational matrices. Two points x and y are equivalent with respect to the box

--- a/pyiron_atomistics/atomistics/structure/symmetry.py
+++ b/pyiron_atomistics/atomistics/structure/symmetry.py
@@ -179,11 +179,11 @@ class Symmetry(dict):
                 self['rotations'],
                 scaled_positions
             ) + self['translations'][:, None, :]
-            if any(self._structure.pbc):
-                positions[..., self._structure.pbc] -= np.floor(
-                    positions[..., self._structure.pbc] + self.epsilon
-                )
-            self._permutations = tree.query(positions)[1].argsort(axis=-1)
+            positions -= np.floor(positions + self.epsilon)
+            distances, self._permutations = tree.query(positions)[1]
+            if not np.allclose(distances, 0):
+                raise AssertionError('Neighbor search failed')
+            self._permutations = self._permutations.argsort(axis=-1)
         return self._permutations
 
     def symmetrize_vectors(

--- a/tests/atomistics/structure/test_symmetry.py
+++ b/tests/atomistics/structure/test_symmetry.py
@@ -123,5 +123,16 @@ class TestAtoms(unittest.TestCase):
             vec[i] = v
             self.assertAlmostEqual(np.linalg.norm(all_vectors - vec, axis=(-1, -2)).min(), 0,)
 
+    def test_arg_equivalent_vectors(self):
+        structure = StructureFactory().ase.bulk('Al', cubic=True).repeat(2)
+        self.assertEqual(np.unique(structure.get_symmetry().arg_equivalent_vectors).squeeze(), 0)
+        x_v = structure.positions[0]
+        del structure[0]
+        arg_v = structure.get_symmetry().arg_equivalent_vectors
+        dx = structure.get_distances_array(structure.positions, x_v, vectors=True)
+        dx_round = np.round(np.absolute(dx), decimals=3)
+        self.assertEqual(len(np.unique(dx_round + arg_v)), len(np.unique(arg_v)))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/atomistics/structure/test_symmetry.py
+++ b/tests/atomistics/structure/test_symmetry.py
@@ -7,11 +7,12 @@ import numpy as np
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.atomistics.structure.factory import StructureFactory
 
+
 class TestAtoms(unittest.TestCase):
     def test_get_arg_equivalent_sites(self):
         a_0 = 4.0
         structure = StructureFactory().ase.bulk('Al', cubic=True, a=a_0).repeat(2)
-        sites = structure.get_wrapped_coordinates(structure.positions+np.array([0, 0, 0.5*a_0]))
+        sites = structure.get_wrapped_coordinates(structure.positions + np.array([0, 0, 0.5 * a_0]))
         v_position = structure.positions[0]
         del structure[0]
         pairs = np.stack((
@@ -19,7 +20,7 @@ class TestAtoms(unittest.TestCase):
             np.unique(np.round(structure.get_distances_array(v_position, sites), decimals=2), return_inverse=True)[1]
         ), axis=-1)
         unique_pairs = np.unique(pairs, axis=0)
-        self.assertEqual(len(unique_pairs), len(np.unique(unique_pairs[:,0])))
+        self.assertEqual(len(unique_pairs), len(np.unique(unique_pairs[:, 0])))
         with self.assertRaises(ValueError):
             structure.get_symmetry().get_arg_equivalent_sites([0, 0, 0])
 
@@ -28,7 +29,7 @@ class TestAtoms(unittest.TestCase):
         structure = StructureFactory().ase.bulk('Al', cubic=True, a=a_0)
         self.assertEqual(
             len(structure),
-            len(structure.get_symmetry().generate_equivalent_points([0, 0, 0.5*a_0]))
+            len(structure.get_symmetry().generate_equivalent_points([0, 0, 0.5 * a_0]))
         )
 
     def test_get_symmetry(self):
@@ -45,9 +46,9 @@ class TestAtoms(unittest.TestCase):
             Al.get_symmetry().symmetrize_vectors(1)
         v = np.random.rand(6).reshape(-1, 3)
         self.assertAlmostEqual(np.linalg.norm(Al.get_symmetry().symmetrize_vectors(v)), 0)
-        Al.positions[0,0] += 0.01
+        Al.positions[0, 0] += 0.01
         w = Al.get_symmetry().symmetrize_vectors(v)
-        self.assertAlmostEqual(np.absolute(w[:,0]).sum(), np.linalg.norm(w, axis=-1).sum())
+        self.assertAlmostEqual(np.absolute(w[:, 0]).sum(), np.linalg.norm(w, axis=-1).sum())
 
     def test_get_symmetry_dataset(self):
         cell = 2.2 * np.identity(3)
@@ -73,7 +74,7 @@ class TestAtoms(unittest.TestCase):
     def test_get_equivalent_points(self):
         basis = Atoms("FeFe", positions=[[0.01, 0, 0], [0.5, 0.5, 0.5]], cell=np.identity(3))
         arr = basis.get_symmetry().generate_equivalent_points([0, 0, 0.5])
-        self.assertAlmostEqual(np.linalg.norm(arr-np.array([0.51, 0.5, 0]), axis=-1).min(), 0)
+        self.assertAlmostEqual(np.linalg.norm(arr - np.array([0.51, 0.5, 0]), axis=-1).min(), 0)
 
     def test_get_space_group(self):
         cell = 2.2 * np.identity(3)
@@ -102,8 +103,8 @@ class TestAtoms(unittest.TestCase):
             [
                 [0.0, 0.0, 0.0],
                 [0.5, 0.5, 0.0],
-                [0.5, 1/6, 0.5],
-                [0.0, 2/3, 0.5],
+                [0.5, 1 / 6, 0.5],
+                [0.0, 2 / 3, 0.5],
             ]
         )
         Mg_hcp = Atoms("Mg4", scaled_positions=pos, cell=cell)


### PR DESCRIPTION
And I just realised that the algorithm doesn't always work. Here I add a simple assertion test in order to be able to fail properly when this happens.

In order not to repeat the mistake, I keep this one open for 24h.