### PR TITLE
[minor] add warning when job already compressed

### DIFF
--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1426,6 +1426,9 @@ class SphinxBase(GenericDFTJob):
         """
         Collects the outputs and stores them to the hdf file
         """
+        if self.is_compressed:
+            warnings.warn('Job already compressed - output not collected')
+            return
         self._output_parser.collect(directory=self.working_directory)
         self._output_parser.to_hdf(self._hdf5, force_update=force_update)
         if compress_files:

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1427,7 +1427,7 @@ class SphinxBase(GenericDFTJob):
         Collects the outputs and stores them to the hdf file
         """
         if self.is_compressed:
-            warnings.warn('Job already compressed - output not collected')
+            warnings.warn("Job already compressed - output not collected")
             return
         self._output_parser.collect(directory=self.working_directory)
         self._output_parser.to_hdf(self._hdf5, force_update=force_update)

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1426,7 +1426,7 @@ class SphinxBase(GenericDFTJob):
         """
         Collects the outputs and stores them to the hdf file
         """
-        if self.is_compressed:
+        if self.is_compressed():
             warnings.warn("Job already compressed - output not collected")
             return
         self._output_parser.collect(directory=self.working_directory)


### PR DESCRIPTION
`collect_output` should not run when the job is already compressed.