### PR TITLE
Support cube files without atoms

### DIFF
--- a/pyiron_atomistics/atomistics/volumetric/generic.py
+++ b/pyiron_atomistics/atomistics/volumetric/generic.py
@@ -399,7 +399,9 @@ class VolumetricData(object):
                     pos_data = np.array([pos_data])
                 atomic_numbers = np.array(pos_data[:, 0], dtype=int)
                 positions = pos_data[:, 2:]
-                self._atoms = Atoms(numbers=atomic_numbers, positions=positions, cell=cell)
+                self._atoms = Atoms(
+                    numbers=atomic_numbers, positions=positions, cell=cell
+                )
             end_int = n_atoms + 6 + int(np.prod(grid_shape) / 6)
             data = np.genfromtxt(lines[n_atoms + 6 : end_int])
             data_flatten = np.hstack(data)

--- a/pyiron_atomistics/atomistics/volumetric/generic.py
+++ b/pyiron_atomistics/atomistics/volumetric/generic.py
@@ -393,12 +393,13 @@ class VolumetricData(object):
             grid_shape = np.array(cell_data[:, 0], dtype=int)
             # total_data = np.zeros(grid_shape)
             cell = np.array([val * grid_shape[i] for i, val in enumerate(cell_grid)])
-            pos_data = np.genfromtxt(lines[6 : n_atoms + 6])
-            if n_atoms == 1:
-                pos_data = np.array([pos_data])
-            atomic_numbers = np.array(pos_data[:, 0], dtype=int)
-            positions = pos_data[:, 2:]
-            self._atoms = Atoms(numbers=atomic_numbers, positions=positions, cell=cell)
+            if n_atoms > 0:
+                pos_data = np.genfromtxt(lines[6 : n_atoms + 6])
+                if n_atoms == 1:
+                    pos_data = np.array([pos_data])
+                atomic_numbers = np.array(pos_data[:, 0], dtype=int)
+                positions = pos_data[:, 2:]
+                self._atoms = Atoms(numbers=atomic_numbers, positions=positions, cell=cell)
             end_int = n_atoms + 6 + int(np.prod(grid_shape) / 6)
             data = np.genfromtxt(lines[n_atoms + 6 : end_int])
             data_flatten = np.hstack(data)


### PR DESCRIPTION
Fixes #525.

I've cross-checked with [this](http://paulbourke.net/dataformats/cube/) definition of cube files, is that correct @fldei101, @sudarsan-surendralal what code are we targeting here?

I haven't tested this, because I have no example files, but it should be ok.  One issue might be that this will leave `self._atoms` undefined which could break assumptions of downstream code.