### PR TITLE
Avoid excessive memory allocation when repeating SparseList

### DIFF
--- a/pyiron_atomistics/atomistics/structure/sparse_list.py
+++ b/pyiron_atomistics/atomistics/structure/sparse_list.py
@@ -253,12 +253,13 @@ class SparseList(object):
     def __mul__(self, other):
         if not isinstance(other, Integral):
             raise ValueError("Multiplication defined only for SparseArray*integers")
-        overall_list = other * np.arange(len(self)).tolist()
-        new_dic = dict()
-        for k in self.keys():
-            for val in np.argwhere(np.array(overall_list) == k).flatten():
-                new_dic[val] = self[k]
-        return self.__class__(new_dic, default=self._default, length=other * len(self))
+        new_dict = {}
+        length = len(self)
+        for rep in range(other):
+            offset = rep * length
+            for k in self.keys():
+                new_dict[k + offset] = self[k]
+        return self.__class__(new_dict, default=self._default, length=other * length)
 
     def __rmul__(self, other):
         if isinstance(other, Integral):


### PR DESCRIPTION
Previous code allocated an array and a list for all atoms (not just
entries) in the SparseList and then in a loop repeatedly called np.array
on it, which creates copies.

This gets very expensive when structures are large (>1k atoms) and is
not necessary here.

In the case I had just now this multiplication of the `SparseList` took **70%** of the run time of multiplying structures!  