### PR TITLE
Lammps velocitiy handling

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -89,7 +89,7 @@ class Atoms(ASEAtoms):
         elements=None,
         dimension=None,
         species=None,
-        **qwargs
+        **qwargs,
     ):
         if symbols is not None:
             if elements is None:
@@ -228,7 +228,8 @@ class Atoms(ASEAtoms):
             self._velocities = val
         else:
             raise ValueError(
-                f"Shape of velocities and positions has to match. Velocities shape: {val.shape}, positions shape: {self.positions.shape}")
+                f"Shape of velocities and positions has to match. Velocities shape: {val.shape}, positions shape: {self.positions.shape}"
+            )
 
     @property
     def spins(self):
@@ -2139,7 +2140,7 @@ class Atoms(ASEAtoms):
                 pse=self._pse,
                 index=index,
                 atoms=self,
-                **new_dict
+                **new_dict,
             )
 
         new_array = super(Atoms, self).__getitem__(item)
@@ -2645,7 +2646,7 @@ class _CrystalStructure(Atoms):
         dimension=3,
         rel_coords=True,
         pse=None,
-        **kwargs
+        **kwargs,
     ):
 
         # print "basis0"

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -215,6 +215,12 @@ class Atoms(ASEAtoms):
             self.dimension = 0
         self._visualize = Visualize(self)
         self._analyse = Analyse(self)
+        # Velocities were not handled at all during file writing
+        self._velocities = None
+
+    @property
+    def velocities(self):
+        return self._velocities
 
     @property
     def spins(self):
@@ -2056,6 +2062,46 @@ class Atoms(ASEAtoms):
             if not len(set(sum_atoms.indices)) == len(sum_atoms.species):
                 raise ValueError("Adding the atom instances went wrong!")
         return self
+
+    def get_momenta(self):
+        """
+        Velocity and momenta functions are currently not supported.
+        For lammps jobs intial velocities can be set using job.structure.velocities = array
+
+        Raises:
+            NotImplementedError: 
+        """        
+        raise NotImplementedError("Currently not used on pyiron atoms")
+    
+    def set_momenta(self):
+        """
+        Velocity and momenta functions are currently not supported.
+        For lammps jobs intial velocities can be set using job.structure.velocities = array
+
+        Raises:
+            NotImplementedError: 
+        """        
+        raise NotImplementedError("Currently not used on pyiron atoms")
+
+    def get_velocities(self):
+        """
+        Velocity and momenta functions are currently not supported.
+        For lammps jobs intial velocities can be set using job.structure.velocities = array
+
+        Raises:
+            NotImplementedError: 
+        """        
+        raise NotImplementedError("Currently not used on pyiron atoms")
+
+    def set_velocities(self):
+        """
+        Velocity and momenta functions are currently not supported.
+        For lammps jobs intial velocities can be set using job.structure.velocities = array
+
+        Raises:
+            NotImplementedError: 
+        """        
+        raise NotImplementedError("Currently not used on pyiron atoms")
 
     __iadd__ = extend
 

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2063,46 +2063,6 @@ class Atoms(ASEAtoms):
                 raise ValueError("Adding the atom instances went wrong!")
         return self
 
-    def get_momenta(self):
-        """
-        Velocity and momenta functions are currently not supported.
-        For lammps jobs intial velocities can be set using job.structure.velocities = array
-
-        Raises:
-            NotImplementedError: 
-        """        
-        raise NotImplementedError("Currently not used on pyiron atoms")
-    
-    def set_momenta(self):
-        """
-        Velocity and momenta functions are currently not supported.
-        For lammps jobs intial velocities can be set using job.structure.velocities = array
-
-        Raises:
-            NotImplementedError: 
-        """        
-        raise NotImplementedError("Currently not used on pyiron atoms")
-
-    def get_velocities(self):
-        """
-        Velocity and momenta functions are currently not supported.
-        For lammps jobs intial velocities can be set using job.structure.velocities = array
-
-        Raises:
-            NotImplementedError: 
-        """        
-        raise NotImplementedError("Currently not used on pyiron atoms")
-
-    def set_velocities(self):
-        """
-        Velocity and momenta functions are currently not supported.
-        For lammps jobs intial velocities can be set using job.structure.velocities = array
-
-        Raises:
-            NotImplementedError: 
-        """        
-        raise NotImplementedError("Currently not used on pyiron atoms")
-
     __iadd__ = extend
 
     def __copy__(self):

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -227,7 +227,8 @@ class Atoms(ASEAtoms):
         if self.positions.shape == val.shape:
             self._velocities = val
         else:
-            raise ValueError("Shape of velocities and positions has to match")
+            raise ValueError(
+                f"Shape of velocities and positions has to match. Velocities shape: {val.shape}, positions shape: {self.positions.shape}")
 
     @property
     def spins(self):

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -8,6 +8,7 @@ from ase.symbols import Symbols as ASESymbols
 import ast
 from copy import copy
 from collections import OrderedDict
+from idna import valid_contextj
 import numpy as np
 import warnings
 import seekpath
@@ -221,6 +222,13 @@ class Atoms(ASEAtoms):
     @property
     def velocities(self):
         return self._velocities
+
+    @velocities.setter
+    def velocities(self, val):
+        if self.positions.shape == val.shape:
+            self._velocities = val
+        else:
+            raise ValueError("Shape of velocities and positions has to match")
 
     @property
     def spins(self):

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -8,7 +8,6 @@ from ase.symbols import Symbols as ASESymbols
 import ast
 from copy import copy
 from collections import OrderedDict
-from idna import valid_contextj
 import numpy as np
 import warnings
 import seekpath

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -1252,24 +1252,6 @@ class LammpsBase(AtomisticGenericJob):
             lmp_structure.cutoff_radius = self.cutoff_radius
         lmp_structure.el_eam_lst = self.input.potential.get_element_lst()
 
-        def structure_to_lammps(structure):
-            """
-            Converts a structure to the Lammps coordinate frame
-
-            Args:
-                structure (pyiron.atomistics.structure.atoms.Atoms): Structure to convert.
-
-            Returns:
-                pyiron.atomistics.structure.atoms.Atoms: Structure with the LAMMPS coordinate frame.
-            """
-            prism = UnfoldingPrism(structure.cell)
-            lammps_structure = structure.copy()
-            lammps_structure.set_cell(prism.A)
-            lammps_structure.positions = np.matmul(structure.positions, prism.R)
-            if lammps_structure.velocities is not None:
-                lammps_structure.velocities = np.matmul(structure.velocities, prism.R)
-            return lammps_structure
-
         if structure is not None:
             lmp_structure.structure = structure_to_lammps(structure)
         else:

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -1243,6 +1243,7 @@ class LammpsBase(AtomisticGenericJob):
 
     def _get_lammps_structure(self, structure=None, cutoff_radius=None):
         lmp_structure = LammpsStructure(bond_dict=self.input.bond_dict)
+        lmp_structure._job = self
         lmp_structure._force_skewed = self.input.control._force_skewed
         lmp_structure.potential = self.input.potential
         lmp_structure.atom_type = self.input.control["atom_style"]

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -1252,6 +1252,23 @@ class LammpsBase(AtomisticGenericJob):
             lmp_structure.cutoff_radius = self.cutoff_radius
         lmp_structure.el_eam_lst = self.input.potential.get_element_lst()
 
+        def structure_to_lammps(structure):
+            """
+            Converts a structure to the Lammps coordinate frame
+
+            Args:
+                structure (pyiron.atomistics.structure.atoms.Atoms): Structure to convert.
+
+            Returns:
+                pyiron.atomistics.structure.atoms.Atoms: Structure with the LAMMPS coordinate frame.
+            """
+            prism = UnfoldingPrism(structure.cell)
+            lammps_structure = structure.copy()
+            lammps_structure.set_cell(prism.A)
+            lammps_structure.positions = np.matmul(structure.positions, prism.R)
+            lammps_structure.velocities = np.matmul(structure.velocities, prism.R)
+            return lammps_structure
+
         if structure is not None:
             lmp_structure.structure = structure_to_lammps(structure)
         else:

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -1266,7 +1266,8 @@ class LammpsBase(AtomisticGenericJob):
             lammps_structure = structure.copy()
             lammps_structure.set_cell(prism.A)
             lammps_structure.positions = np.matmul(structure.positions, prism.R)
