### PR TITLE
Ipywidgets are only required when building notebooks

### DIFF
--- a/.ci_support/environment-notebooks.yml
+++ b/.ci_support/environment-notebooks.yml
@@ -5,6 +5,7 @@ dependencies:
 - jupyter
 - lammps >=2021.05.27
 - nglview
+- ipywidgets <8  # conflict with NGLview
 - papermill
 - seaborn
 - sphinxdft >=3.0

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -21,5 +21,4 @@ dependencies:
 - seekpath =2.0.1
 - scikit-learn =1.1.2
 - spglib =2.0.1
-- ipywidgets < 8
 - mp-api =0.27.3


### PR DESCRIPTION
By adding `ipywidgets` as dependency in our build environments in https://github.com/pyiron/pyiron_atomistics/pull/729 it is installed for all tests, while before it was only installed when the notebooks were build - this is fixed now. 