### PR TITLE
Enable boolean indices for SparseList

### DIFF
--- a/pyiron_atomistics/atomistics/structure/sparse_list.py
+++ b/pyiron_atomistics/atomistics/structure/sparse_list.py
@@ -213,9 +213,14 @@ class SparseList(object):
         if max(key) > self._length:
             raise IndexError
 
-
-        for i in key:
-            self._dict[i] = value
+        keys = list(key)
+        if isinstance(keys[0], (bool, np.bool_)):
+            for i, bo in enumerate(keys):
+                if bo:
+                    self._dict[i] = value
+        else:
+            for i in key:
+                self._dict[i] = value
 
     def __delitem__(self, key):
         # programmed for simplicity, not for performance

--- a/pyiron_atomistics/atomistics/structure/sparse_list.py
+++ b/pyiron_atomistics/atomistics/structure/sparse_list.py
@@ -212,9 +212,8 @@ class SparseList(object):
 
         keys = list(key)
         if isinstance(keys[0], (bool, np.bool_)):
-            for i, bo in enumerate(keys):
-                if bo:
-                    self._dict[i] = value
+            for i in np.argwhere(keys).flatten():
+                self._dict[i] = value
         else:
             for i in key:
                 self._dict[i] = value

--- a/pyiron_atomistics/atomistics/structure/sparse_list.py
+++ b/pyiron_atomistics/atomistics/structure/sparse_list.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 import sys
 import copy
 import numpy as np
+from numbers import Integral
 from collections import OrderedDict
 from collections.abc import Sequence
 
@@ -172,7 +173,7 @@ class SparseList(object):
                 yield val
 
     def __getitem__(self, item):
-        if isinstance(item, (int, np.integer)):
+        if isinstance(item, Integral):
             if item in self._dict:
                 return self._dict[item]
             return self._default
@@ -188,7 +189,7 @@ class SparseList(object):
                     if len(item) != len(self):
                         raise IndexError("Length of boolean index does not match indexed list!")
                     ind_list = np.argwhere(item).flatten()
-                elif isinstance(item[0], (int, np.integer)):
+                elif isinstance(item[0], Integral):
                     ind_list = item
         else:
             raise ValueError("Unknown item type: " + str(type(item)))
@@ -199,7 +200,7 @@ class SparseList(object):
         return self.__class__(sliced_dict, default=self._default, length=len(ind_list))
 
     def __setitem__(self, key, value):
-        if isinstance(key, (int, np.integer)):
+        if isinstance(key, Integral):
             if key > len(self):
                 raise IndexError
             self._dict[key] = value
@@ -244,7 +245,7 @@ class SparseList(object):
         return new_list
 
     def __mul__(self, other):
-        if not isinstance(other, (int, np.integer)):
+        if not isinstance(other, Integral):
             raise ValueError("Multiplication defined only for SparseArray*integers")
         overall_list = other * np.arange(len(self)).tolist()
         new_dic = dict()
@@ -254,7 +255,7 @@ class SparseList(object):
         return self.__class__(new_dic, default=self._default, length=other * len(self))
 
     def __rmul__(self, other):
-        if isinstance(other, int):
+        if isinstance(other, Integral):
             return self * other
 
     def __str__(self):
@@ -427,7 +428,7 @@ class SparseArray(object):
 
     def __getitem__(self, item):
         new_dict = {}
-        if isinstance(item, int):
+        if isinstance(item, Integral):
             for key, value in self._lists.items():
                 if value[item] is not None:
                     new_dict[key] = value[item]
@@ -540,7 +541,7 @@ class SparseArray(object):
         return new_array
 
     def __mul__(self, other):
-        if not isinstance(other, int):
+        if not isinstance(other, Integral):
             raise ValueError(
                 "Multiplication with SparseMatrix only implemented for integers"
             )
@@ -552,7 +553,7 @@ class SparseArray(object):
         return new_array
 
     def __rmul__(self, other):
-        if isinstance(other, int):
+        if isinstance(other, Integral):
             return self * other
 
     def add_tag(self, *args, **qwargs):

--- a/pyiron_atomistics/atomistics/structure/sparse_list.py
+++ b/pyiron_atomistics/atomistics/structure/sparse_list.py
@@ -187,10 +187,7 @@ class SparseList(object):
                 if isinstance(item[0], (bool, np.bool_)):
                     if len(item) != len(self):
                         raise IndexError("Length of boolean index does not match indexed list!")
