### PR TITLE
Properly parse energy states and occupations

### DIFF
--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -2122,9 +2122,7 @@ class _SphinxLogParser:
         return self._n_steps
 
     def _parse_band(self, term):
-        arr = np.loadtxt(
-                re.findall(term, self.log_main, re.MULTILINE)
-        )
+        arr = np.loadtxt(re.findall(term, self.log_main, re.MULTILINE))
         shape = (-1, len(self.k_points), arr.shape[-1])
         if self.spin_enabled:
             shape = (-1, 2, len(self.k_points), shape[-1])

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -2122,11 +2122,8 @@ class _SphinxLogParser:
         return self._n_steps
 
     def _parse_band(self, term):
-        fa = re.findall(term, self.log_main, re.MULTILINE)
-        arr = (
-            np.array(re.sub("[^-0-9\. ]", "", "".join(fa)).split())
-            .astype(float)
-            .reshape(len(fa), -1)
+        arr = np.loadtxt(
+                re.findall(term, self.log_main, re.MULTILINE)
         )
         shape = (-1, len(self.k_points), arr.shape[-1])
         if self.spin_enabled:
@@ -2134,10 +2131,10 @@ class _SphinxLogParser:
         return arr.reshape(shape)
 
     def get_band_energy(self):
-        return self._parse_band("final eig \[eV\].*$")
+        return self._parse_band(f"final eig \[eV\]:(.*)$")
 
     def get_occupancy(self):
-        return self._parse_band("final focc:.*$")
+        return self._parse_band("final focc:(.*)$")
 
     def get_convergence(self):
         conv_dict = {

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -2124,7 +2124,7 @@ class _SphinxLogParser:
     def _parse_band(self, term):
         fa = re.findall(term, self.log_main, re.MULTILINE)
         arr = (
-            np.array(re.sub("[^0-9\. ]", "", "".join(fa)).split())
+            np.array(re.sub("[^-0-9\. ]", "", "".join(fa)).split())
             .astype(float)
             .reshape(len(fa), -1)
         )


### PR DESCRIPTION
Due to a faulty regex previously we threw away the signs of both energy states and occupations parsed from sphinx logs.