### PR TITLE
Allow to fix some axes in Murnaghan

### DIFF
--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -301,7 +301,7 @@ class MurnaghanJobGenerator(JobGenerator):
             (list)
         """
         parameter_lst = []
-        axes = np.array([a in self._master.input["axes"] for a in ('x', 'y', 'z')])
+        axes = np.array([a in self._master.input["axes"] for a in ("x", "y", "z")])
         num_axes = sum(axes)
         for strain in np.linspace(
             -self._master.input["vol_range"],
@@ -747,6 +747,15 @@ class Murnaghan(AtomisticParallelMaster):
             return [parameter[1] for parameter in self._job_generator.parameter_list]
         else:
             return []
+
+    def validate_ready_to_run(self):
+        axes = self.input["axes"]
+        if len(set(axes)) != len(axes):
+            raise ValueError("input[\"axes\"] may not contain duplicate entries!")
+        if not (1 <= len(axes) <= 3):
+            raise ValueError("input[\"axes\"] must contain one to three entries!")
+        if set(axes).union(["x", "y", "z"]) != {"x", "y", "z"}:
+            raise ValueError("input[\"axes\"] entries must be one of \"x\", \"y\" or \"z\"!")
 
     def collect_output(self):
         if self.ref_job.server.run_mode.interactive:

--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -304,11 +304,11 @@ class MurnaghanJobGenerator(JobGenerator):
         axes = np.array([a in self._master.input["axes"] for a in ("x", "y", "z")])
         num_axes = sum(axes)
         for strain in np.linspace(
-            -self._master.input["vol_range"],
-            +self._master.input["vol_range"],
+            1 - self._master.input["vol_range"],
+            1 + self._master.input["vol_range"],
             int(self._master.input["num_points"]),
         ):
-            strains = axes * strain**(1.0/num_axes)
+            strains = axes * (strain**(1.0/num_axes) - 1)
             basis = self._master.ref_job.structure.apply_strain(strains, return_box=True)
             parameter_lst.append([np.round(strain, 7), basis])
         return parameter_lst

--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -301,13 +301,15 @@ class MurnaghanJobGenerator(JobGenerator):
             (list)
         """
         parameter_lst = []
+        axes = np.array([a in self._master.input["axes"] for a in ('x', 'y', 'z')])
+        num_axes = sum(axes)
         for strain in np.linspace(
-            1 - self._master.input["vol_range"],
-            1 + self._master.input["vol_range"],
+            -self._master.input["vol_range"],
+            +self._master.input["vol_range"],
             int(self._master.input["num_points"]),
         ):
-            basis = self._master.ref_job.structure.copy()
-            basis.set_cell(basis.cell * strain ** (1.0 / 3.0), scale_atoms=True)
+            strains = axes * strain**(1.0/num_axes)
+            basis = self._master.ref_job.structure.apply_strain(strains, return_box=True)
             parameter_lst.append([np.round(strain, 7), basis])
         return parameter_lst
 
@@ -629,6 +631,7 @@ class Murnaghan(AtomisticParallelMaster):
             0.1,
             "relative volume variation around volume defined by ref_ham",
         )
+        self.input["axes"] = (["x", "y", "z"], "Axes along which the strain will be applied")
 
         self.debye_model = DebyeModel(self)
         self.fit_module = EnergyVolumeFit()

--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 from __future__ import print_function
+from typing import List
 
 import numpy as np
 import scipy.constants
@@ -292,6 +293,17 @@ class DebyeModel(object):
         return atoms_per_cell * val
 
 
+def _strain_axes(structure: Atoms, axes: List[str], volume_strain: float):
+    """
+    Strain box along given axes to achieve given *volumetric* strain.
+
+    Returns a copy.
+    """
+    axes = np.array([a in axes for a in ("x", "y", "z")])
+    num_axes = sum(axes)
+    strains = axes * (volume_strain**(1.0/num_axes) - 1)
+    return structure.apply_strain(strains, return_box=True)
+
 class MurnaghanJobGenerator(JobGenerator):
     @property
     def parameter_list(self):
