### PR TITLE
Save VASP stresses as matrix

### DIFF
--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -277,23 +277,23 @@ class Outcar(object):
             filename=filename,
             trigger="FORCE on cell =-STRESS in cart. coord.  units (eV):",
         )
-        pullay_stress_lst = []
+        stress_lst = []
         for j in trigger_indices:
             try:
                 if si_unit:
-                    pullay_stress_lst.append(
-                        [float(l) for l in lines[j + 13].split()[1:7]]
-                    )
+                    stress = [float(l) for l in lines[j + 13].split()[1:7]]
                 else:
-                    pullay_stress_lst.append(
-                        [float(l) for l in lines[j + 14].split()[2:8]]
-                    )
+                    stress = [float(l) for l in lines[j + 14].split()[2:8]]
             except ValueError:
-                if si_unit:
-                    pullay_stress_lst.append([float("NaN")] * 6)
-                else:
-                    pullay_stress_lst.append([float("NaN")] * 6)
-        return np.array(pullay_stress_lst)
+                stress = [float("NaN")] * 6
+            # VASP outputs the stresses in XX, YY, ZZ, XY, YZ, ZX order
+            #                               0,  1,  2,  3,  4,  5
+            stressm = np.diag(stress[:3])
+            stressm[0, 1] = stressm[1, 0] = stress[3]
+            stressm[1, 2] = stressm[2, 1] = stress[4]
+            stressm[0, 2] = stressm[2, 0] = stress[5]
+            stress_lst.append(stressm)
+        return np.array(stress_lst)
 
     @staticmethod
     def get_irreducible_kpoints(

--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -279,11 +279,21 @@ class Outcar(object):
         )
         stress_lst = []
         for j in trigger_indices:
+            # search for '------...' delimiters of the stress table
+            # setting a constant offset into `lines` does not work, because the number of stress contributions may vary
+            # depending on the VASP configuration (e.g. with or without van der Waals interactions)
+            jj = j
+            while set(lines[jj].strip()) != {'-'}:
+                jj += 1
+            jj += 1
+            # there's two delimiters, so search again
+            while set(lines[jj].strip()) != {'-'}:
+                jj += 1
             try:
                 if si_unit:
-                    stress = [float(l) for l in lines[j + 13].split()[1:7]]
+                    stress = [float(l) for l in lines[jj + 1].split()[1:7]]
                 else:
-                    stress = [float(l) for l in lines[j + 14].split()[2:8]]
+                    stress = [float(l) for l in lines[jj + 2].split()[2:8]]
             except ValueError:
                 stress = [float("NaN")] * 6
             # VASP outputs the stresses in XX, YY, ZZ, XY, YZ, ZX order

--- a/tests/vasp/test_outcar.py
+++ b/tests/vasp/test_outcar.py
@@ -32,6 +32,10 @@ class TestOutcar(unittest.TestCase):
             filename = posixpath.join(direc, f)
             cls.file_list.append(filename)
 
+    def setUp(self):
+        self.addTypeEqualityFunc(np.ndarray, lambda a, b, msg=None: \
+                np.testing.assert_array_equal(a, b, err_msg=msg))
+
     def test_from_file(self):
         for filename in self.file_list:
             self.outcar_parser.from_file(filename=filename)
@@ -564,38 +568,24 @@ class TestOutcar(unittest.TestCase):
             self.assertIsInstance(output_si, np.ndarray)
             self.assertIsInstance(output_kb, np.ndarray)
             if int(filename.split("/OUTCAR_")[-1]) == 1:
-                pullay_si = np.array([[-14.41433, -14.41433, -14.41433, 0.0, 0.0, 0.0]])
-                pullay_kb = np.array(
-                    [[-455.93181, -455.93181, -455.93181, 0.0, 0.0, 0.0]]
-                )
-                self.assertEqual(output_si.__str__(), pullay_si.__str__())
-                self.assertEqual(output_kb.__str__(), pullay_kb.__str__())
+                pullay_si = -14.41433 * np.eye(3)
+                pullay_kb = -455.93181 * np.eye(3)
             if int(filename.split("/OUTCAR_")[-1]) == 2:
