### PR TITLE
Rename unit test workflow

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Unit Tests
 
 on:
   push:


### PR DESCRIPTION
I found it annoying that the workflow for unit tests is labeled "Python Package", so I changed it.