-            lammps_structure.velocities = np.matmul(structure.velocities, prism.R)
+            if lammps_structure.velocities is not None:
+                lammps_structure.velocities = np.matmul(structure.velocities, prism.R)
             return lammps_structure
 
         if structure is not None:

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -1242,8 +1242,7 @@ class LammpsBase(AtomisticGenericJob):
         return structure_to_lammps(structure=structure)
 
     def _get_lammps_structure(self, structure=None, cutoff_radius=None):
-        lmp_structure = LammpsStructure(bond_dict=self.input.bond_dict)
-        lmp_structure._job = self
+        lmp_structure = LammpsStructure(bond_dict=self.input.bond_dict, job=self)
         lmp_structure._force_skewed = self.input.control._force_skewed
         lmp_structure.potential = self.input.potential
         lmp_structure.atom_type = self.input.control["atom_style"]

--- a/pyiron_atomistics/lammps/structure.py
+++ b/pyiron_atomistics/lammps/structure.py
@@ -243,12 +243,11 @@ class LammpsStructure(GenericParameters):
             uc = UnitConverter("metal")
             self._structure.velocities *= uc.pyiron_to_lammps("velocity")
             vels = self.rotate_velocities(self._structure)
-            input_str += "\nVelocities\n"
+            input_str += "Velocities\n"
             format_str = "{0:d} {1:f} {2:f} {3:f}\n"
             for id_atom, (x, y, z) in enumerate(vels, start=1):
                 input_str += (
                     format_str.format(id_atom, x, y, z)
-                    + "\n"
                 )
 
         self.load_string(input_str)

--- a/pyiron_atomistics/lammps/structure.py
+++ b/pyiron_atomistics/lammps/structure.py
@@ -237,19 +237,22 @@ class LammpsStructure(GenericParameters):
             input_str = self.structure_charge()
         else:  # self.atom_type == 'atomic'
             input_str = self.structure_atomic()
-        
+
         if self._structure.velocities is not None:
-            # Always assume metal units for now.
             uc = UnitConverter("metal")
             self._structure.velocities *= uc.pyiron_to_lammps("velocity")
             vels = self.rotate_velocities(self._structure)
             input_str += "Velocities\n\n"
-            format_str = "{0:d} {1:f} {2:f} {3:f}\n"
-            for id_atom, (x, y, z) in enumerate(vels, start=1):
-                input_str += (
-                    format_str.format(id_atom, x, y, z)
-                )
-
+            if self._structure.dimension == 3:
+                # Always assume metal units for now.
+                format_str = "{0:d} {1:f} {2:f} {3:f}\n"
+                for id_atom, (x, y, z) in enumerate(vels, start=1):
+                    input_str += format_str.format(id_atom, x, y, z)
+            if self._structure.dimension == 2:
+                # Always assume metal units for now.
+                format_str = "{0:d} {1:f} {2:f}\n"
+                for id_atom, (x, y) in enumerate(vels, start=1):
+                    input_str += format_str.format(id_atom, x, y)
         self.load_string(input_str)
 
     @property

--- a/pyiron_atomistics/lammps/structure.py
+++ b/pyiron_atomistics/lammps/structure.py
@@ -244,7 +244,7 @@ class LammpsStructure(GenericParameters):
             self._structure.velocities *= uc.pyiron_to_lammps("velocity")
             vels = self.rotate_velocities(self._structure)
             input_str += "\nVelocities\n"