-                pullay_si = np.array([[-5.38507, -5.38507, -5.38507, -0.0, 0.0, -0.0]])
-                pullay_kb = np.array([[-393.032, -393.032, -393.032, -0.0, 0.0, -0.0]])
-                self.assertEqual(output_si.__str__(), pullay_si.__str__())
-                self.assertEqual(output_kb.__str__(), pullay_kb.__str__())
+                pullay_si = -5.38507 * np.eye(3)
+                pullay_kb = -393.032 * np.eye(3)
             if int(filename.split("/OUTCAR_")[-1]) == 3:
-                pullay_si = np.array([[-3.29441, -3.29441, -3.29441, 0.0, -0.0, 0.0]])
-                pullay_kb = np.array(
-                    [[-240.44384, -240.44384, -240.44384, 0.0, -0.0, 0.0]]
-                )
-                self.assertEqual(output_si.__str__(), pullay_si.__str__())
-                self.assertEqual(output_kb.__str__(), pullay_kb.__str__())
+                pullay_si = -3.29441 * np.eye(3)
+                pullay_kb = -240.44384 * np.eye(3)
             if int(filename.split("/OUTCAR_")[-1]) == 4:
-                pullay_si = np.array([[-3.29441, -3.29441, -3.29441, -0.0, -0.0, -0.0]])
-                pullay_kb = np.array(
-                    [[-240.44384, -240.44384, -240.44384, -0.0, -0.0, -0.0]]
-                )
-                self.assertEqual(output_si.__str__(), pullay_si.__str__())
-                self.assertEqual(output_kb.__str__(), pullay_kb.__str__())
+                pullay_si = -3.29441 * np.eye(3)
+                pullay_kb = -240.44384 * np.eye(3)
             if int(filename.split("/OUTCAR_")[-1]) in [5, 6]:
-                pullay_si = np.array([[-3.3066, -3.3066, -3.3066, 0.0, -0.0, 0.0]])
-                pullay_kb = np.array(
-                    [[-241.33405, -241.33409, -241.33405, 0.0, -0.0, 0.0]]
-                )
-                self.assertEqual(output_si.__str__(), pullay_si.__str__())
-                self.assertEqual(output_kb.__str__(), pullay_kb.__str__())
+                pullay_si = -3.3066 * np.eye(3)
+                pullay_kb = -241.33405 * np.eye(3)
+            self.assertEqual(output_si, pullay_si,
+                            "Wrong pressures parse (SI units)")
+            self.assertEqual(output_kb, pullay_kb,
+                            "Wrong pressures parse (kb units)")
 
     def test_get_kinetic_energy_error(self):
         for filename in self.file_list:

--- a/tests/vasp/test_outcar.py
+++ b/tests/vasp/test_outcar.py
@@ -562,30 +562,71 @@ class TestOutcar(unittest.TestCase):
                 self.assertEqual(len(output[-1][-1]), 3)
 
     def test_get_stresses(self):
