### PR TITLE
Consistent indices for StructureStorage.get_structures

### DIFF
--- a/pyiron_atomistics/atomistics/structure/structurestorage.py
+++ b/pyiron_atomistics/atomistics/structure/structurestorage.py
@@ -190,12 +190,15 @@ class StructureStorage(FlattenedStorage, HasStructure):
             raise KeyError(f"No structure named {frame}.") from None
 
     def _get_structure(self, frame=-1, wrap_atoms=True):
+        index_map = {e: i for i, e in enumerate(np.unique(self["symbols"]))}
         try:
             magmoms = self.get_array("spins", frame)
         except KeyError:
             # not all structures have spins saved on them
             magmoms = None
-        return Atoms(symbols=self.get_array("symbols", frame),
+        symbols = self.get_array("symbols", frame)
+        return Atoms(symbols=symbols,
+                     indices=[index_map[e] for e in symbols],
                      positions=self.get_array("positions", frame),
                      cell=self.get_array("cell", frame),
                      pbc=self.get_array("pbc", frame),

--- a/pyiron_atomistics/atomistics/structure/structurestorage.py
+++ b/pyiron_atomistics/atomistics/structure/structurestorage.py
@@ -9,6 +9,7 @@ Alternative structure container that stores them in flattened arrays.
 import numpy as np
 
 from pyiron_base import FlattenedStorage
+from pyiron_atomistics.atomistics.structure.atom import Atom
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.atomistics.structure.has_structure import HasStructure
 
@@ -190,14 +191,15 @@ class StructureStorage(FlattenedStorage, HasStructure):
             raise KeyError(f"No structure named {frame}.") from None
 
     def _get_structure(self, frame=-1, wrap_atoms=True):
-        index_map = {e: i for i, e in enumerate(np.unique(self["symbols"]))}
+        elements = self.get_elements()
+        index_map = {e: i for i, e in enumerate(elements)}
         try:
             magmoms = self.get_array("spins", frame)
         except KeyError:
             # not all structures have spins saved on them
             magmoms = None
         symbols = self.get_array("symbols", frame)
-        return Atoms(symbols=symbols,
+        return Atoms(species=[Atom(e).element for e in elements],
                      indices=[index_map[e] for e in symbols],
                      positions=self.get_array("positions", frame),
                      cell=self.get_array("cell", frame),


### PR DESCRIPTION
Previously the index<->chemical element mapping was unspecified for structures returned from a storage.  This works ok for single calculations since our jobs remap the indices, but crucially they only do it once for the first structure set on a job.  So if you have two structures with an inconsistent mapping and put them through the same interactive job great despair ensues.  The structures are passed correctly to lammps, but since the index mapping changed they are incorrectly saved in the HDF and using `get_structure` on that job will give from structures (with elements swapped).  More details in the commit messages.