### PR TITLE
dont write kpoints file

### DIFF
--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -2442,7 +2442,7 @@ class Kpoints(GenericParameters):
         )
         self._path_name = None
         self._n_path = None
-        
+
     def write_file(self, file_name, cwd=None):
         if self.file_name == False:
             return

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -1856,7 +1856,10 @@ class Input:
             directory (str): The working directory for the VASP run
         """
         self.incar.write_file(file_name="INCAR", cwd=directory)
-        self.kpoints.write_file(file_name="KPOINTS", cwd=directory)
+        if "KSPACING" in self.incar.keys():
+            warnings.warn("'KSPACING' found in INCAR, no KPOINTS file written")
+        else:
+            self.kpoints.write_file(file_name="KPOINTS", cwd=directory)
         self.potcar.potcar_set_structure(structure, modified_elements)
         self.potcar.write_file(file_name="POTCAR", cwd=directory)
         # Write the species info in the POSCAR file only if there are no user defined species
@@ -2442,11 +2445,6 @@ class Kpoints(GenericParameters):
         )
         self._path_name = None
         self._n_path = None
-
-    def write_file(self, file_name, cwd=None):
-        if self.file_name == False:
-            return
-        return super().write_file(file_name, cwd)
 
     def set_kpoints_file(
         self, method=None, size_of_mesh=None, shift=None, n_path=None, path=None

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -2442,6 +2442,11 @@ class Kpoints(GenericParameters):
         )
         self._path_name = None
         self._n_path = None
+        
+    def write_file(self, file_name, cwd=None):
+        if self.file_name == False:
+            return
+        return super().write_file(file_name, cwd)
 
     def set_kpoints_file(
         self, method=None, size_of_mesh=None, shift=None, n_path=None, path=None

--- a/tests/vasp/test_vasp.py
+++ b/tests/vasp/test_vasp.py
@@ -446,6 +446,18 @@ class TestVasp(unittest.TestCase):
             job.run(run_mode="manual")
             self.assertEqual(len(w), 0)
 
+    def test_kspacing(self):
+        job_kspace = self.project.create_job("Vasp", "job_kspacing")
+        job_kspace.structure = self.project.create_ase_bulk("Fe")
+        job_kspace.input.incar["KSPACING"] = 0.5
+        with warnings.catch_warnings(record=True) as w:
+            job_kspace.run(run_mode="manual")
+            self.assertNotIn("KPOINTS", job_kspace.list_files(), "'KPOINTS' file written even when "
+                                                                 "KPACING tag is present in INCAR")
+
+            self.assertEqual(len(w), 1)
+            self.assertEqual(str(w[0].message), "'KSPACING' found in INCAR, no KPOINTS file written")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Bcause it is possible to use KSPACING in INCAR and I have to calculate some data in a consistent manner with that setting so I need an option to not write the KPOINTS file.

This is an ugly workaround so I am open to other suggestions. Also it does not get stored in hdf, but the hdf storage of GenericParameters looks mysterious to me and I didn't want to put too much effort into the ugly workaround.

