### PR TITLE
bugfix for non constraint

### DIFF
--- a/pyiron_atomistics/atomistics/structure/sparse_list.py
+++ b/pyiron_atomistics/atomistics/structure/sparse_list.py
@@ -174,6 +174,9 @@ class SparseList(object):
 
     def __getitem__(self, item):
         if isinstance(item, Integral):
+            if item > len(self):
+                raise IndexError
+            item = item % len(self)
             if item in self._dict:
                 return self._dict[item]
             return self._default
@@ -205,6 +208,7 @@ class SparseList(object):
         if isinstance(key, Integral):
             if key > len(self):
                 raise IndexError
+            key = key % len(self)
             self._dict[key] = value
             return
         elif isinstance(key, slice):

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1832,7 +1832,6 @@ class InputWriter(object):
         """
         state.logger.debug(f"Writing {file_name}")
         if spins_list is None or len(spins_list) == 0:
-            spins_list = []
             state.logger.debug(
                 "Getting magnetic moments via \
                 get_initial_magnetic_moments"
@@ -1855,16 +1854,10 @@ class InputWriter(object):
                         "SPHInX only supports collinear spins at the moment."
                     )
                 else:
-                    for spin, value in zip(
-                        self.structure.spin_constraint[self.id_pyi_to_spx],
-                        self.structure.get_initial_magnetic_moments()[
-                            self.id_pyi_to_spx
-                        ],
-                    ):
-                        if spin:
-                            spins_list.append(str(value))
-                        else:
-                            spins_list.append("X")
+                    constraint = np.asarray(self.structure.spin_constraint)[self.id_pyi_to_spx]
+                    spins = self.structure.get_initial_magnetic_moments()[self.id_pyi_to_spx]
+                    spins_list = np.array([str(v) for v in spins])
+                    spins_list[~constraint] = "X"
                     spins_str = "\n".join(spins_list) + "\n"
         if spins_str is not None:
             if cwd is not None:

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1854,7 +1854,7 @@ class InputWriter(object):
                         "SPHInX only supports collinear spins at the moment."
                     )
                 else:
-                    constraint = np.asarray(self.structure.spin_constraint)[self.id_pyi_to_spx]
+                    constraint = self.structure.spin_constraint[self.id_pyi_to_spx]
                     spins = self.structure.get_initial_magnetic_moments()[self.id_pyi_to_spx]
                     spins_list = np.array([str(v) for v in spins])
                     spins_list[~constraint] = "X"

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1855,10 +1855,11 @@ class InputWriter(object):
                     )
                 else:
                     constraint = self.structure.spin_constraint[self.id_pyi_to_spx]
-                    spins = self.structure.get_initial_magnetic_moments()[self.id_pyi_to_spx]
-                    spins_list = np.array([str(v) for v in spins])
-                    spins_list[~constraint] = "X"
-                    spins_str = "\n".join(spins_list) + "\n"
+                    spins = self.structure.get_initial_magnetic_moments()[
+                        self.id_pyi_to_spx
+                    ].astype(str)
+                    spins[~np.asarray(constraint)] = "X"
+                    spins_str = "\n".join(spins) + "\n"
         if spins_str is not None:
             if cwd is not None:
                 file_name = posixpath.join(cwd, file_name)

--- a/tests/sphinx/test_base.py
+++ b/tests/sphinx/test_base.py
@@ -633,5 +633,16 @@ class TestSphinx(unittest.TestCase):
         self.assertEqual(int(job.input.sphinx.main.ricQN.maxSteps), 250)
         self.assertEqual(int(job.input.sphinx.main.ricQN.bornOppenheimer.scfDiag.maxSteps), 200)
 
+    def test_partial_constraint(self):
+        spx = self.project.create.job.Sphinx('spx_partial_constraint')
+        spx.structure = self.project.create.structure.bulk('Fe', cubic=True)
+        spx.structure.set_initial_magnetic_moments(2 * [2])
+        spx.fix_spin_constraint = True
+        spx.structure.spin_constraint[-1] = False
+        spx.calc_static()
+        spx.server.run_mode.manual = True
+        spx.run()
+        self.assertEqual(spx['spins.in'], ['2\n', 'X\n'])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
SPHInX offers the possibility to not constrain some of the magnetic moments, which could not be activated before this fix, because `SparseList` does not work in the same way as array or list.