### PR TITLE
Fix off-by-one in space_group plot

### DIFF
--- a/pyiron_atomistics/atomistics/structure/structurestorage.py
+++ b/pyiron_atomistics/atomistics/structure/structurestorage.py
@@ -380,7 +380,7 @@ class StructurePlots:
                 return "trigonal"
             elif num in range(168, 195):
                 return "hexagonal"
-            elif num in range(195, 230):
+            elif num in range(195, 231):
                 return "cubic"
 
         def extract(s):


### PR DESCRIPTION
As everyone knows, there's only two hard problems in computer science:

1. Cache-coherency
2. Naming things
3. Off-by-one errors