### PR TITLE
Short cut ChemicalElement comparison if same object

### DIFF
--- a/pyiron_atomistics/atomistics/structure/periodic_table.py
+++ b/pyiron_atomistics/atomistics/structure/periodic_table.py
@@ -90,7 +90,9 @@ class ChemicalElement(object):
             return self.sub[item]
 
     def __eq__(self, other):
-        if isinstance(other, self.__class__):
+        if self is other:
+            return True
+        elif isinstance(other, self.__class__):
             conditions = list()
             conditions.append(self.sub.to_dict() == other.sub.to_dict())
             return all(conditions)


### PR DESCRIPTION
When replacing species types in large structures a lot of comparisons between `ChemicalElements` are triggered. Previously the equality check was implemented by comparing the *full* data that describes the element.  This is quite costly and not necessary since `ChemicalElements` is now a singleton object.  I have therefore added a short circuit check when the elements compared are the same object.  Since the singleton-ness of `ChemicalElements` can be considered an implementation detail, I've still left the old implementation in place as a fallback.