### PR TITLE
StructurePlots: Correctly label crystal systems

### DIFF
--- a/pyiron_atomistics/atomistics/structure/structurestorage.py
+++ b/pyiron_atomistics/atomistics/structure/structurestorage.py
@@ -373,7 +373,7 @@ class StructurePlots:
             elif num in range(3, 16):
                 return "monoclinic"
             elif num in range(16, 75):
-                return "orthorombic"
+                return "orthorhombic"
             elif num in range(75, 143):
                 return "tetragonal"
             elif num in range(143, 168):

--- a/pyiron_atomistics/atomistics/structure/structurestorage.py
+++ b/pyiron_atomistics/atomistics/structure/structurestorage.py
@@ -375,9 +375,9 @@ class StructurePlots:
             elif num in range(16, 75):
                 return "orthorombic"
             elif num in range(75, 143):
-                return "trigonal"
-            elif num in range(143, 168):
                 return "tetragonal"
+            elif num in range(143, 168):
+                return "trigonal"
             elif num in range(168, 195):
                 return "hexagonal"
             elif num in range(195, 230):


### PR DESCRIPTION
Previously trigonal and tetragonal were swapped