### PR TITLE
Modify where number of bond types is chosen from

### DIFF
--- a/pyiron_atomistics/lammps/structure.py
+++ b/pyiron_atomistics/lammps/structure.py
@@ -341,7 +341,7 @@ class LammpsStructure(GenericParameters):
             + " \n"
             + "{0} atom types".format(self._structure.get_number_of_species())
             + " \n"
-            + "{0} bond types".format(np.max(bond_type))
+            + "{0} bond types".format(np.max(bonds[:, 2]))
             + " \n"
         )
 

--- a/pyiron_atomistics/lammps/structure.py
+++ b/pyiron_atomistics/lammps/structure.py
@@ -341,7 +341,7 @@ class LammpsStructure(GenericParameters):
             + " \n"
             + "{0} atom types".format(self._structure.get_number_of_species())
             + " \n"
-            + "{0} bond types".format(np.max(bonds[:, 2]))
+            + "{0} bond types".format(np.max(np.array(bonds)[:, 2]))
             + " \n"
         )
 

--- a/pyiron_atomistics/lammps/structure.py
+++ b/pyiron_atomistics/lammps/structure.py
@@ -341,7 +341,7 @@ class LammpsStructure(GenericParameters):
             + " \n"
             + "{0} atom types".format(self._structure.get_number_of_species())
             + " \n"
-            + "{0} bond types".format(np.max(bonds[:, 2]))
+            + "{0} bond types".format(np.max(bond_type))
             + " \n"
         )
 

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -697,16 +697,12 @@ class TestLammps(TestWithCleanProject):
         self.job.structure.bonds = [[1, 2, 1], [1, 3, 2]]
         self.job.potential = potential
         self.job.calc_static()
-        file_directory = os.path.join(
-            self.execution_path, "..", "static", "lammps_test_files"
-        )
-        self.job.restart_file_list.append(
-            os.path.join(file_directory, "dump.out")
-        )
-        self.job.restart_file_list.append(
-            os.path.join(file_directory, "log.lammps")
-        )
         self.job.run(run_mode="manual")
-        self.job.status.collect = True
-        self.job.run()
+
+        bond_str = "2 bond types\n"
+        struct_file = open(self.job.get_workdir_file('structure.inp'), 'r')
+        struct_lines = struct_file.readlines()[4]
+        struct_file.close()
+        self.assertTrue(struct_lines[-1], bond_str)
+
 

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -697,5 +697,16 @@ class TestLammps(TestWithCleanProject):
         self.job.structure.bonds = [[1, 2, 1], [1, 3, 2]]
         self.job.potential = potential
         self.job.calc_static()
+        file_directory = os.path.join(
+            self.execution_path, "..", "static", "lammps_test_files"
+        )
+        self.job.restart_file_list.append(
+            os.path.join(file_directory, "dump.out")
+        )
+        self.job.restart_file_list.append(
+            os.path.join(file_directory, "log.lammps")
+        )
+        self.job.run(run_mode="manual")
+        self.job.status.collect = True
         self.job.run()
 

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -678,3 +678,22 @@ class TestLammps(TestWithCleanProject):
         def setter(x):
             self.job.units = x
         self.assertRaises(ValueError, setter, "nonsense")
+
+    def test_bonds_input(self):
+        potential = pd.DataFrame({'Name': ['Morse'],
+                                  'Filename': [[]],
+                                  'Model'   : ['Morse'],
+                                  'Species' : [['Al']],
+                                  'Config'  : [['bond_coeff 1 0.1 1.5 2.856\n',
+                                                'bond_coeff 2 0.1 1.5 2.856']]})
+        cell = Atoms(elements=4*['Al'], positions=[[0., 0., 0.],
+                                                   [0., 2., 2.],
+                                                   [2., 0., 2.],
+                                                   [2., 2., 0.]],
+                     cell=4*np.eye(3))
+        self.job.structure = cell.repeat(2)
+        self.job.structure.bonds = [[1, 2, 1], [1, 3, 2]]
+        self.job.potential = potential
+        self.job.calc_static()
+        self.job.run()
+

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -684,8 +684,10 @@ class TestLammps(TestWithCleanProject):
                                   'Filename': [[]],
                                   'Model'   : ['Morse'],
                                   'Species' : [['Al']],
-                                  'Config'  : [['bond_coeff 1 0.1 1.5 2.856\n',
-                                                'bond_coeff 2 0.1 1.5 2.856']]})
+                                  'Config'  : [['atom_style bond\n',
+                                                'bond_style morse\n',
+                                                'bond_coeff 1 0.1 1.5 2.0\n',
+                                                'bond_coeff 2 0.1 1.5 2.0']]})
         cell = Atoms(elements=4*['Al'], positions=[[0., 0., 0.],
                                                    [0., 2., 2.],
                                                    [2., 0., 2.],

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -700,9 +700,6 @@ class TestLammps(TestWithCleanProject):
         self.job.run(run_mode="manual")
 
         bond_str = "2 bond types\n"
-        struct_file = open(self.job.get_workdir_file('structure.inp'), 'r')
-        struct_lines = struct_file.readlines()[4]
-        struct_file.close()
-        self.assertTrue(struct_lines[-1], bond_str)
+        self.assertTrue(self.job["structure.inp"][4][-1], bond_str)
 
 


### PR DESCRIPTION
As discussed in the pyiron meeting yesterday (14/03/2022), I changed the variable from which the number of bond types is chosen to be written to the `structure.inp` file.