### PR TITLE
Raise error when incompatible structures are set on interactive jobs

### DIFF
--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -473,7 +473,9 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         old_symbols = self.structure.get_species_symbols()
         new_symbols = structure.get_species_symbols()
         if old_symbols != new_symbols:
-            raise ValueError(f"structure has different chemical symbols than old one: {new_symbols} != {old_symbols}")
+            raise ValueError(
+                f"structure has different chemical symbols than old one: {new_symbols} != {old_symbols}"
+            )
         self._interactive_lib_command("clear")
         self._set_selective_dynamics()
         self._interactive_lib_command("units " + self.input.control["units"])

--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -470,6 +470,10 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             self._logger.debug("interactive run - done")
 
     def interactive_structure_setter(self, structure):
+        old_symbols = self.structure.get_species_symbols()
+        new_symbols = structure.get_species_symbols()
+        if old_symbols != new_symbols:
+            raise ValueError(f"structure has different chemical symbols than old one: {new_symbols} != {old_symbols}")
         self._interactive_lib_command("clear")
         self._set_selective_dynamics()
         self._interactive_lib_command("units " + self.input.control["units"])


### PR DESCRIPTION
If the species_symbols between two structures don't match (including
order) the atom indices written to the job output will be inconsistent.
While the current code takes care to send the correct remapped indices
to lammps the unmapped indices are written to HDF5, therefore on reading
the job output thing will no longer match.

Until this is fixed this error is raised to alert users, that the
results will not match what they expect.

Related issues are #700, #718.