### PR TITLE
Selective dynamics in some directions of a VASP POSCAR in ASE Atoms is not supported (pymatgen Structure -> Atoms converter) pymatgen_to_pyiron(structure)

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -3256,19 +3256,21 @@ def pyiron_to_pymatgen(pyiron_obj):
     Returns:
         pymatgen Structure object
     """
+    pyiron_obj_conv = pyiron_obj.copy() # necessary to avoid changing original object
     # This workaround is necessary because ASE refuses to accept limited degrees of freedom in their atoms object
     # e.g. only accepts [T T T] or [F F F] but rejects [T, T, F] etc.
     # Let's just implement this workaround if any selective dynamics are present
     if hasattr(pyiron_obj, "selective_dynamics"):
-        sel_dyn_list = pyiron_obj.copy().selective_dynamics
-        pyiron_obj.selective_dynamics = [True, True, True]
-        ase_obj = pyiron_to_ase(pyiron_obj)
-        pymatgen_obj = AseAtomsAdaptor().get_structure(atoms=ase_obj, cls=None)
-        new_site_properties = pymatgen_obj.site_properties
+
+        sel_dyn_list = pyiron_obj.selective_dynamics
+        pyiron_obj_conv.selective_dynamics = [True, True, True]
+        ase_obj = pyiron_to_ase(pyiron_obj_conv)
+        pymatgen_obj_conv = AseAtomsAdaptor().get_structure(atoms=ase_obj, cls=None)
+        new_site_properties = pymatgen_obj_conv.site_properties
         new_site_properties['selective_dynamics'] = sel_dyn_list
-        pymatgen_obj = pymatgen_obj.copy(site_properties = new_site_properties)
+        pymatgen_obj = pymatgen_obj_conv.copy(site_properties = new_site_properties)
     else:
-        ase_obj = pyiron_to_ase(pyiron_obj.copy())
+        ase_obj = pyiron_to_ase(pyiron_obj_conv)
         _check_if_simple_atoms(atoms=ase_obj)
         pymatgen_obj = AseAtomsAdaptor().get_structure(atoms=ase_obj, cls=None)
     return pymatgen_obj

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -3268,7 +3268,7 @@ def pyiron_to_pymatgen(pyiron_obj):
         new_site_properties['selective_dynamics'] = sel_dyn_list
         pymatgen_obj = pymatgen_obj.copy(site_properties = new_site_properties)
     else:
-        ase_obj = pyiron_to_ase(pyiron_obj)
+        ase_obj = pyiron_to_ase(pyiron_obj.copy())
         _check_if_simple_atoms(atoms=ase_obj)
         pymatgen_obj = AseAtomsAdaptor().get_structure(atoms=ase_obj, cls=None)
     return pymatgen_obj

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -3234,15 +3234,15 @@ def pymatgen_to_pyiron(structure):
     # Have to check for the property explicitly otherwise it just straight crashes
     # Let's just implement this workaround if any selective dynamics are present
     if "selective_dynamics" in structure.site_properties.keys():
-        sel_dyn_list = structure.site_properties['selective_dynamics']
+        sel_dyn_list = structure.site_properties["selective_dynamics"]
         struct = structure.copy()
         struct.remove_site_property("selective_dynamics")
-        pyiron_atoms = ase_to_pyiron(AseAtomsAdaptor().get_atoms(structure = struct))
-        pyiron_atoms.add_tag(selective_dynamics = [True, True, True])
+        pyiron_atoms = ase_to_pyiron(AseAtomsAdaptor().get_atoms(structure=struct))
+        pyiron_atoms.add_tag(selective_dynamics=[True, True, True])
         for i, _ in enumerate(pyiron_atoms):
             pyiron_atoms.selective_dynamics[i] = sel_dyn_list[i]
     else:
-        pyiron_atoms = ase_to_pyiron(AseAtomsAdaptor().get_atoms(structure = structure))
+        pyiron_atoms = ase_to_pyiron(AseAtomsAdaptor().get_atoms(structure=structure))
     return pyiron_atoms
 
 
@@ -3256,7 +3256,7 @@ def pyiron_to_pymatgen(pyiron_obj):
     Returns:
         pymatgen Structure object
     """
