### PR TITLE
[minor] Replace `start_job` by `ref_job` in `SerialMaster`

### DIFF
--- a/pyiron_atomistics/atomistics/master/serial.py
+++ b/pyiron_atomistics/atomistics/master/serial.py
@@ -46,15 +46,15 @@ class SerialMaster(SerialMasterBase, AtomisticGenericJob):
 
     @property
     def structure(self):
-        if self.start_job is not None:
-            return self._start_job.structure
+        if self.ref_job is not None:
+            return self.ref_job.structure
         else:
             return None
 
     @structure.setter
     def structure(self, basis):
-        if self.start_job is not None:
-            self._start_job.structure = basis
+        if self.ref_job is not None:
+            self.ref_job.structure = basis
         else:
             raise ValueError(
                 "A structure can only be set after a start job has been assigned."


### PR DESCRIPTION
I consider this PR as a minor one because I don't see why the same thing should be called `ref_job` in `ParallelMaster` & `InteractiveWrapper` and `start_job` in `SerialMaster` (especially regarding the fact that `ref_job` is also available in `SerialMaster`).