### PR TITLE
Revert "Raise error when incompatible structures are set on interactive jobs"

### DIFF
--- a/pyiron_atomistics/lammps/interactive.py
+++ b/pyiron_atomistics/lammps/interactive.py
@@ -470,12 +470,6 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             self._logger.debug("interactive run - done")
 
     def interactive_structure_setter(self, structure):
-        old_symbols = self.structure.get_species_symbols()
-        new_symbols = structure.get_species_symbols()
-        if old_symbols != new_symbols:
-            raise ValueError(
-                f"structure has different chemical symbols than old one: {new_symbols} != {old_symbols}"
-            )
         self._interactive_lib_command("clear")
         self._set_selective_dynamics()
         self._interactive_lib_command("units " + self.input.control["units"])


### PR DESCRIPTION
Reverts pyiron/pyiron_atomistics#731 since this causes our integration notebooks to fail: 

```python-traceback
---------------------------------------------------------------------------
Exception encountered at "In [5]":
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Input In [5], in <cell line: 8>()
      6 job_int.interactive_water_bonds = True
      7 job_int.calc_static()
----> 8 job_int.run()
      9 job_int.interactive_close()

File /usr/share/miniconda/envs/test/lib/python3.9/site-packages/pyiron_base/utils/deprecate.py:171, in Deprecator.__deprecate_argument.<locals>.decorated(*args, **kwargs)
    161     if kw in self.arguments:
    162         warnings.warn(
    163             message_format.format(
    164                 "{}.{}({}={})".format(
   (...)
    169             stacklevel=2,
    170         )
--> 171 return function(*args, **kwargs)

File /usr/share/miniconda/envs/test/lib/python3.9/site-packages/pyiron_base/jobs/job/generic.py:729, in GenericJob.run(self, delete_existing_job, repair, debug, run_mode, run_again)
    727     self._run_if_repair()
    728 elif status == "initialized":
--> 729     self._run_if_new(debug=debug)
    730 elif status == "created":
    731     self._run_if_created()

File /usr/share/miniconda/envs/test/lib/python3.9/site-packages/pyiron_base/jobs/job/generic.py:1263, in GenericJob._run_if_new(self, debug)
   12[55](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:56) def _run_if_new(self, debug=False):
   12[56](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:57)     """
   12[57](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:58)     Internal helper function the run if new function is called when the job status is 'initialized'. It prepares
   12[58](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:59)     the hdf5 file and the corresponding directory structure.
   (...)
   12[61](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:62)         debug (bool): Debug Mode
   12[62](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:63)     """
-> 12[63](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:64)     run_job_with_status_initialized(job=self, debug=debug)

File /usr/share/miniconda/envs/test/lib/python3.9/site-packages/pyiron_base/jobs/job/runfunction.py:76, in run_job_with_status_initialized(job, debug)
     74 else:
     75     job.save()
---> 76     job.run()

File /usr/share/miniconda/envs/test/lib/python3.9/site-packages/pyiron_base/utils/deprecate.py:171, in Deprecator.__deprecate_argument.<locals>.decorated(*args, **kwargs)
    161     if kw in self.arguments:
    162         warnings.warn(
    163             message_format.format(
    1[64](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:65)                 "{}.{}({}={})".format(
   (...)
    169             stacklevel=2,
    170         )
--> 171 return function(*args, **kwargs)

File /usr/share/miniconda/envs/test/lib/python3.9/site-packages/pyiron_base/jobs/job/generic.py:731, in GenericJob.run(self, delete_existing_job, repair, debug, run_mode, run_again)
    729     self._run_if_new(debug=debug)
    730 elif status == "created":
--> 731     self._run_if_created()
    732 elif status == "submitted":
    733     run_job_with_status_submitted(job=self)

File /usr/share/miniconda/envs/test/lib/python3.9/site-packages/pyiron_base/jobs/job/generic.py:1274, in GenericJob._run_if_created(self)
   12[65](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:66) def _run_if_created(self):
   12[66](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:67)     """
   12[67](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:68)     Internal helper function the run if created function is called when the job status is 'created'. It executes
   12[68](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:69)     the simulation, either in modal mode, meaning waiting for the simulation to finish, manually, or submits the
   (...)
   12[72](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:73)         int: Queue ID - if the job was send to the queue
   12[73](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:74)     """
-> 12[74](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:75)     return run_job_with_status_created(job=self)

File /usr/share/miniconda/envs/test/lib/python3.9/site-packages/pyiron_base/jobs/job/runfunction.py:111, in run_job_with_status_created(job)
    109     job.run_if_scheduler()
    110 elif job.server.run_mode.interactive:
--> 111     job.run_if_interactive()
    112 elif job.server.run_mode.interactive_non_modal:
    113     job.run_if_interactive_non_modal()

File ~/work/pyiron_atomistics/pyiron_atomistics/pyiron_atomistics/lammps/interactive.py:436, in LammpsInteractive.run_if_interactive(self)
    433         counter += 1
    435 else:
--> 436     super(LammpsInteractive, self).run_if_interactive()
    437     self.interactive_execute()
    438     self.interactive_collect()

File ~/work/pyiron_atomistics/pyiron_atomistics/pyiron_atomistics/atomistics/job/interactive.py:125, in GenericInteractive.run_if_interactive(self)
    123     raise ValueError("Input structure not set. Use method set_structure()")
    124 if not self.interactive_is_activated():
--> 125     self.interactive_initialize_interface()
    126 if self._structure_previous is None:
    127     self._structure_previous = self.structure.copy()

File ~/work/pyiron_atomistics/pyiron_atomistics/pyiron_atomistics/lammps/interactive.py:247, in LammpsInteractive.interactive_initialize_interface(self)
    243     self.input.control["boundary"] = " ".join(
    244         ["p" if coord else "f" for coord in self.structure.pbc]
    245     )
    246 self._reset_interactive_run_command()
--> 247 self.interactive_structure_setter(self.structure)

File ~/work/pyiron_atomistics/pyiron_atomistics/pyiron_atomistics/lammps/interactive.py:4[75](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:76), in LammpsInteractive.interactive_structure_setter(self, structure)
    473 old_symbols = self.structure.get_species_symbols()
    474 new_symbols = structure.get_species_symbols()
--> 475 if old_symbols != new_symbols:
    4[76](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:77)     raise ValueError(
    4[77](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:78)         f"structure has different chemical symbols than old one: {new_symbols} != {old_symbols}"
    4[78](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:79)     )
    4[79](https://github.com/pyiron/pyiron_atomistics/runs/8095309307?check_suite_focus=true#step:6:80) self._interactive_lib_command("clear")

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```