### PR TITLE
revert error

### DIFF
--- a/pyiron_atomistics/atomistics/master/quasi.py
+++ b/pyiron_atomistics/atomistics/master/quasi.py
@@ -90,7 +90,6 @@ class QuasiHarmonicJob(AtomisticParallelMaster):
         self.input["temperature_end"] = 500
         self.input["temperature_steps"] = 10
         self.input["polynomial_degree"] = 3
-        self.input['ignore_structure_optimization'] = False
         self._job_generator = MurnaghanJobGenerator(self)
 
     def collect_output(self):
@@ -127,21 +126,6 @@ class QuasiHarmonicJob(AtomisticParallelMaster):
         with self.project_hdf5.open("output") as hdf5_out:
             for key, val in self._output.items():
                 hdf5_out[key] = val
-
-    def validate_ready_to_run(self):
-        super().validate_ready_to_run()
-        if not self.input['ignore_structure_optimization']:
-            random_vector = np.random.random(self.structure.positions.shape)
-            sym_vector = self.structure.get_symmetry().symmetrize_vectors(random_vector)
-            if not np.allclose(sym_vector, 0):
-                raise ValueError("""
-                    Current implementation of QHA does not perform a structure optimization,
-                    meaning the displacement fields for strained structures (and therefore the
-                    resulting force constants) are only correct if the structure is a perfect
-                    crystal. Currently we do not offer alternatives, other than setting
-                    `job.input['ignore_structure_optimization'] = True`, which will deliver
-                    wrong results with no estimate of how far they are from the correct values.
-                """)
 
     def optimise_volume(self, bulk_eng):
         """

--- a/tests/atomistics/master/test_quasi.py
+++ b/tests/atomistics/master/test_quasi.py
@@ -13,16 +13,6 @@ class TestQuasi(TestWithCleanProject):
         phono = lmp.create_job('PhonopyJob', 'phono')
         qha = phono.create_job('QuasiHarmonicJob', 'quasi')
         self.assertEqual(qha.validate_ready_to_run(), None)
-        lmp = self.project.create.job.Lammps('lmp_phono')
-        lmp.structure = self.project.create.structure.bulk('Al', cubic=True)
-        lmp.structure += self.project.create.structure.atoms(
-            elements=['H'], positions=[[0, 0, 0.3]], cell=lmp.structure.cell
-        )
-        phono = lmp.create_job('PhonopyJob', 'phono')
-        qha = phono.create_job('QuasiHarmonicJob', 'quasi')
-        self.assertRaises(ValueError, qha.validate_ready_to_run)
-        qha.input['ignore_structure_optimization'] = True
-        self.assertEqual(qha.validate_ready_to_run(), None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I just realised that Phonopy actually does an internal symmetrisation of forces by taking displacements in both +dx and -dx, meaning as long as the structure is close to the energy minimum it manages to find the correct force constants. Therefore, I revert the changes I created in the [previous PR](https://github.com/pyiron/pyiron_atomistics/pull/466).

This being said, it means it requires twice as many calculations as it would otherwise be required (while the force symmetrisation can be achieved by using the energies as well), so I would still go ahead with the implementation of my quasi harmonic code.