### PR TITLE
add lstrip() to lines for parsing

### DIFF
--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -607,6 +607,7 @@ class LammpsBase(AtomisticGenericJob):
         if os.path.exists(file_name):
             with open(file_name, "r") as f:
                 f = f.readlines()
+                f = [l.lstrip() for l in f]
                 l_start = np.where([line.startswith("Step") for line in f])[0]
                 l_end = np.where([line.startswith("Loop") for line in f])[0]
                 if len(l_start) > len(l_end):


### PR DESCRIPTION
Some package/lammps version change or similar shifts the line
Step Temp PotEng TotEng Pxx Pxy Pxz Pyy Pyz Pzz Volume
which is used as a trigger for parsing by some whitespace, causing problems.
To generally prevent this lstrip() is applied to all lines read from log.lammps
