### PR TITLE
Adjust n_print to be at most max_iter in calc_minimize

### DIFF
--- a/pyiron_atomistics/lammps/control.py
+++ b/pyiron_atomistics/lammps/control.py
@@ -231,6 +231,9 @@ class LammpsControl(GenericParameters):
         # defaults stay consistent!
 
         max_evaluations = 100 * max_iter
+        if n_print > max_iter:
+            warnings.warn('n_print larger than max_iter, adjusting to n_print=max_iter')
+            n_print = max_iter
 
         if self["units"] not in LAMMPS_UNIT_CONVERSIONS.keys():
             raise NotImplementedError

--- a/pyiron_atomistics/lammps/control.py
+++ b/pyiron_atomistics/lammps/control.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 import hashlib
 import numpy as np
 import warnings
-from pyiron_base import GenericParameters
+from pyiron_base import GenericParameters, state
 from pyiron_atomistics.lammps.units import LAMMPS_UNIT_CONVERSIONS
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal, Jan Janssen"

--- a/pyiron_atomistics/lammps/control.py
+++ b/pyiron_atomistics/lammps/control.py
@@ -232,7 +232,7 @@ class LammpsControl(GenericParameters):
 
         max_evaluations = 100 * max_iter
         if n_print > max_iter:
-            warnings.warn('n_print larger than max_iter, adjusting to n_print=max_iter')
+            state.logger.warning('n_print larger than max_iter, adjusting to n_print=max_iter')
             n_print = max_iter
 
         if self["units"] not in LAMMPS_UNIT_CONVERSIONS.keys():


### PR DESCRIPTION
Changing max_iter to be less than n_print causes lammps to only print out the initial structure+forces, which is very confusing if you don't expect it.