-            format_str = "{0:d} {1:d} {2:d} {3:f} {4:f}"
+            format_str = "{0:d} {1:f} {2:f} {3:f}\n"
             for id_atom, (x, y, z) in enumerate(vels, start=1):
                 input_str += (
                     format_str.format(id_atom, x, y, z)

--- a/pyiron_atomistics/lammps/structure.py
+++ b/pyiron_atomistics/lammps/structure.py
@@ -730,6 +730,6 @@ def structure_to_lammps(structure):
     lammps_structure = structure.copy()
     lammps_structure.set_cell(prism.A)
     lammps_structure.positions = np.matmul(structure.positions, prism.R)
-    if structure.velocitiies is not None:
+    if structure.velocities is not None:
         lammps_structure.velocities = np.matmul(structure.velocities, prism.R)
     return lammps_structure

--- a/pyiron_atomistics/lammps/structure.py
+++ b/pyiron_atomistics/lammps/structure.py
@@ -243,7 +243,7 @@ class LammpsStructure(GenericParameters):
             uc = UnitConverter("metal")
             self._structure.velocities *= uc.pyiron_to_lammps("velocity")
             vels = self.rotate_velocities(self._structure)
-            input_str += "Velocities\n"
+            input_str += "Velocities\n\n"
             format_str = "{0:d} {1:f} {2:f} {3:f}\n"
             for id_atom, (x, y, z) in enumerate(vels, start=1):
                 input_str += (

--- a/pyiron_atomistics/lammps/structure.py
+++ b/pyiron_atomistics/lammps/structure.py
@@ -200,6 +200,7 @@ class LammpsStructure(GenericParameters):
         self.digits = 10
         self._bond_dict = bond_dict
         self._force_skewed = False
+        self._job = None
 
     @property
     def potential(self):
@@ -239,17 +240,15 @@ class LammpsStructure(GenericParameters):
             input_str = self.structure_atomic()
 
         if self._structure.velocities is not None:
-            uc = UnitConverter("metal")
+            uc = UnitConverter(self._job.units)
             self._structure.velocities *= uc.pyiron_to_lammps("velocity")
             vels = self.rotate_velocities(self._structure)
             input_str += "Velocities\n\n"
             if self._structure.dimension == 3:
-                # Always assume metal units for now.
                 format_str = "{0:d} {1:f} {2:f} {3:f}\n"
                 for id_atom, (x, y, z) in enumerate(vels, start=1):
                     input_str += format_str.format(id_atom, x, y, z)
             if self._structure.dimension == 2:
-                # Always assume metal units for now.
                 format_str = "{0:d} {1:f} {2:f}\n"
                 for id_atom, (x, y) in enumerate(vels, start=1):
                     input_str += format_str.format(id_atom, x, y)

--- a/pyiron_atomistics/lammps/structure.py
+++ b/pyiron_atomistics/lammps/structure.py
@@ -185,7 +185,7 @@ class LammpsStructure(GenericParameters):
         input_file_name:
     """
 
-    def __init__(self, input_file_name=None, bond_dict=None):
+    def __init__(self, input_file_name=None, bond_dict=None, job=None):
         super(LammpsStructure, self).__init__(
             input_file_name=input_file_name,
             table_name="structure_inp",
@@ -200,7 +200,7 @@ class LammpsStructure(GenericParameters):
         self.digits = 10
         self._bond_dict = bond_dict
         self._force_skewed = False
-        self._job = None
+        self._job = job
 
     @property
     def potential(self):

--- a/tests/lammps/test_structure.py
+++ b/tests/lammps/test_structure.py
@@ -49,7 +49,7 @@ class TestLammpsStructure(TestWithCleanProject):
         self.ref_project.remove_jobs_silently(recursive=True)  # cf. comment in setUp
 
     def test_velocity_basics(self):
-        creator = Creator()
+        creator = Creator(self.project)
         self.job.structure = creator.structure.ase.bulk("Cu")
         self.assertTrue(
             self.job.structure.velocities is None,

--- a/tests/lammps/test_structure.py
+++ b/tests/lammps/test_structure.py
@@ -7,6 +7,7 @@ import os
 from pyiron_base import state, ProjectHDFio
 from pyiron_atomistics.lammps.lammps import Lammps
 from pyiron_base._tests import TestWithCleanProject
+from pyiron_atomistics.project import Creator
 
 # Lammps and pyiron structure clearly require more tests
 class TestLammpsStructure(TestWithCleanProject):
@@ -47,8 +48,9 @@ class TestLammpsStructure(TestWithCleanProject):
         super().tearDown()
         self.ref_project.remove_jobs_silently(recursive=True)  # cf. comment in setUp
 
-    def test__velocity_basics(self):
-        self.job.structure = self.project.create.structure.ase.bulk("Cu")
+    def test_velocity_basics(self):
+        creator = Creator()
+        self.job.structure = creator.structure.ase.bulk("Cu")
         self.assertTrue(
             self.job.structure.velocities is None,
             msg="Initial velocties of structure are not None",

--- a/tests/lammps/test_structure.py
+++ b/tests/lammps/test_structure.py
@@ -67,8 +67,10 @@ class TestLammpsStructure(TestWithCleanProject):
             )
         vels = np.array([[1.0, 1.0, 1.0]])
         self.job.structure.velocities = vels
-        self.assertAlmostEqual(
-            self.job.structure.velocities,
-            vels,
+        self.assertTrue(
+            np.allclose(
+                self.job.structure.velocities,
+                vels
+            ),
             msg="Velocties of structure are not correctly set",
         )

--- a/tests/lammps/test_structure.py
+++ b/tests/lammps/test_structure.py
@@ -59,16 +59,16 @@ class TestLammpsStructure(TestWithCleanProject):
             ValueError,
             msg="Setting velocities with a different shape than positions should raise",
         ):
-            self.structure.velocities = np.array(
+            self.job.structure.velocities = np.array(
                 [
                     [1.0, 1.0, -1.0],
                     [3.0, 2.0, -1.0],
                 ],
             )
         vels = np.array([1.0, 1.0, 1.0])
-        self.structure.velocities = vels
+        self.job.structure.velocities = vels
         self.assertAlmostEqual(
-            self.structure.velocities,
+            self.job.structure.velocities,
             vels,
             msg="Velocties of structure are not correctly set",
         )

--- a/tests/lammps/test_structure.py
+++ b/tests/lammps/test_structure.py
@@ -1,0 +1,57 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import numpy as np
+import os
+from pyiron_base import state, ProjectHDFio
+from pyiron_atomistics.atomistics.structure.atoms import Atoms
+from pyiron_atomistics.lammps.lammps import Lammps
+from pyiron_base._tests import TestWithCleanProject
+
+# Lammps and pyiron structure clearly require more tests
+class TestLammpsStructure(TestWithCleanProject):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.execution_path = os.path.dirname(os.path.abspath(__file__))
+        state.update({'resource_paths': os.path.join(os.path.dirname(os.path.abspath(__file__)), "../static")})
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        state.update()
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.job = Lammps(
+            project=ProjectHDFio(project=self.project, file_name="lammps"),
+            job_name="lammps",
+        )
+        self.ref = Lammps(
+            project=ProjectHDFio(project=self.project, file_name="ref"),
+            job_name="ref",
+        )
+        # Creating jobs this way puts them at the right spot, but decouples them from our self.project instance.
+        # I still don't understand what's happening as deeply as I'd like (at all!) but I've been fighting with it too
+        # long, so for now I will just force the issue by redefining the project attribute(s). -Liam Huber
+        self.project = self.job.project
+        self.ref_project = self.ref.project
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self.ref_project.remove_jobs_silently(recursive=True)    # cf. comment in setUp
+
+    def test__velocity_basics(self):
+        self.job.structure = self.project.create.structure.ase.bulk("Cu")
+        self.assertTrue(self.job.structure.velocities is None, msg="Initial velocties of structure are not None")
+        with self.assertRaises(ValueError):
+            self.structure.velocities = np.array([
+                [1.0, 1.0, -1.0],
+                [3.0, 2.0, -1.0],
+            ],
+            msg = "Setting velocities with a different shape than positions should raise"
+            )
+        vels = np.array([1.0, 1.0, 1.0])
+        self.structure.velocities = vels
+        self.assertAlmostEqual(self.structure.velocities, vels, msg="Velocties of structure are not correctly set")

--- a/tests/lammps/test_structure.py
+++ b/tests/lammps/test_structure.py
@@ -55,13 +55,15 @@ class TestLammpsStructure(TestWithCleanProject):
             self.job.structure.velocities is None,
             msg="Initial velocties of structure are not None",
         )
-        with self.assertRaises(ValueError):
+        with self.assertRaises(
+            ValueError,
+            msg="Setting velocities with a different shape than positions should raise",
+        ):
             self.structure.velocities = np.array(
                 [
                     [1.0, 1.0, -1.0],
                     [3.0, 2.0, -1.0],
                 ],
-                msg="Setting velocities with a different shape than positions should raise",
             )
         vels = np.array([1.0, 1.0, 1.0])
         self.structure.velocities = vels

--- a/tests/lammps/test_structure.py
+++ b/tests/lammps/test_structure.py
@@ -15,7 +15,13 @@ class TestLammpsStructure(TestWithCleanProject):
     def setUpClass(cls):
         super().setUpClass()
         cls.execution_path = os.path.dirname(os.path.abspath(__file__))
-        state.update({'resource_paths': os.path.join(os.path.dirname(os.path.abspath(__file__)), "../static")})
+        state.update(
+            {
+                "resource_paths": os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)), "../static"
+                )
+            }
+        )
 
     @classmethod
     def tearDownClass(cls):
@@ -40,18 +46,26 @@ class TestLammpsStructure(TestWithCleanProject):
 
     def tearDown(self) -> None:
         super().tearDown()
-        self.ref_project.remove_jobs_silently(recursive=True)    # cf. comment in setUp
+        self.ref_project.remove_jobs_silently(recursive=True)  # cf. comment in setUp
 
     def test__velocity_basics(self):
         self.job.structure = self.project.create.structure.ase.bulk("Cu")
-        self.assertTrue(self.job.structure.velocities is None, msg="Initial velocties of structure are not None")
+        self.assertTrue(
+            self.job.structure.velocities is None,
+            msg="Initial velocties of structure are not None",
+        )
         with self.assertRaises(ValueError):
-            self.structure.velocities = np.array([
-                [1.0, 1.0, -1.0],
-                [3.0, 2.0, -1.0],
-            ],
-            msg = "Setting velocities with a different shape than positions should raise"
+            self.structure.velocities = np.array(
+                [
+                    [1.0, 1.0, -1.0],
+                    [3.0, 2.0, -1.0],
+                ],
+                msg="Setting velocities with a different shape than positions should raise",
             )
         vels = np.array([1.0, 1.0, 1.0])
         self.structure.velocities = vels
-        self.assertAlmostEqual(self.structure.velocities, vels, msg="Velocties of structure are not correctly set")
+        self.assertAlmostEqual(
+            self.structure.velocities,
+            vels,
+            msg="Velocties of structure are not correctly set",
+        )

--- a/tests/lammps/test_structure.py
+++ b/tests/lammps/test_structure.py
@@ -5,7 +5,6 @@
 import numpy as np
 import os
 from pyiron_base import state, ProjectHDFio
-from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.lammps.lammps import Lammps
 from pyiron_base._tests import TestWithCleanProject
 

--- a/tests/lammps/test_structure.py
+++ b/tests/lammps/test_structure.py
@@ -65,7 +65,7 @@ class TestLammpsStructure(TestWithCleanProject):
                     [3.0, 2.0, -1.0],
                 ],
             )
-        vels = np.array([1.0, 1.0, 1.0])
+        vels = np.array([[1.0, 1.0, 1.0]])
         self.job.structure.velocities = vels
         self.assertAlmostEqual(
             self.job.structure.velocities,


### PR DESCRIPTION
Implement writing of velocities in lammps data file. Currently only works for metal units and only for lammps, but handling of velocities is completely inconsistent and buggy anyway. I tried to raise NotImplementedError in the ase inherited set and get velocities and momenta functions, but that completely breaks the pyiron atoms class, which is very bad, because right now I can call set_velocities and it will simply do nothing when the structure is written.
I didn't test yet if velocities are correctly written, especially not for skewed structures, but the code runs.