### PR TITLE
AseJob: Use pyiron Atoms instead of Ase Atoms

### DIFF
--- a/pyiron_atomistics/gpaw/gpaw.py
+++ b/pyiron_atomistics/gpaw/gpaw.py
@@ -92,7 +92,7 @@ class Gpaw(AseJob, GenericDFTJob):
             kpts=kpoints,
             txt=self.working_directory + "/" + self.job_name + ".txt",
         )
-        self.structure.set_calculator(calc)
+        self.ase_structure.set_calculator(calc)
 
     def to_hdf(self, hdf=None, group_name=None):
         """

--- a/pyiron_atomistics/gpaw/pyiron_ase.py
+++ b/pyiron_atomistics/gpaw/pyiron_ase.py
@@ -8,7 +8,7 @@ import copy
 import importlib
 import numpy as np
 from pyiron_atomistics.atomistics.job.interactive import GenericInteractive
-from pyiron_atomistics.atomistics.structure.atoms import pyiron_to_ase, Atoms as PAtoms
+from pyiron_atomistics.atomistics.structure.atoms import pyiron_to_ase, ase_to_pyiron, Atoms as PAtoms
 
 try:
     from ase.cell import Cell
@@ -103,7 +103,7 @@ class AseJob(GenericInteractive):
 
     @property
     def structure(self):
-        return GenericInteractive.structure.fget(self)
+        return ase_to_pyiron(GenericInteractive.structure.fget(self))
 
     @structure.setter
     def structure(self, structure):
@@ -244,7 +244,7 @@ class AseJob(GenericInteractive):
                             self.output.positions[frame]
                             + self.output.total_displacements[frame]
                         )
-                atoms = Atoms(
+                atoms = PAtoms(
                     symbols=np.array([el_lst[el] for el in indices]),
                     positions=positions,
                     cell=self.output.cells[frame],


### PR DESCRIPTION
Previously AseJob used the Atoms class from ASE internally.  This breaks
expectation of other code in pyiron that `job.structure` is always our
subclass of the Atoms class.  The previous commit added an automatic
conversion from ASE Atoms to ours, but that breaks the internal code of
this class.  As a work around this commit introduces a new attribute
`_ase_atoms` that keeps an ASE Atoms with the calculator attached and
changes the standard `job.structure` to be our Atoms sub class.  They
are kept in sync with the structure setter.