### PR TITLE
Drop defaults for Atoms.rotate

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2547,7 +2547,7 @@ class Atoms(ASEAtoms):
         self.spins = magmoms
 
     def rotate(
-        self, a=0.0, v=None, center=(0, 0, 0), rotate_cell=False, index_list=None
+        self, a, v, center=(0, 0, 0), rotate_cell=False, index_list=None
     ):
         """
         Rotate atoms based on a vector and an angle, or two vectors. This function is completely adopted from ASE code
@@ -2555,7 +2555,7 @@ class Atoms(ASEAtoms):
 
         Args:
 
-            a (float/list) in degrees = None:
+            a (float/list) in degrees:
                 Angle that the atoms is rotated around the vecor 'v'. If an angle
                 is not specified, the length of 'v' is used as the angle
                 (default). The angle can also be a vector and then 'v' is rotated


### PR DESCRIPTION
Not passing at least a & v raises an error in ASE.
So while this strictly speaking breaks API, the use case (calling with
less than two arguments) was broken before anyway.