### PR TITLE
Only include necessary POTCARs

### DIFF
--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -109,8 +109,10 @@ class VaspBase(GenericDFTJob):
         """
         GenericDFTJob.structure.fset(self, structure)
         if structure is not None:
+            elements = structure.get_species_symbols().tolist()
+            elements = [el for el in elements if el in structure.get_chemical_symbols()]
             self._potential = VaspPotentialSetter(
-                element_lst=structure.get_species_symbols().tolist()
+                element_lst=elements
             )
 
     @property

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -42,10 +42,7 @@ class VaspInteractive(VaspBase, GenericInteractive):
     @structure.setter
     def structure(self, structure):
         GenericInteractive.structure.fset(self, structure)
-        if structure is not None:
-            self._potential = VaspPotentialSetter(
-                element_lst=structure.get_species_symbols().tolist()
-            )
+        VaspBase.structure.fset(self, structure)
 
     @property
     def interactive_enforce_structure_reset(self):

--- a/pyiron_atomistics/vasp/potential.py
+++ b/pyiron_atomistics/vasp/potential.py
@@ -420,9 +420,13 @@ class Potcar(GenericParameters):
 
     def _set_potential_paths(self):
         element_list = (
-            self._structure.get_species_symbols()
+            el for el in self._structure.get_species_symbols()
+                if el in self._structure.get_chemical_symbols()
         )  # .ElementList.getSpecies()
-        object_list = self._structure.get_species_objects()
+        object_list = [
+            el for el in self._structure.get_species_objects()
+                if el in self._structure.get_chemical_elements()
+        ]
         state.logger.debug("element list: {0}".format(element_list))
         self.el_path_lst = list()
         try:


### PR DESCRIPTION
It can happen that a structure defines more chemical elements on it than are actually present in it.  For example `Atoms(species=['Fe','Al'], indices=[1,1,1,1], ....)` defines a structure with four aluminum inside.  `StructureStorage` does this systematically to ensure that indices of structures from one container are consistent and but it can also happen after deleting atoms from a structure or something similar. 

When a Vasp job sees such a structure it starts writing out POTCARs for all elements defined instead of those that are present.  Since the POSCAR however only has one element present, the calculation ends up using the wrong pseudopotential.

I've made a quick fix by ensuring that only POTCARs of elements present in the structure are written, but it's a bit of a footgun waiting to happen again.  I'm open for other suggestions how to fix this more cleanly.  