-    pyiron_obj_conv = pyiron_obj.copy() # necessary to avoid changing original object
+    pyiron_obj_conv = pyiron_obj.copy()  # necessary to avoid changing original object
     # This workaround is necessary because ASE refuses to accept limited degrees of freedom in their atoms object
     # e.g. only accepts [T T T] or [F F F] but rejects [T, T, F] etc.
     # Let's just implement this workaround if any selective dynamics are present
@@ -3267,8 +3267,8 @@ def pyiron_to_pymatgen(pyiron_obj):
         ase_obj = pyiron_to_ase(pyiron_obj_conv)
         pymatgen_obj_conv = AseAtomsAdaptor().get_structure(atoms=ase_obj, cls=None)
         new_site_properties = pymatgen_obj_conv.site_properties
-        new_site_properties['selective_dynamics'] = sel_dyn_list
-        pymatgen_obj = pymatgen_obj_conv.copy(site_properties = new_site_properties)
+        new_site_properties["selective_dynamics"] = sel_dyn_list
+        pymatgen_obj = pymatgen_obj_conv.copy(site_properties=new_site_properties)
     else:
         ase_obj = pyiron_to_ase(pyiron_obj_conv)
         _check_if_simple_atoms(atoms=ase_obj)

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -3204,17 +3204,30 @@ def _check_if_simple_atoms(atoms):
         warnings.warn("Info is not empty: " + str(atoms.__dict__["info"]))
 
 
-def pymatgen_to_pyiron(pymatgen_obj):
+def pymatgen_to_pyiron(pymatgen):
     """
-    Convert pymatgen atoms object to pyiron atoms object (pymatgen->ASE->pyiron)
+        Convert pymatgen Structure object to pyiron atoms object (pymatgen->ASE->pyiron)
 
     Args:
-        pymatgen_obj: pymatgen atoms object
+        pymatgen_obj: pymatgen Structure object
 
     Returns:
         pyiron atoms object
     """
-    return ase_to_pyiron(AseAtomsAdaptor().get_atoms(structure=pymatgen_obj))
+    # This workaround is necessary because ASE refuses to accept limited degrees of freedom in their atoms object
+    # e.g. only accepts [T T T] or [F F F] but rejects [T, T, F] etc.
+    # Have to check for the property explicitly otherwise it just straight crashes
+    # Let's just implement this workaround if any selective dynamics are present
+    if "selective_dynamics" in pymatgen_obj.site_properties.keys():
+        sel_dyn_list = pymatgen_obj.site_properties['selective_dynamics']
+        pymatgen_obj.remove_site_property("selective_dynamics")
+        pyiron_atoms = ase_to_pyiron(AseAtomsAdaptor().get_atoms(structure = pymatgen_obj))
+        pyiron_atoms.add_tag(selective_dynamics = [True, True, True])
+        for i, _ in enumerate(pyiron_atoms):
+            pyiron_atoms.selective_dynamics[i] = sel_dyn_list[i]
+    else:
+        pyiron_atoms = ase_to_pyiron(AseAtomsAdaptor().get_atoms(structure = pymatgen_obj))
+    return pyiron_atoms
 
 
 def pyiron_to_pymatgen(pyiron_obj):
@@ -3225,11 +3238,25 @@ def pyiron_to_pymatgen(pyiron_obj):
         pyiron_obj: pyiron atoms object
 
     Returns:
-        pymatgen atoms object
+        pymatgen Structure object
     """
-    ase_atoms = pyiron_to_ase(pyiron_obj)
-    _check_if_simple_atoms(atoms=ase_atoms)
-    return AseAtomsAdaptor().get_structure(atoms=ase_atoms, cls=None)
+    # This workaround is necessary because ASE refuses to accept limited degrees of freedom in their atoms object
+    # e.g. only accepts [T T T] or [F F F] but rejects [T, T, F] etc.
+    # Let's just implement this workaround if any selective dynamics are present
+    if hasattr(pyiron_obj, "selective_dynamics"):
+        sel_dyn_list = pyiron_obj.selective_dynamics
+        pyiron_obj.selective_dynamics = [True, True, True]
+        ase_obj = pyiron_to_ase(pyiron_obj)
+
+        pymatgen_obj = AseAtomsAdaptor().get_structure(atoms=ase_obj, cls=None)
+        new_site_properties = pymatgen_obj.site_properties
+        new_site_properties['selective_dynamics'] = sel_dyn_list
+        pymatgen_obj = pymatgen_obj.copy(site_properties = new_site_properties)
+    else:
+        ase_obj = pyiron_to_ase(pyiron_obj)
+        _check_if_simple_atoms(atoms=ase_obj)
+        pymatgen_obj = AseAtomsAdaptor().get_structure(atoms=ase_obj, cls=None)
+    return pymatgen_obj
 
 
 def ovito_to_pyiron(ovito_obj):

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -3204,7 +3204,7 @@ def _check_if_simple_atoms(atoms):
         warnings.warn("Info is not empty: " + str(atoms.__dict__["info"]))
 
 
-def pymatgen_to_pyiron(pymatgen):
+def pymatgen_to_pyiron(structure):
     """
         Convert pymatgen Structure object to pyiron atoms object (pymatgen->ASE->pyiron)
 
@@ -3218,21 +3218,22 @@ def pymatgen_to_pyiron(pymatgen):
     # e.g. only accepts [T T T] or [F F F] but rejects [T, T, F] etc.
     # Have to check for the property explicitly otherwise it just straight crashes
     # Let's just implement this workaround if any selective dynamics are present
-    if "selective_dynamics" in pymatgen_obj.site_properties.keys():
-        sel_dyn_list = pymatgen_obj.site_properties['selective_dynamics']
-        pymatgen_obj.remove_site_property("selective_dynamics")
-        pyiron_atoms = ase_to_pyiron(AseAtomsAdaptor().get_atoms(structure = pymatgen_obj))
+    if "selective_dynamics" in structure.site_properties.keys():
+        sel_dyn_list = structure.site_properties['selective_dynamics']
+        struct = structure.copy()
+        struct.remove_site_property("selective_dynamics")
+        pyiron_atoms = ase_to_pyiron(AseAtomsAdaptor().get_atoms(structure = struct))
         pyiron_atoms.add_tag(selective_dynamics = [True, True, True])
         for i, _ in enumerate(pyiron_atoms):
             pyiron_atoms.selective_dynamics[i] = sel_dyn_list[i]
     else:
-        pyiron_atoms = ase_to_pyiron(AseAtomsAdaptor().get_atoms(structure = pymatgen_obj))
+        pyiron_atoms = ase_to_pyiron(AseAtomsAdaptor().get_atoms(structure = structure))
     return pyiron_atoms
 
 
 def pyiron_to_pymatgen(pyiron_obj):
     """
-    Convert pyiron atoms object to pymatgen atoms object
+    Convert pyiron atoms object to pymatgen Structure object
 
     Args:
         pyiron_obj: pyiron atoms object
@@ -3244,10 +3245,9 @@ def pyiron_to_pymatgen(pyiron_obj):
     # e.g. only accepts [T T T] or [F F F] but rejects [T, T, F] etc.
     # Let's just implement this workaround if any selective dynamics are present
     if hasattr(pyiron_obj, "selective_dynamics"):
-        sel_dyn_list = pyiron_obj.selective_dynamics
+        sel_dyn_list = pyiron_obj.copy().selective_dynamics
         pyiron_obj.selective_dynamics = [True, True, True]
         ase_obj = pyiron_to_ase(pyiron_obj)
-
         pymatgen_obj = AseAtomsAdaptor().get_structure(atoms=ase_obj, cls=None)
         new_site_properties = pymatgen_obj.site_properties
         new_site_properties['selective_dynamics'] = sel_dyn_list

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -7,9 +7,8 @@ import numpy as np
 import os
 import time
 import warnings
-from pyiron_atomistics import ase_to_pyiron
 from pyiron_atomistics.atomistics.structure.atom import Atom
-from pyiron_atomistics.atomistics.structure.atoms import Atoms, CrystalStructure
+from pyiron_atomistics.atomistics.structure.atoms import Atoms, CrystalStructure, ase_to_pyiron, pymatgen_to_pyiron, pyiron_to_pymatgen
 from pyiron_atomistics.atomistics.structure.factory import StructureFactory
 from pyiron_atomistics.atomistics.structure.sparse_list import SparseList
 from pyiron_atomistics.atomistics.structure.periodic_table import element, PeriodicTable, ChemicalElement
@@ -17,7 +16,7 @@ from pyiron_base import FileHDFio, ProjectHDFio, Project
 from ase.cell import Cell as ASECell
 from ase.atoms import Atoms as ASEAtoms
 from ase.build import molecule
-
+from pymatgen.core import Structure
 
 class TestAtoms(unittest.TestCase):
     @classmethod
@@ -1617,6 +1616,132 @@ class TestAtoms(unittest.TestCase):
         # check that again with three elements
         self.assertGreater(dt65 / dt76, expected_speedup_factor,
                             "Atom creation not speed up to the required level by caches!")
+
+    def test_pymatgen_to_pyiron_conversion(self):
+        """
+        Tests pymatgen_to_pyiron conversion functionality (implemented conversion path is pymatgen->ASE->pyiron)
+        Tests:
+        1. If conversion works with no site-specific properties
+        2. Equivalence in selective dynamics tags after conversion if only sel dyn is present
+        3. Checks if other tags are affected when sel dyn is present (magmom is checked)
+        4. Checks if other tags are affected when sel dyn is not present (magmom is checked)
+        """
+
+        coords = [[0, 0, 0], [0.75,0.5,0.75]]
+        lattice = Lattice.from_parameters(a=4.2, b=4.2, c=4.2, alpha=120,
+                                        beta=90, gamma=60)
+        struct = Structure(lattice, ["Fe", "Fe"], coords)
+
+        struct_with_sd = struct.copy()
+        new_site_properties = struct.site_properties
+        new_site_properties['selective_dynamics'] = [[True, False, False] for site in struct]
+        struct_with_sd = struct.copy(site_properties = new_site_properties)
+
+        pyiron_atoms_sd = pymatgen_to_pyiron(struct_with_sd)
+
+        # First test make sure it actually works for structures without sel-dyn
+        pyiron_atoms_no_sd = pymatgen_to_pyiron(struct)
+        # Check that it doesn't have any selective dynamics tags attached when it shouldn't
+        self.assertFalse(
+            hasattr(pyiron_atoms_no_sd, "selective_dynamics"), "It's adding selective dynamics after conversion even when original object doesn't have it"
+        )
+
+        # Second test for equivalence in selective dynamics tags in pyiron Atoms vs pymatgen Structure
+        sd_equivalent = struct_with_sd.site_properties["selective_dynamics"] == [x.selective_dynamics for x in pyiron_atoms_sd]
+        self.assertTrue(
+            sd_equivalent, "Failed equivalence test of selective dynamics tags after conversion"\
+        )
+        
+        # Third test make sure no tags are erased (e.g. magmom) if selective dynamics are present
+        new_site_properties = struct.site_properties
+        new_site_properties['selective_dynamics'] = [[True, False, False] for site in struct]
+        new_site_properties['magmom'] = [0.61 for site in struct]
+        new_site_properties['magmom'][1] = 3.0
+        struct_with_sd_magmom = struct.copy(site_properties = new_site_properties)
+        pyiron_atoms_sd_magmom = pymatgen_to_pyiron(struct_with_sd_magmom)
+        magmom_equivalent = struct_with_sd_magmom.site_properties["magmom"] == [x.spin for x in pyiron_atoms_sd_magmom]
+        sd_equivalent = struct_with_sd_magmom.site_properties["selective_dynamics"] == [x.selective_dynamics for x in pyiron_atoms_sd_magmom]
+        self.assertTrue(
+            magmom_equivalent, "Failed equivalence test of magnetic moment tags if selective dynamics present after conversion (it's messing with other site-specific properties)"\
+        )
+        self.assertTrue(
+            sd_equivalent, "Failed equivalence test of selective dynamics tags if magmom site property is also present"\
+        )
+
+        # Fourth test, make sure if other traits are present (e.g. magmom) but no sel dyn, the conversion works properly (check if magmom is transferred)
+        new_site_properties = struct.site_properties
+        new_site_properties['magmom'] = [0.61 for site in struct]
+        new_site_properties['magmom'][1] = 3.0
+        struct_with_magmom = struct.copy(site_properties = new_site_properties)
+        pyiron_atoms_magmom = pymatgen_to_pyiron(struct_with_magmom)
+        magmom_equivalent = struct_with_magmom.site_properties["magmom"] == [x.spin for x in pyiron_atoms_magmom]
+        self.assertTrue(
+            magmom_equivalent, "Failed to convert site-specific properties (checked magmom spin) when no selective dynamics was present)"\
+        )
+        # Make sure no sel dyn tags are added unnecessarily
+        self.assertFalse(
+            hasattr(pyiron_atoms_magmom, "selective_dynamics")
+        )
+
+    def test_pyiron_to_pymatgen_conversion(self):
+        """
+        Tests pyiron_to_pymatgen conversion functionality (implemented conversion path is pyiron->ASE->pymatgen)
+
+        Tests:
+        1. If conversion works with no site-specific properties
+        2. Equivalence in selective dynamics tags after conversion if only sel dyn is present
+        3. Checks if other tags are affected when sel dyn is present (magmom is checked)
+        4. Checks if other tags are affected when sel dyn is not present (magmom is checked)
+        """
+        pyiron_atoms = StructureFactory().bulk(name = "Fe", crystalstructure = "bcc", a = 4.182) * [1,2,1]
+        
+        # First, check conversion actually works
+        struct = pyiron_to_pymatgen(pyiron_atoms)
+        # Ensure no random selective dynamics are added
+        self.assertFalse(
+            "selective_dynamics" in struct.site_properties
+        )
+
+        # Second, ensure that when only sel_dyn is present (no other site-props present), conversion works
+        pyiron_atoms_sd = pyiron_atoms.copy()
+        pyiron_atoms_sd.add_tag(selective_dynamics = [False, True, True])
+        pyiron_atoms_sd.selective_dynamics[1] = [True, False, False]
+
+        struct_sd = pyiron_to_pymatgen(pyiron_atoms_sd)
+        self.assertTrue(
+            struct_sd.site_properties["selective_dynamics"] == [x.selective_dynamics for x in pyiron_atoms_sd],\
+            "Failed to produce equivalent selective dynamics after conversion!"
+        )
+
+        # Third, ensure when magnetic moment is present without selective dynamics, conversion works and magmom is transferred
+        pyiron_atoms_magmom = pyiron_atoms.copy()
+        pyiron_atoms_magmom.add_tag(spin = 0.61)
+        pyiron_atoms_magmom.spin[1] = 3
+
+        struct_magmom = pyiron_to_pymatgen(pyiron_atoms_magmom)
+        self.assertTrue(
+            struct_magmom.site_properties["magmom"] == [x.spin for x in pyiron_atoms_magmom],\
+            "Failed to produce equivalent magmom when only magmom and no sel_dyn are present!"
+        )
+        self.assertFalse(
+            "selective_dynamics" in struct_magmom.site_properties,\
+            "Failed because selective dynamics was randomly added after conversion!"
+        )
+
+        # Fourth, ensure when both magmom and sd are present, conversion works and magmom+selective dynamics are transferred properly
+        pyiron_atoms_sd_magmom = pyiron_atoms_sd.copy()
+        pyiron_atoms_sd_magmom.add_tag(spin = 0.61)
+        pyiron_atoms_sd_magmom.spin[1] = 3
+
+        struct_sd_magmom = pyiron_to_pymatgen(pyiron_atoms_sd_magmom)
+        self.assertTrue(
+            struct_sd_magmom.site_properties["magmom"] == [x.spin for x in pyiron_atoms_sd_magmom],\
+            "Failed to produce equivalent magmom when both magmom + sel_dyn are present!"
+        )
+        self.assertTrue(
+            struct_sd_magmom.site_properties["selective_dynamics"] == [x.spin for x in pyiron_atoms_sd_magmom],\
+            "Failed to produce equivalent sel_dyn when both magmom + sel_dyn are present!"
+        )
 
 
 def generate_fcc_lattice(a=4.2):

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -1673,7 +1673,7 @@ class TestAtoms(unittest.TestCase):
         )
         # Make sure no sel dyn tags are added unnecessarily
         self.assertFalse(
-            hasattr(pyiron_atoms_magmom, "selective_dynamics")
+            hasattr(pyiron_atoms_magmom, "selective_dynamics"), "selective dynamics are added when there was none in original pymatgen Structure"
         )
 
     def test_pyiron_to_pymatgen_conversion(self):
@@ -1732,7 +1732,7 @@ class TestAtoms(unittest.TestCase):
             "Failed to produce equivalent magmom when both magmom + sel_dyn are present!"
         )
         self.assertTrue(
-            struct_sd_magmom.site_properties["selective_dynamics"] == [x.spin for x in pyiron_atoms_sd_magmom],\
+            struct_sd_magmom.site_properties["selective_dynamics"] == [x.selective_dynamics for x in pyiron_atoms_sd_magmom],\
             "Failed to produce equivalent sel_dyn when both magmom + sel_dyn are present!"
         )
 

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -1736,18 +1736,18 @@ class TestAtoms(unittest.TestCase):
             "Failed to produce equivalent sel_dyn when both magmom + sel_dyn are present!"
         )
 
-    # def test_calc_to_hdf(self):
-    #     """Calculators set on the structure should be properly reloaded after reading from HDF."""
-    #     structure = self.CO2.copy()
-    #     structure.calc = MorsePotential(epsilon=2, r0=2)
-    #     structure.to_hdf(hdf=self.hdf_obj, group_name="structure_w_calc")
-    #     read_structure = self.hdf_obj["structure_w_calc"].to_object()
-    #     for k in structure.calc.parameters:
-    #         self.assertEqual(
-    #                 structure.calc.parameters[k],
-    #                 read_structure.calc.parameters[k],
-    #                 msg=f"Calculator parameter {k} not correctly restored from HDF!"
-    #         )
+    def test_calc_to_hdf(self):
+        """Calculators set on the structure should be properly reloaded after reading from HDF."""
+        structure = self.CO2.copy()
+        structure.calc = MorsePotential(epsilon=2, r0=2)
+        structure.to_hdf(hdf=self.hdf_obj, group_name="structure_w_calc")
+        read_structure = self.hdf_obj["structure_w_calc"].to_object()
+        for k in structure.calc.parameters:
+            self.assertEqual(
+                    structure.calc.parameters[k],
+                    read_structure.calc.parameters[k],
+                    msg=f"Calculator parameter {k} not correctly restored from HDF!"
+            )
 
 def generate_fcc_lattice(a=4.2):
     positions = [[0, 0, 0]]


### PR DESCRIPTION
Fixes #786

---
name: Bug fix
about: Submit a pull request that fixes one or more bugs
title: ''
labels: bug
assignees: ''

---

**Summary**

Checks for selective dynamics tags and implements a workaround for ASE not accepting semi-fixed relaxation selective dynamic tags (e.g. [T T F] is not accepted). So, we follow the suggestion by Marvin in #786

Merging this should hopefully fix #786 completely
