### PR TITLE
Avoid calling get_chemical_elements in Atoms.select_index

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -674,13 +674,22 @@ class Atoms(ASEAtoms):
         element_indices = []
         for element in el:
             if isinstance(element, str):
-                element_object = self._store_elements[element]
+                try:
+                    element_object = self._store_elements[element]
+                except KeyError:
+                    pass
             elif isinstance(element, ChemicalElement):
                 element_object = element
             else:
                 raise ValueError(f"el must be str, ChemicalElement or an Iterable thereof, not {el}")
-            element_indices.append(self._species_to_index_dict[element_object])
-        return np.where(np.isin(self.indices, element_indices))[0]
+            try:
+                element_indices.append(self._species_to_index_dict[element_object])
+            except KeyError:
+                pass
+        if len(element_indices) > 0:
+            return np.where(np.isin(self.indices, element_indices))[0]
+        else:
+            return np.array([], dtype=int)
 
     def select_parent_index(self, el):
         """

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -668,7 +668,7 @@ class Atoms(ASEAtoms):
         Returns:
             numpy.ndarray: An array of indices of the atoms of the given element
         """
-        if not isinstance(el, Iterable):
+        if not isinstance(el, Iterable) or isinstance(el, str):
             el = (el,)
 
         element_indices = []


### PR DESCRIPTION
select_index needs to check which Atoms in a structure match the passed
in element.  It does so by calling get_chemical_elements and then
compares the ChemicalElement object of each atom in the structure.
get_chemical_elements recreates an array of the chemical element objects
every time it is called.  That costs memory for large structures and is
unnecesary since Atoms.indices keeps a perfectly good array of chemical
indices around at all times.  Therefore the new code translates the
passed in element(s) into the index first then looks up which indices
match the ones in (the already existing) Atoms.indices.

This reduced the time to create  ~5000  structures with 5k to 20k atoms from more than an hour down to 5min.