### PR TITLE
Make Atoms pickle-able

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atom.py
+++ b/pyiron_atomistics/atomistics/structure/atom.py
@@ -93,7 +93,7 @@ class Atom(ASEAtom, SparseArrayElement):
                 index=index,
             )
         except KeyError:
-            symbol = pse.Parent[symbol]
+            symbol = pse["Parent"][symbol]
             ASEAtom.__init__(
                 self,
                 symbol=symbol,
@@ -120,7 +120,7 @@ class Atom(ASEAtom, SparseArrayElement):
             float: The atomic mass in a.u.
 
         """
-        return float(self.element.AtomicMass)
+        return float(self.element["AtomicMass"])
 
     @property
     def symbol(self):
@@ -131,7 +131,7 @@ class Atom(ASEAtom, SparseArrayElement):
             str: The chemical symbol of the atom
 
         """
-        return self.element.Abbreviation
+        return self.element["Abbreviation"]
 
     @property
     def number(self):
@@ -142,7 +142,7 @@ class Atom(ASEAtom, SparseArrayElement):
             int: The atomic number according to the periodic table
 
         """
-        return self.element.AtomicNumber
+        return self.element["AtomicNumber"]
 
     def __eq__(self, other):
         if not (isinstance(other, Atom)):

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -791,7 +791,7 @@ class Atoms(ASEAtoms):
             numpy.ndarray: A list of atomic numbers
 
         """
-        el_lst = [el.AtomicNumber for el in self.species]
+        el_lst = [el["AtomicNumber"] for el in self.species]
         return np.array([el_lst[el] for el in self.indices])
 
     def get_chemical_symbols(self):
@@ -815,14 +815,16 @@ class Atoms(ASEAtoms):
         """
         sp_parent_list = list()
         for sp in self.species:
-            if isinstance(sp['Parent'], (float, type(None))):
+            if isinstance(sp["Parent"], (float, type(None))):
                 name = sp["Abbreviation"]
+            else:
+                name = sp["Parent"]
             sp_parent_list.append(name)
         return np.array([sp_parent_list[i] for i in self.indices])
 
     def get_parent_basis(self):
         """
-        Returns the basis with all user defined/special elements as the it's parent
+        Returns the basis with all user defined/special elements as their parent elements.
 
         Returns:
             pyiron.atomistics.structure.atoms.Atoms: Structure without any user defined elements
@@ -831,7 +833,8 @@ class Atoms(ASEAtoms):
         parent_basis = copy(self)
         new_species = np.array(parent_basis.species)
         for i, sp in enumerate(new_species):
-            if not isinstance(sp['Parent'], (float, type(None))):
+            parent = sp["Parent"]
+            if not isinstance(parent, (float, type(None))):
                 pse = PeriodicTable()
                 new_species[i] = pse.element(parent)
         sym_list = [el["Abbreviation"] for el in new_species]
@@ -930,7 +933,7 @@ class Atoms(ASEAtoms):
             numpy.ndarray: Array of masses
 
         """
-        el_lst = [el.AtomicMass for el in self.species]
+        el_lst = [el["AtomicMass"] for el in self.species]
         return np.array([el_lst[el] for el in self.indices])
 
     def get_masses_dof(self):
@@ -2083,7 +2086,7 @@ class Atoms(ASEAtoms):
                     ind_conv[ind_old] = ind_new
                 else:
                     new_species_lst.append(el)
-                    sum_atoms._store_elements[el.Abbreviation] = el
+                    sum_atoms._store_elements[el["Abbreviation"]] = el
                     ind_conv[ind_old] = len(new_species_lst) - 1
 
             for key, val in ind_conv.items():

--- a/pyiron_atomistics/atomistics/structure/periodic_table.py
+++ b/pyiron_atomistics/atomistics/structure/periodic_table.py
@@ -153,10 +153,10 @@ class ChemicalElement(object):
         Args:
             hdf (Hdfio): Hdfio object which will be used
         """
-        with hdf.open(self.Abbreviation) as hdf_el:  # "Symbol of the chemical element"
+        with hdf.open(self["Abbreviation"]) as hdf_el:  # "Symbol of the chemical element"
             # TODO: save all parameters that are different from the parent (e.g. modified mass)
-            if self.Parent is not None:
-                self._dataset = {"Parameter": ["Parent"], "Value": [self.Parent]}
+            if self["Parent"] is not None:
+                self._dataset = {"Parameter": ["Parent"], "Value": [self["Parent"]]}
                 hdf_el["elementData"] = self._dataset
             with hdf_el.open(
                 "tagData"
@@ -251,7 +251,7 @@ class PeriodicTable(object):
                 if not new_element.tags["sub_tags"]:
                     del new_element.tags["sub_tags"]
 
-            if new_element.Parent is None:
+            if new_element["Parent"] is None:
                 if not (el in self.dataframe.index.values):
                     raise AssertionError()
                 if len(new_element.sub["tags"]) > 0:
@@ -326,8 +326,8 @@ class PeriodicTable(object):
         if not isinstance(atom_no, int):
             raise ValueError("type not defined: " + str(type(atom_no)))
 
-        return self.Abbreviation[
-            np.nonzero(self.AtomicNumber.to_numpy() == atom_no)[0][0]
+        return self["Abbreviation"][
+            np.nonzero(self["AtomicNumber"].to_numpy() == atom_no)[0][0]
         ]
 
     def add_element(

--- a/pyiron_atomistics/atomistics/structure/periodic_table.py
+++ b/pyiron_atomistics/atomistics/structure/periodic_table.py
@@ -76,11 +76,6 @@ class ChemicalElement(object):
             s for s in dir(self._mendeleev_element) if not s.startswith("_")
         ]
 
-    def __getattr__(self, item):
-        if item in ["__array_struct__", "__array_interface__", "__array__"]:
-            raise AttributeError
-        return self[item]
-
     def __getitem__(self, item):
         if item in self._mendeleev_translation_dict.keys():
             item = self._mendeleev_translation_dict[item]
@@ -88,6 +83,12 @@ class ChemicalElement(object):
             return getattr(self._mendeleev_element, item)
         if item in self.sub.index:
             return self.sub[item]
+
+    def get(self, item, default=None):
+        value = self[item]
+        if value is None:
+            value = default
+        return value
 
     def __eq__(self, other):
         if self is other:
@@ -214,14 +215,17 @@ class PeriodicTable(object):
         self._parent_element = None
         self.el = None
 
-    def __getattr__(self, item):
-        return self[item]
-
     def __getitem__(self, item):
         if item in self.dataframe.columns.values:
             return self.dataframe[item]
         if item in self.dataframe.index.values:
             return self.dataframe.loc[item]
+
+    def get(self, item, default=None):
+        value = self[item]
+        if value is None:
+            value = default
+        return value
 
     def from_hdf(self, hdf):
         """

--- a/tests/atomistics/structure/test_atom.py
+++ b/tests/atomistics/structure/test_atom.py
@@ -19,11 +19,11 @@ class TestAtom(unittest.TestCase):
 
     def test__init__(self):
         self.Fe_atom.rel = True
-        self.assertEqual(self.Fe_atom.element.Abbreviation, "Fe")
+        self.assertEqual(self.Fe_atom.element["Abbreviation"], "Fe")
         self.assertEqual(self.Fe_atom.position.tolist(), [0, 0, 0])
         self.assertEqual(self.Fe_atom.rel, True)
 
-        self.assertEqual(Atom(Z=13).element.Abbreviation, "Al")
+        self.assertEqual(Atom(Z=13).element["Abbreviation"], "Al")
         self.assertRaises(ValueError, Atom, 13)
         self.assertEqual(Atom("Si", (0, 0, 0)).position.tolist(), [0, 0, 0])
 

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -118,10 +118,10 @@ class TestAtoms(unittest.TestCase):
         basis.set_species([el])
         self.assertEqual(basis.get_chemical_formula(), "Pt")
         self.assertTrue(
-            "Al" not in [sp.Abbreviation] for sp in basis._species_to_index_dict.keys()
+            "Al" not in [sp["Abbreviation"] for sp in basis._species_to_index_dict.keys()]
         )
         self.assertTrue(
-            "Pt" in [sp.Abbreviation] for sp in basis._species_to_index_dict.keys()
+            "Pt" in [sp["Abbreviation"] for sp in basis._species_to_index_dict.keys()]
         )
 
     def test_new_array(self):
@@ -203,7 +203,7 @@ class TestAtoms(unittest.TestCase):
         num_list = [1, 12, 13, 6]
         self.assertTrue(
             np.array_equal(
-                [el.Abbreviation for el in self.CO2.numbers_to_elements(num_list)],
+                [el["Abbreviation"] for el in self.CO2.numbers_to_elements(num_list)],
                 ["H", "Mg", "Al", "C"],
             )
         )

--- a/tests/atomistics/structure/test_periodic_table.py
+++ b/tests/atomistics/structure/test_periodic_table.py
@@ -22,56 +22,56 @@ class TestPeriodicTable(unittest.TestCase):
 
     def test_numbertechnic(self):
         el1 = self.pse.element(1)
-        self.assertEqual(el1.Abbreviation, "H")
+        self.assertEqual(el1["Abbreviation"], "H")
 
     def test_Element_by_Abbreviation(self):
         el1 = self.pse.element("Na")
-        self.assertEqual(el1.Abbreviation, "Na")
+        self.assertEqual(el1["Abbreviation"], "Na")
 
     def test_Element_by_Index(self):
         el1 = self.pse.element(20)
-        self.assertEqual(el1.Abbreviation, "Ca")
+        self.assertEqual(el1["Abbreviation"], "Ca")
 
     def test_Abbreviation_range(self):
-        self.assertEqual(len(self.pse.dataframe.Abbreviation[self.pse.Period < 4]), 18)
+        self.assertEqual(len(self.pse.dataframe["Abbreviation"][self.pse["Period"] < 4]), 18)
 
     def test_add_element_without_tags(self):
         fe_up = self.pse.add_element("Fe", "B_up")
-        self.assertEqual(int(fe_up.MeltingPoint), 1808)
+        self.assertEqual(int(fe_up["MeltingPoint"]), 1808)
 
     def test_add_Abbreviation_bug(self):
         fe_up = self.pse.add_element("Fe", "B_up")
-        self.assertEqual(fe_up.Abbreviation, "B_up")
+        self.assertEqual(fe_up["Abbreviation"], "B_up")
 
     def test_add_element_tags(self):
         fe_up = self.pse.add_element(
             "Fe", "Fe_up", spin="up", pseudo_name="GGA", testtag="testtest"
         )
-        self.assertEqual(fe_up.Abbreviation, "Fe_up")
+        self.assertEqual(fe_up["Abbreviation"], "Fe_up")
         self.assertEqual(fe_up.tags["spin"], "up")
         self.assertEqual(fe_up.tags["pseudo_name"], "GGA")
         self.assertEqual(fe_up.tags["testtag"], "testtest")
 
     def test_atomic_mass(self):
         el1 = self.pse.element("Fe")
-        self.assertAlmostEqual(el1.AtomicMass, 55.845, places=3)
+        self.assertAlmostEqual(el1["AtomicMass"], 55.845, places=3)
 
     def test_group(self):
         el1 = self.pse.element("Fe")
-        self.assertEqual(el1.Group, 8)
+        self.assertEqual(el1["Group"], 8)
 
     def test_Period(self):
         el1 = self.pse.element("Fe")
-        self.assertEqual(el1.Period, 4)
+        self.assertEqual(el1["Period"], 4)
 
     def test_add_MeltingPoint(self):
         el1 = self.pse.element("Fe")
-        self.assertEqual(int(el1.MeltingPoint), 1808)
+        self.assertEqual(int(el1["MeltingPoint"]), 1808)
 
     def test_set_item(self):
         el1 = self.pse.element("Fe")
-        el1.MeltingPoint = 1900
-        self.assertEqual(int(el1.MeltingPoint), 1900)
+        el1["MeltingPoint"] = 1900
+        self.assertEqual(int(el1["MeltingPoint"]), 1900)
 
     def test_is_element(self):
         self.assertEqual(self.pse.is_element("Fe"), True)


### PR DESCRIPTION
Previous problems with {,un}pickling Atoms were caused by our unclean overriding of `__getattr__`.  pickle (copy presumably as well) relies on this method to discover where the object in question defines methods that customize this behaviour  (`__reduce_ex__` and `__setstate__`).

That means first that returning `None` indiscriminately on undefined keys from `__getattr__` will break this search, because pickle will try to call `None`s.

Second `__setstate__` will be called on an object just after `__new__` (on copied and unpickled object `__init__` is not called at all).  So when `__getattr__` relies on attributes itself that are only defined in `__init__` this will lead to an infinite regression.

Both of these problems appear on the `ChemicalElements` and `PeriodicTable` classes as used inside `Atoms` and also with `Atoms` itself.  For the first two I have simply removed `__getattr__` and adjusted down-stream code because users are not (or rarely) interacting with it and the additional headache is not worth it, just to cut down some typing.  For `Atoms` accessing tags as attributes is part of the interface, so I have moved those attributes (_tag_list) that cause the regress to be initialized in `__new__`.

Fixes #643, #831.

I'm on vacation for two weeks from tomorrow, so I'll let someone else write a `pickle.loads(pickle.dumps(Atoms(...)))` unit test.