### PR TITLE
Trajectory: ensure remapped_indices is always an array

### DIFF
--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -628,7 +628,7 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
                 sub_struct,
                 center_of_mass=center_of_mass,
                 cells=cells[::stride],
-                indices=remapped_indices[::stride, atom_indices],
+                indices=np.asarray(remapped_indices)[::stride, atom_indices],
             )
 
     def write_traj(


### PR DESCRIPTION
Might fix #605.