### PR TITLE
Do not reinitialize VaspPotentialFile all the time

### DIFF
--- a/pyiron_atomistics/vasp/potential.py
+++ b/pyiron_atomistics/vasp/potential.py
@@ -376,6 +376,13 @@ class Potcar(GenericParameters):
         self.el_path_lst = list()
         self.el_path_dict = dict()
         self.modified_elements = dict()
+        self._vasp_potentials = None
+
+    @property
+    def vasp_potentials(self):
+        if self._vasp_potentials is None:
+            self._vasp_potentials =  VaspPotentialFile(self.get("xc"))
+        return self._vasp_potentials
 
     def potcar_set_structure(self, structure, modified_elements):
         self._structure = structure
@@ -396,7 +403,6 @@ class Potcar(GenericParameters):
     def _set_default_path_dict(self):
         if self._structure is None:
             return
-        vasp_potentials = VaspPotentialFile(xc=self.get("xc"))
         for i, el_obj in enumerate(self._structure.get_species_objects()):
             if isinstance(el_obj.Parent, str):
                 el = el_obj.Parent
@@ -424,7 +430,6 @@ class Potcar(GenericParameters):
         except tables.exceptions.NoSuchNodeError:
             xc = self.get("xc")
         state.logger.debug("XC: {0}".format(xc))
-        vasp_potentials = VaspPotentialFile(xc=xc)
         for i, el_obj in enumerate(object_list):
             if isinstance(el_obj.Parent, str):
                 el = el_obj.Parent
@@ -435,11 +440,11 @@ class Potcar(GenericParameters):
                 and "pseudo_potcar_file" in el_obj.tags.keys()
             ):
                 new_element = el_obj.tags["pseudo_potcar_file"]
-                vasp_potentials.add_new_element(
+                self.vasp_potentials.add_new_element(
                     parent_element=el, new_element=new_element
                 )
                 el_path = find_potential_file(
-                    path=vasp_potentials.find_default(new_element)["Filename"].values[
+                    path=self.vasp_potentials.find_default(new_element)["Filename"].values[
                         0
                     ][0]
                 )
@@ -450,17 +455,17 @@ class Potcar(GenericParameters):
                 if os.path.isabs(new_element):
                     el_path = new_element
                 else:
-                    vasp_potentials.add_new_element(
+                    self.vasp_potentials.add_new_element(
                         parent_element=el, new_element=new_element
                     )
                     el_path = find_potential_file(
-                        path=vasp_potentials.find_default(new_element)[
+                        path=self.vasp_potentials.find_default(new_element)[
                             "Filename"
                         ].values[0][0]
                     )
             else:
                 el_path = find_potential_file(
-                    path=vasp_potentials.find_default(el)["Filename"].values[0][0]
+                    path=self.vasp_potentials.find_default(el)["Filename"].values[0][0]
                 )
 
             if not (os.path.isfile(el_path)):

--- a/pyiron_atomistics/vasp/potential.py
+++ b/pyiron_atomistics/vasp/potential.py
@@ -411,11 +411,11 @@ class Potcar(GenericParameters):
             if isinstance(el_obj.tags, dict):
                 if "pseudo_potcar_file" in el_obj.tags.keys():
                     new_element = el_obj.tags["pseudo_potcar_file"]
-                    vasp_potentials.add_new_element(
+                    self.vasp_potentials.add_new_element(
                         parent_element=el, new_element=new_element
                     )
-            key = vasp_potentials.find_default(el).Species.values[0][0]
-            val = vasp_potentials.find_default(el).Name.values[0]
+            key = self.vasp_potentials.find_default(el).Species.values[0][0]
+            val = self.vasp_potentials.find_default(el).Name.values[0]
             self[key] = val
 
     def _set_potential_paths(self):

--- a/pyiron_atomistics/vasp/potential.py
+++ b/pyiron_atomistics/vasp/potential.py
@@ -381,7 +381,7 @@ class Potcar(GenericParameters):
     @property
     def vasp_potentials(self):
         if self._vasp_potentials is None:
-            self._vasp_potentials =  VaspPotentialFile(self.get("xc"))
+            self._vasp_potentials = VaspPotentialFile(self.get("xc"))
         return self._vasp_potentials
 
     def potcar_set_structure(self, structure, modified_elements):
@@ -444,9 +444,9 @@ class Potcar(GenericParameters):
                     parent_element=el, new_element=new_element
                 )
                 el_path = find_potential_file(
-                    path=self.vasp_potentials.find_default(new_element)["Filename"].values[
-                        0
-                    ][0]
+                    path=self.vasp_potentials.find_default(new_element)[
+                        "Filename"
+                    ].values[0][0]
                 )
                 if not (os.path.isfile(el_path)):
                     raise ValueError("such a file does not exist in the pp directory")


### PR DESCRIPTION
This speeds up Vasp job creation by a factor 2-3.  The underlying issue is that the logic that looks up POTCARs is quite convoluted and is run multiple times for each instantiated `Potcar`.  I haven't touched that since I don't understand it at all, but by making the `VaspPotentialFile` class an attribute at least some the cost is saved.