### PR TITLE
Add cache to StructureStorage.get_elements

### DIFF
--- a/pyiron_atomistics/atomistics/structure/structurestorage.py
+++ b/pyiron_atomistics/atomistics/structure/structurestorage.py
@@ -6,6 +6,8 @@
 Alternative structure container that stores them in flattened arrays.
 """
 
+from typing import List
+
 import numpy as np
 
 from pyiron_base import FlattenedStorage
@@ -152,12 +154,12 @@ class StructureStorage(FlattenedStorage, HasStructure):
         if name == "symbols":
             self._element_cache = None
 
-    def get_elements(self):
+    def get_elements(self) -> List[str]:
         """
-        Return a list of chemical elements in the training set.
+        Return a list of chemical elements present in the storage.
 
         Returns:
-            :class:`list`: list of unique elements in the training set as strings of their standard abbreviations
+            :class:`list`: list of unique elements as strings of chemical symbols
         """
         if self._element_cache is None:
             self._element_cache = list(np.unique(self._per_element_arrays["symbols"]))

--- a/tests/atomistics/structure/test_structurestorage.py
+++ b/tests/atomistics/structure/test_structurestorage.py
@@ -29,6 +29,24 @@ class TestContainer(TestWithProject):
         """get_elements() should return all unique chemical elements stored in its structures."""
         self.assertEqual(sorted(self.elements), sorted(self.cont.get_elements()),
                          "Results from get_elements() do not match added elements.")
+        self.assertEqual(
+            sorted(self.cont.get_elements()),
+            sorted(self.elements),
+            "get_elements() returned wrong elements."
+        )
+        cont = self.cont.copy()
+        cont.add_structure(self.project.create.structure.bulk("Fe").repeat(2))
+        self.assertEqual(
+            sorted(cont.get_elements()),
+            sorted(self.elements),
+            "get_elements() returned wrong elements after adding same structure again."
+        )
+        cont.add_structure(self.project.create.structure.bulk("Ag"))
+        self.assertEqual(
+            sorted(cont.get_elements()),
+            sorted(self.elements + ("Ag",)),
+            "get_elements() returned wrong elements after adding new structure."
+        )
 
     def test_set_array(self):
         """set_array should set the arrays for the correct structures and only those."""
@@ -63,26 +81,6 @@ class TestContainer(TestWithProject):
         for s in self.structures:
             self.assertEqual(s, self.cont.get_structure(s.get_chemical_formula()),
                              "get_structure returned wrong structure for given identifier.")
-
-    def test_get_elements(self):
-        self.assertEqual(
-            sorted(self.cont.get_elements()),
-            sorted(self.elements),
-            "get_elements() returned wrong elements."
-        )
-        cont = self.cont.copy()
-        cont.add_structure(self.project.create.structure.bulk("Fe").repeat(2))
-        self.assertEqual(
-            sorted(cont.get_elements()),
-            sorted(self.elements),
-            "get_elements() returned wrong elements after adding same structure again."
-        )
-        cont.add_structure(self.project.create.structure.bulk("Ag"))
-        self.assertEqual(
-            sorted(cont.get_elements()),
-            sorted(self.elements + ("Ag",)),
-            "get_elements() returned wrong elements after adding new structure."
-        )
 
     def test_add_structure(self):
         """add_structure(identifier=None) should set the current structure index as identifier"""

--- a/tests/atomistics/structure/test_structurestorage.py
+++ b/tests/atomistics/structure/test_structurestorage.py
@@ -64,6 +64,26 @@ class TestContainer(TestWithProject):
             self.assertEqual(s, self.cont.get_structure(s.get_chemical_formula()),
                              "get_structure returned wrong structure for given identifier.")
 
+    def test_get_elements(self):
+        self.assertEqual(
+            sorted(self.cont.get_elements()),
+            sorted(self.elements),
+            "get_elements() returned wrong elements."
+        )
+        cont = self.cont.copy()
+        cont.add_structure(self.project.create.structure.bulk("Fe").repeat(2))
+        self.assertEqual(
+            sorted(cont.get_elements()),
+            sorted(self.elements),
+            "get_elements() returned wrong elements after adding same structure again."
+        )
+        cont.add_structure(self.project.create.structure.bulk("Ag"))
+        self.assertEqual(
+            sorted(cont.get_elements()),
+            sorted(self.elements + ("Ag",)),
+            "get_elements() returned wrong elements after adding new structure."
+        )
+
     def test_add_structure(self):
         """add_structure(identifier=None) should set the current structure index as identifier"""
 


### PR DESCRIPTION
This method got quite slow when used on storages with millions of atoms, so I put a cache in front of it.  The method is still slow, but iterating over large storages is usable now.

An alternative would be to save only element indices in the storage and translate them to chemical symbols.  `np.unique` should be much faster on integers, but I haven't checked that and thought it's not necessary so far.