### PR TITLE
Check for negative occupation

### DIFF
--- a/pyiron_atomistics/sphinx/interactive.py
+++ b/pyiron_atomistics/sphinx/interactive.py
@@ -383,7 +383,7 @@ class SphinxOutput(GenericInteractiveOutput):
         n_elec = int(np.ceil(n_elec / 2))
         bands = self._job["output/generic/dft/bands_occ"][-1]
         bands = bands.reshape(-1, bands.shape[-1])
-        max_occ = np.sum(bands > 0, axis=-1).max()
+        max_occ = np.sum(~np.isclose(bands, 0), axis=-1).max()
         n_bands = bands.shape[-1]
         if plot:
             xticks = np.arange(1, n_bands + 1)


### PR DESCRIPTION
For Methfessel-Paxton smearing the occupation of orbitals can be negative.  Checking >0 in check_band_occupancy is therefore not enough.