### PR TITLE
[minor] update spin evaluation

### DIFF
--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1860,7 +1860,7 @@ class InputWriter(object):
                     spins = self.structure.get_initial_magnetic_moments()[
                         self.id_pyi_to_spx
                     ].astype(str)
-                    spins[~np.asarray(constraint)] = "X"
+                    spins[~np.asarray([bool(c) for c in constraint])] = "X"
                     spins_str = "\n".join(spins) + "\n"
         if spins_str is not None:
             if cwd is not None:


### PR DESCRIPTION
For some reason spin constraints were parse list when the job was aborted and the content was reloaded. This allows for a safer evaluation