### PR TITLE
Bugfixes in StructurePlot and error handling for Atoms.get_symmetry

### DIFF
--- a/pyiron_atomistics/atomistics/structure/structurestorage.py
+++ b/pyiron_atomistics/atomistics/structure/structurestorage.py
@@ -15,6 +15,7 @@ import pandas as pd
 from pyiron_base import FlattenedStorage, ImportAlarm
 from pyiron_atomistics.atomistics.structure.atom import Atom
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
+from pyiron_atomistics.atomistics.structure.symmetry import SymmetryError
 from pyiron_atomistics.atomistics.structure.neighbors import NeighborsTrajectory
 from pyiron_atomistics.atomistics.structure.has_structure import HasStructure
 
@@ -386,7 +387,7 @@ class StructurePlots:
         def extract(s):
             try:
                 spg = s.get_symmetry(symprec=symprec).spacegroup["Number"]
-            except:
+            except SymmetryError:
                 spg = 1
             return {"space_group": spg, "crystal_system": get_crystal_system(spg)}
 

--- a/pyiron_atomistics/atomistics/structure/structurestorage.py
+++ b/pyiron_atomistics/atomistics/structure/structurestorage.py
@@ -413,7 +413,7 @@ class StructurePlots:
         sort_key = {
             "triclinic": 1,
             "monoclinic": 3,
-            "orthorombic": 16,
+            "orthorhombic": 16,
             "trigonal": 75,
             "tetragonal": 143,
             "hexagonal": 168,

--- a/pyiron_atomistics/atomistics/structure/structurestorage.py
+++ b/pyiron_atomistics/atomistics/structure/structurestorage.py
@@ -414,8 +414,8 @@ class StructurePlots:
             "triclinic": 1,
             "monoclinic": 3,
             "orthorhombic": 16,
-            "trigonal": 75,
-            "tetragonal": 143,
+            "tetragonal": 75,
+            "trigonal": 143,
             "hexagonal": 168,
             "cubic": 195,
         }

--- a/pyiron_atomistics/atomistics/structure/structurestorage.py
+++ b/pyiron_atomistics/atomistics/structure/structurestorage.py
@@ -384,7 +384,10 @@ class StructurePlots:
                 return "cubic"
 
         def extract(s):
-            spg = s.get_symmetry(symprec=symprec).spacegroup["Number"]
+            try:
+                spg = s.get_symmetry(symprec=symprec).spacegroup["Number"]
+            except:
+                spg = 1
             return {"space_group": spg, "crystal_system": get_crystal_system(spg)}
 
         return pd.DataFrame(map(extract, self._store.iter_structures()))

--- a/pyiron_atomistics/atomistics/structure/symmetry.py
+++ b/pyiron_atomistics/atomistics/structure/symmetry.py
@@ -19,8 +19,10 @@ __email__ = "waseda@mpie.de"
 __status__ = "production"
 __date__ = "Sep 1, 2017"
 
+
 class SymmetryError(Exception):
     pass
+
 
 class Symmetry(dict):
 

--- a/pyiron_atomistics/atomistics/structure/symmetry.py
+++ b/pyiron_atomistics/atomistics/structure/symmetry.py
@@ -373,5 +373,6 @@ class Symmetry(dict):
             is_time_reversal=is_time_reversal,
             symprec=self._symprec,
         )
-        if mesh is not None:
+        if mesh is None:
             raise SymmetryError(spglib.spglib.spglib_error.message)
+        return mesh

--- a/pyiron_atomistics/atomistics/structure/symmetry.py
+++ b/pyiron_atomistics/atomistics/structure/symmetry.py
@@ -19,6 +19,8 @@ __email__ = "waseda@mpie.de"
 __status__ = "production"
 __date__ = "Sep 1, 2017"
 
+class SymmetryError(Exception):
+    pass
 
 class Symmetry(dict):
 
@@ -260,11 +262,14 @@ class Symmetry(dict):
 
 
         """
-        return spglib.get_symmetry(
+        sym = spglib.get_symmetry(
             cell=self._get_spglib_cell(),
             symprec=symprec,
             angle_tolerance=angle_tolerance,
         )
+        if sym is None:
+            raise SymmetryError(spglib.spglib.spglib_error.message)
+        return sym
 
     @property
     def info(self):

--- a/tests/atomistics/structure/test_symmetry.py
+++ b/tests/atomistics/structure/test_symmetry.py
@@ -5,6 +5,7 @@
 import unittest
 import numpy as np
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
+from pyiron_atomistics.atomistics.structure.symmetry import SymmetryError
 from pyiron_atomistics.atomistics.structure.factory import StructureFactory
 
 
@@ -135,6 +136,13 @@ class TestAtoms(unittest.TestCase):
         dx_round = np.round(np.absolute(dx), decimals=3)
         self.assertEqual(len(np.unique(dx_round + arg_v)), len(np.unique(arg_v)))
 
+    def test_error(self):
+        """spglib errors should be wrapped in a SymmetryError."""
+
+        structure = StructureFactory().bulk('Al')
+        structure += structure[-1]
+        with self.assertRaises(SymmetryError):
+            structure.get_symmetry()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
There were some small typos in StructurePlots.  Additionally I found that for "weird" structures spglib can run into internal errors when calling get_symmetry.  This then produced unrelated errors in the Symmetry class, because we're not expecting spglib to fail.  So I've added a simple error class and `None` checks.