+        def from_vasp_voigt(stress):
+            sigma = np.diag(stress[:3])
+            sigma[1, 2] = sigma[2, 1] = stress[4]
+            sigma[0, 2] = sigma[2, 0] = stress[5]
+            sigma[0, 1] = sigma[1, 0] = stress[3]
+            return sigma.reshape(1, 3, 3)
+
+        test_data = {
+                'OUTCAR_1': (
+                    from_vasp_voigt([-14.41433, -14.41433, -14.41433, 0.00000, 0.00000, 0.00000]),
+                    from_vasp_voigt([-455.93181, -455.93181, -455.93181, 0.00000, 0.00000, 0.00000])
+                ),
+                'OUTCAR_2': (
+                    from_vasp_voigt([-5.38507, -5.38507, -5.38507, -0.00000, 0.00000, -0.00000]),
+                    from_vasp_voigt([-393.03200, -393.03200, -393.03200, -0.00000, 0.00000, -0.00000])
+                ),
+                'OUTCAR_3': (
+                    from_vasp_voigt([-3.29441, -3.29441, -3.29441, 0.00000, -0.00000, 0.00000]),
+                    from_vasp_voigt([-240.44384, -240.44384, -240.44384, 0.00000, -0.00000, 0.00000])
+                ),
+                'OUTCAR_4': (
+                    from_vasp_voigt([-3.29441, -3.29441, -3.29441, 0.00000, -0.00000, 0.00000]),
+                    from_vasp_voigt([-240.44384, -240.44384, -240.44384, 0.00000, -0.00000, 0.00000])
+                ),
+                'OUTCAR_5': (
+                    from_vasp_voigt([-3.30660, -3.30660, -3.30660, 0.00000, -0.00000, 0.00000]),
+                    from_vasp_voigt([-241.33405, -241.33409, -241.33405, 0.00000, -0.00000, 0.00000])
+                ),
+                'OUTCAR_6': (
+                    from_vasp_voigt([-3.30660, -3.30660, -3.30660, 0.00000, -0.00000, 0.00000]),
+                    from_vasp_voigt([-241.33405, -241.33409, -241.33405, 0.00000, -0.00000, 0.00000])
+                ),
+                'OUTCAR_7': (
+                    from_vasp_voigt([-11.88272, -11.88272, 1.40676, 0.10858, -1.27251, 1.27251]),
+                    from_vasp_voigt([-30.25634, -30.25634, 3.58195, 0.27646, -3.24012, 3.24012])
+                ),
+                'OUTCAR_8': (
+                    from_vasp_voigt([26.40677, 26.40677, 26.40677, 0.00000, 0.00000, 0.00000]),
+                    from_vasp_voigt([77.52482, 77.52482, 77.52482, 0.00000, 0.00000, 0.00000])
+                ),
+                'OUTCAR_9': (
+                    np.concatenate([from_vasp_voigt([-8.22615, -16.37087, -24.79610,
+                                                      0.00000, 0.00000, 0.00000]),
+                                    from_vasp_voigt([-0.51498, -5.95380, 3.02638,
+                                                      0.00000, 0.00000, 0.00000])]),
+                    np.concatenate([from_vasp_voigt([-13.17976, -26.22903, -39.72774,
+                                                       0.00000, 0.00000, 0.00000]),
+                                    from_vasp_voigt([-0.82508, -9.53905, 4.84880,
+                                                      0.00000, 0.00000, 0.00000])])
+                ),
+                'OUTCAR_10': (
+                    from_vasp_voigt([-0.01303, -0.01303, -0.01300, 0.00000, -0.00000, 0.00000]),
+                    from_vasp_voigt([-0.00619, -0.00619, -0.00617, 0.00000, -0.00000, 0.00000])
+                ),
+        }
         for filename in self.file_list:
             output_si = self.outcar_parser.get_stresses(filename, si_unit=True)
             output_kb = self.outcar_parser.get_stresses(filename, si_unit=False)
             self.assertIsInstance(output_si, np.ndarray)
             self.assertIsInstance(output_kb, np.ndarray)
-            if int(filename.split("/OUTCAR_")[-1]) == 1:
-                pullay_si = -14.41433 * np.eye(3)
-                pullay_kb = -455.93181 * np.eye(3)
-            if int(filename.split("/OUTCAR_")[-1]) == 2:
-                pullay_si = -5.38507 * np.eye(3)
-                pullay_kb = -393.032 * np.eye(3)
-            if int(filename.split("/OUTCAR_")[-1]) == 3:
-                pullay_si = -3.29441 * np.eye(3)
-                pullay_kb = -240.44384 * np.eye(3)
-            if int(filename.split("/OUTCAR_")[-1]) == 4:
-                pullay_si = -3.29441 * np.eye(3)
-                pullay_kb = -240.44384 * np.eye(3)
-            if int(filename.split("/OUTCAR_")[-1]) in [5, 6]:
-                pullay_si = -3.3066 * np.eye(3)
-                pullay_kb = -241.33405 * np.eye(3)
-            self.assertEqual(output_si, pullay_si,
-                            "Wrong pressures parse (SI units)")
-            self.assertEqual(output_kb, pullay_kb,
-                            "Wrong pressures parse (kb units)")
+            test_si, test_kb = test_data[filename.split('/')[-1]]
+            self.assertEqual(output_si, test_si,
+                            "Wrong pressures parsed (SI units)")
+            self.assertEqual(output_kb, test_kb,
+                            "Wrong pressures parsed (kb units)")
 
     def test_get_kinetic_energy_error(self):
         for filename in self.file_list:


### PR DESCRIPTION
Turns out VASP writes the stress components in non-Voigt order (*WHY?!*) and I missed that in #354 originally.  This provides the fix.

@niklassiemer This is probably worth pointing out in the next CHANGELOG.