### PR TITLE
Never let format_black fail

### DIFF
--- a/.github/workflows/format_black.yml
+++ b/.github/workflows/format_black.yml
@@ -28,6 +28,7 @@ jobs:
         git config --local user.email "pyiron@mpie.de"
         git config --local user.name "pyiron-runner"
         git commit -m "Format black" -a
+        exit 0
     - name: push
       uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/format_black.yml
+++ b/.github/workflows/format_black.yml
@@ -27,8 +27,7 @@ jobs:
       run: |
         git config --local user.email "pyiron@mpie.de"
         git config --local user.name "pyiron-runner"
-        git commit -m "Format black" -a
-        exit 0
+        git commit -m "Format black" -a || exit 0
     - name: push
       uses: ad-m/github-push-action@master
       with:


### PR DESCRIPTION
Previously the format_black workflow fails, if the checked code conforms to black already (because git complains that there's nothing to commit). I always exit 0 now, so that this is hopefully silenced.

I'm not sure if exit and such are supported by the workflow template and haven't tested it.