### PR TITLE
Add warning that Sphinx.calc_minimize does not support pressure

### DIFF
--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -691,6 +691,10 @@ class SphinxBase(GenericDFTJob):
         Loads defaults for all SPHInX input groups, including a
         ricQN-based main Group.
 
+        .. warning::
+            Sphinx does not support volume minimizations!  Calling this method with `pressure` or `volume_only` results
+            in an error.
+
         Args:
             retain_electrostatic_potential:
             retain_charge_density:
@@ -710,7 +714,7 @@ class SphinxBase(GenericDFTJob):
                                   forces (optional)
             volume_only (bool):
         """
-        if pressure is not None:
+        if pressure is not None or volume_only:
             raise NotImplementedError(
                 "pressure minimization is not implemented in SPHInX"
             )


### PR DESCRIPTION
Sphinx does not allow volume relaxations and while the code does throw an error if you pass `pressure`, the docstring doesn't mention this, so I've added a small warning to it.

@samwaseda and I also talked about this a bit from a more general perspective.  I think the current `AtomisticGenericJob.calc_minimize` is too generic.  It promises functionality that not all codes can deliver.  That makes it very difficult to program against `AtomisticGenericJob` as an interface.  He proposed to remove pressure related options from `Sphinx` jobs, but I feel that doesn't solve the problem, i.e. code written against `AtomisticGenericJob` would still fail when passed a `Sphinx` job.  A more intrusive option would be to remove the pressure related parameters from `AtomisticGenericJob`, but allow subclasses to add parameters of their own and then do that in `Vasp` and `Lammps` (the only codes I know that actually can do pressure stuff).  Thoughts?