@@ -301,15 +313,12 @@ class MurnaghanJobGenerator(JobGenerator):
             (list)
         """
         parameter_lst = []
-        axes = np.array([a in self._master.input["axes"] for a in ("x", "y", "z")])
-        num_axes = sum(axes)
         for strain in np.linspace(
             1 - self._master.input["vol_range"],
             1 + self._master.input["vol_range"],
             int(self._master.input["num_points"]),
         ):
-            strains = axes * (strain**(1.0/num_axes) - 1)
-            basis = self._master.ref_job.structure.apply_strain(strains, return_box=True)
+            basis = _strain_axes(self._master.structure, self._master.input["axes"], strain)
             parameter_lst.append([np.round(strain, 7), basis])
         return parameter_lst
 
@@ -892,13 +901,10 @@ class Murnaghan(AtomisticParallelMaster):
             :class:`pyiron_atomistics.atomistics.structure.atoms.Atoms`: requested structure
         """
         if frame == 1:
-            snapshot = self.structure.copy()
-            old_vol = snapshot.get_volume()
+            old_vol = self.structure.get_volume()
             new_vol = self["output/equilibrium_volume"]
-            k = (new_vol / old_vol) ** (1.0 / 3.0)
-            new_cell = snapshot.cell * k
-            snapshot.set_cell(new_cell, scale_atoms=True)
-            return snapshot
+            vol_strain = new_vol / old_vol
+            return _strain_axes(self.structure, self.input["axes"], vol_strain)
         elif frame == 0:
             return self.structure
 

--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -301,8 +301,9 @@ def _strain_axes(structure: Atoms, axes: List[str], volume_strain: float):
     """
     axes = np.array([a in axes for a in ("x", "y", "z")])
     num_axes = sum(axes)
-    strains = axes * (volume_strain**(1.0/num_axes) - 1)
+    strains = axes * (volume_strain ** (1.0 / num_axes) - 1)
     return structure.apply_strain(strains, return_box=True)
+
 
 class MurnaghanJobGenerator(JobGenerator):
     @property
@@ -318,7 +319,9 @@ class MurnaghanJobGenerator(JobGenerator):
             1 + self._master.input["vol_range"],
             int(self._master.input["num_points"]),
         ):
-            basis = _strain_axes(self._master.structure, self._master.input["axes"], strain)
+            basis = _strain_axes(
+                self._master.structure, self._master.input["axes"], strain
+            )
             parameter_lst.append([np.round(strain, 7), basis])
         return parameter_lst
 
@@ -640,7 +643,10 @@ class Murnaghan(AtomisticParallelMaster):
             0.1,
             "relative volume variation around volume defined by ref_ham",
         )
-        self.input["axes"] = (["x", "y", "z"], "Axes along which the strain will be applied")
+        self.input["axes"] = (
+            ["x", "y", "z"],
+            "Axes along which the strain will be applied",
+        )
 
         self.debye_model = DebyeModel(self)
         self.fit_module = EnergyVolumeFit()
@@ -760,11 +766,11 @@ class Murnaghan(AtomisticParallelMaster):
     def validate_ready_to_run(self):
         axes = self.input["axes"]
         if len(set(axes)) != len(axes):
-            raise ValueError("input[\"axes\"] may not contain duplicate entries!")
+            raise ValueError('input["axes"] may not contain duplicate entries!')
         if not (1 <= len(axes) <= 3):
-            raise ValueError("input[\"axes\"] must contain one to three entries!")
+            raise ValueError('input["axes"] must contain one to three entries!')
         if set(axes).union(["x", "y", "z"]) != {"x", "y", "z"}:
-            raise ValueError("input[\"axes\"] entries must be one of \"x\", \"y\" or \"z\"!")
+            raise ValueError('input["axes"] entries must be one of "x", "y" or "z"!')
 
     def collect_output(self):
         if self.ref_job.server.run_mode.interactive:


### PR DESCRIPTION
This simply changes the job generator to apply the strain only along axes that are in `murn.input['axes']`. 