### PR TITLE
Enable ScipyMinizer without gradients

### DIFF
--- a/pyiron_atomistics/interactive/scipy_minimizer.py
+++ b/pyiron_atomistics/interactive/scipy_minimizer.py
@@ -114,7 +114,7 @@ class ScipyMinimizer(InteractiveWrapper):
             fun=self._get_value,
             x0=x0,
             jac=self._get_gradient if self.input.use_pressure else None,
-            tol=1.0e-20,
+            tol=self.input.ionic_energy_tolerance,
             options={"maxiter": self.input.ionic_steps, "return_all": True},
         )
         self.status.collect = True


### PR DESCRIPTION
Previously this job relied on the reference job providing pressures to do the minimization.  However the underlying minimization method from scipy also offers algorithms that can do without explicit gradients and we have some jobs (sphinx), that do not offer pressure output.  I therefore added a flag that makes the gradient calculation optional.  

Also the tolerance for the minimizer was hardcoded to 1e-20, so I changed it to the `ionic_energy_tolerance`.  Not sure if that's very meaningful, but better than 1e-20.