-                    ind_list = []
-                    for i, bo in enumerate(item):
-                        if bo:
-                            ind_list.append(i)
+                    ind_list = np.argwhere(item).flatten()
                 elif isinstance(item[0], (int, np.integer)):
                     ind_list = item
         else:

--- a/pyiron_atomistics/atomistics/structure/sparse_list.py
+++ b/pyiron_atomistics/atomistics/structure/sparse_list.py
@@ -183,13 +183,16 @@ class SparseList(object):
             if len(item) == 0:
                 ind_list = []
             else:
-                if isinstance(item[0], (int, np.integer)):
-                    ind_list = item
-                elif isinstance(item[0], (bool, np.bool_)):
+                # for some reason isinstance(True, int) == True, so check for bools first explicitly
+                if isinstance(item[0], (bool, np.bool_)):
+                    if len(item) != len(self):
+                        raise IndexError("Length of boolean index does not match indexed list!")
                     ind_list = []
                     for i, bo in enumerate(item):
                         if bo:
                             ind_list.append(i)
+                elif isinstance(item[0], (int, np.integer)):
+                    ind_list = item
         else:
             raise ValueError("Unknown item type: " + str(type(item)))
         sliced_dict = {
@@ -209,6 +212,8 @@ class SparseList(object):
 
         if max(key) > self._length:
             raise IndexError
+
+
         for i in key:
             self._dict[i] = value
 

--- a/pyiron_atomistics/atomistics/structure/sparse_list.py
+++ b/pyiron_atomistics/atomistics/structure/sparse_list.py
@@ -187,7 +187,9 @@ class SparseList(object):
                 # for some reason isinstance(True, int) == True, so check for bools first explicitly
                 if isinstance(item[0], (bool, np.bool_)):
                     if len(item) != len(self):
-                        raise IndexError("Length of boolean index does not match indexed list!")
+                        raise IndexError(
+                            "Length of boolean index does not match indexed list!"
+                        )
                     ind_list = np.argwhere(item).flatten()
                 elif isinstance(item[0], Integral):
                     ind_list = item

--- a/tests/atomistics/structure/test_sparse_list.py
+++ b/tests/atomistics/structure/test_sparse_list.py
@@ -53,6 +53,12 @@ class TestSparseList(unittest.TestCase):
                          "Indexing with boolean mask sets wrong values!")
         self.assertEqual(cListModified[1], 0.1,
                          "Indexing with boolean mask sets wrong values!")
+        self.assertNotEqual(cListModified[2], 0.1,
+                         "Indexing with boolean mask sets wrong values!")
+        self.assertNotEqual(cListModified[3], 0.1,
+                         "Indexing with boolean mask sets wrong values!")
+        self.assertNotEqual(cListModified[4], 0.1,
+                         "Indexing with boolean mask sets wrong values!")
 
     def test__setitem__(self):
         self.aList[::2] = True

--- a/tests/atomistics/structure/test_sparse_list.py
+++ b/tests/atomistics/structure/test_sparse_list.py
@@ -44,6 +44,16 @@ class TestSparseList(unittest.TestCase):
         self.assertEqual(self.cList[-1], 0)
         self.assertTrue(isinstance(self.cList[2:4], SparseList))
 
+        self.assertEqual(self.aList[[False, True, False, False, True, False, False]].list(),
+                         [True, True],
+                         "Indexing with boolean mask returns wrong values!")
+        cListModified = self.cList.__copy__()
+        cListModified[[True, True, False, False, False]] = 0.1
+        self.assertEqual(cListModified[0], 0.1,
+                         "Indexing with boolean mask sets wrong values!")
+        self.assertEqual(cListModified[1], 0.1,
+                         "Indexing with boolean mask sets wrong values!")
+
     def test__setitem__(self):
         self.aList[::2] = True
         self.assertEqual(self.aList.list(), [True, True, True, None, True, None, True])


### PR DESCRIPTION
This makes using it for selective dynamics a bit more ergonomic, since you can do something like
```python
structure.selective_dynamics[structure.get_chemical_elements()=='H'] = [True, False, False]
```
directly without calculating the indices yourself.