### PR TITLE
Fix Input HDF serialization in ScipyOptimizer

### DIFF
--- a/pyiron_atomistics/interactive/scipy_minimizer.py
+++ b/pyiron_atomistics/interactive/scipy_minimizer.py
@@ -293,7 +293,6 @@ class ScipyMinimizer(InteractiveWrapper):
 
 
 class ScipyMinimizerInput(HasStorage):
-
     def __init__(self):
         super().__init__()
         self.storage.table_name = "parameters"
@@ -368,6 +367,7 @@ class ScipyMinimizerInput(HasStorage):
     @volume_only.setter
     def volume_only(self, value: bool):
         self.storage.volume_only = value
+
 
 class ScipyMinimizerOutput(GenericInteractiveOutput):
     def __init__(self, job):

--- a/pyiron_atomistics/interactive/scipy_minimizer.py
+++ b/pyiron_atomistics/interactive/scipy_minimizer.py
@@ -102,7 +102,7 @@ class ScipyMinimizer(InteractiveWrapper):
         self.ref_job.run(delete_existing_job=self._delete_existing_job)
         self.status.running = True
         if self.input.pressure is not None:
-            x0 = np.zeros(sum(self.input.pressure != None))
+            x0 = np.zeros(sum(np.asarray(self.input.pressure) != None))
             if not self.input.volume_only:
                 x0 = np.append(
                     x0, self.ref_job.structure.get_scaled_positions().flatten()

--- a/pyiron_atomistics/interactive/scipy_minimizer.py
+++ b/pyiron_atomistics/interactive/scipy_minimizer.py
@@ -73,7 +73,7 @@ class ScipyMinimizer(InteractiveWrapper):
         super(ScipyMinimizer, self).__init__(project, job_name)
 
         self._ref_job = None
-        self.input = Input()
+        self.input = ScipyMinimizerInput()
         self.output = ScipyMinimizerOutput(job=self)
         self.interactive_cache = {}
         self._delete_existing_job = True
@@ -292,7 +292,7 @@ class ScipyMinimizer(InteractiveWrapper):
         self.input.pressure_tolerance = pressure_tolerance
 
 
-class Input(HasStorage):
+class ScipyMinimizerInput(HasStorage):
 
     def __init__(self):
         super().__init__()

--- a/pyiron_atomistics/interactive/scipy_minimizer.py
+++ b/pyiron_atomistics/interactive/scipy_minimizer.py
@@ -358,8 +358,6 @@ class ScipyMinimizerInput(HasStorage):
     @pressure.setter
     def pressure(self, value: Iterable[float]):
         value = list(value)
-        if len(value) != 6:
-            raise ValueError(f"value must be length 3 iterable not: {value}!")
         self.storage.pressure = value
 
     @property

--- a/pyiron_atomistics/interactive/scipy_minimizer.py
+++ b/pyiron_atomistics/interactive/scipy_minimizer.py
@@ -102,7 +102,7 @@ class ScipyMinimizer(InteractiveWrapper):
         self.ref_job.run(delete_existing_job=self._delete_existing_job)
         self.status.running = True
         if self.input.pressure is not None:
-            x0 = np.zeros(sum(np.asarray(self.input.pressure) != None))
+            x0 = np.zeros(sum(self.input.pressure != None))
             if not self.input.volume_only:
                 x0 = np.append(
                     x0, self.ref_job.structure.get_scaled_positions().flatten()
@@ -350,9 +350,12 @@ class ScipyMinimizerInput(HasStorage):
         self.storage.pressure_tolerance = value
 
     @property
-    def pressure(self) -> List[float]:
+    def pressure(self):
         """float: target pressure"""
-        return self.storage.pressure
+        if isinstance(self.storage.pressure, Iterable):
+            return np.asarray(self.storage.pressure)
+        else:
+            return self.storage.pressure
 
     @pressure.setter
     def pressure(self, value: Iterable[float]):

--- a/pyiron_atomistics/interactive/scipy_minimizer.py
+++ b/pyiron_atomistics/interactive/scipy_minimizer.py
@@ -329,7 +329,7 @@ class ScipyMinimizerInput(HasStorage):
 
     @ionic_force_tolerance.setter
     def ionic_force_tolerance(self, value: float):
-        return self.storage.ionic_force_tolerance
+        self.storage.ionic_force_tolerance = value
 
     @property
     def ionic_energy_tolerance(self) -> float:


### PR DESCRIPTION
This currently blocks [this PR](https://github.com/pyiron/pyiron_base/pull/823) in pyiron_base. 

See the commit messages for detailed description of the issue, but the problem was that the input didn't write itself to the right location in HDF.  This meant also that `ScipyOptimizer` jobs could not be reloaded in the past, therefore I'm not trying to be backwards compatible here.