### PR TITLE
Adding `animate` method to Trajectory

### DIFF
--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -370,16 +370,8 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         )
         if repeat is not None:
             traj = traj.transform(lambda s: s.repeat(repeat))
-        animation = nglview.show_asetraj(traj)
-        if spacefill:
-            animation.add_spacefill(radius_type="vdw", scale=0.5, radius=particle_size)
-            animation.remove_ball_and_stick()
-        else:
-            animation.add_ball_and_stick()
-        if show_cell:
-            if self.structure.cell is not None:
-                animation.add_unitcell()
-        animation.camera = camera
+            
+        animation = traj.animate(spacefill, show_cell, center_of_mass, particle_size, camera)
         return animation
 
     def view_structure(self, snapshot=-1, spacefill=True, show_cell=True):
@@ -976,6 +968,55 @@ class Trajectory(HasStructure):
             :class:`~.TransformTrajectory`: trajectory that contains the transformed structures
         """
         return TransformTrajectory(self, transform)
+    
+    def animate(
+        self,
+        spacefill: bool = True,
+        show_cell: bool = True,
+        center_of_mass: bool = False,
+        particle_size: float = 0.5,
+        camera: str = "orthographic",
+        atom_indices: Union[list, np.ndarray] = None,
+        snapshot_indices: Union[list, np.ndarray] = None,
+        repeat: Union[int, Tuple[int, int, int]] = None,
+    ):
+        """
+        Animates the job if a trajectory is present
+
+        Args:
+            spacefill (bool): If True, then atoms are visualized in spacefill stype
+            show_cell (bool): True if the cell boundaries of the structure is to be shown
+            particle_size (float): Scaling factor for the spheres representing the atoms.
+                                    (The radius is determined by the atomic number)
+            center_of_mass (bool): False (default) if the specified positions are w.r.t. the origin
+            camera (str):
+                camera perspective, choose from "orthographic" or "perspective"
+                
+        Returns:
+            animation: nglview IPython widget
+
+        """
+        try:
+            import nglview
+        except ImportError:
+            raise ImportError(
+                "The animate() function requires the package nglview to be installed"
+            )
+
+        if self._number_of_structures <= 1:
+            raise ValueError("job must have more than one structure to animate!")
+
+        animation = nglview.show_asetraj(self)
+        if spacefill:
+            animation.add_spacefill(radius_type="vdw", scale=0.5, radius=particle_size)
+            animation.remove_ball_and_stick()
+        else:
+            animation.add_ball_and_stick()
+        if show_cell:
+            if self.structure.cell is not None:
+                animation.add_unitcell()
+        animation.camera = camera
+        return animation
 
 
 class TransformTrajectory(HasStructure):

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -318,6 +318,8 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         else:
             ValueError("There is no structure attached to the current Job.")
 
+    @deprecate("Call animate_structures() instead.  Arguments stride/center_of_mass/atom_indices/snapshot_indices/repeat "
+               "can be emulated by calling trajectory() first.")
     def animate_structure(
         self,
         spacefill: bool = True,
@@ -352,12 +354,6 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
             animation: nglview IPython widget
 
         """
-        try:
-            import nglview
-        except ImportError:
-            raise ImportError(
-                "The animate() function requires the package nglview to be installed"
-            )
 
         if self.number_of_structures <= 1:
             raise ValueError("job must have more than one structure to animate!")
@@ -371,7 +367,7 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         if repeat is not None:
             traj = traj.transform(lambda s: s.repeat(repeat))
 
-        animation = traj.animate(
+        animation = traj.animate_structures(
             spacefill, show_cell, center_of_mass, particle_size, camera
         )
         return animation
@@ -970,52 +966,6 @@ class Trajectory(HasStructure):
             :class:`~.TransformTrajectory`: trajectory that contains the transformed structures
         """
         return TransformTrajectory(self, transform)
-
-    def animate(
-        self,
-        spacefill: bool = True,
-        show_cell: bool = True,
-        center_of_mass: bool = False,
-        particle_size: float = 0.5,
-        camera: str = "orthographic",
-    ):
-        """
-        Animates the job if a trajectory is present
-
-        Args:
-            spacefill (bool): If True, then atoms are visualized in spacefill stype
-            show_cell (bool): True if the cell boundaries of the structure is to be shown
-            particle_size (float): Scaling factor for the spheres representing the atoms.
-                                    (The radius is determined by the atomic number)
-            center_of_mass (bool): False (default) if the specified positions are w.r.t. the origin
-            camera (str):
-                camera perspective, choose from "orthographic" or "perspective"
-
-        Returns:
-            animation: nglview IPython widget
-
-        """
-        try:
-            import nglview
-        except ImportError:
-            raise ImportError(
-                "The animate() function requires the package nglview to be installed"
-            )
-
-        if self._number_of_structures <= 1:
-            raise ValueError("job must have more than one structure to animate!")
-
-        animation = nglview.show_asetraj(self)
-        if spacefill:
-            animation.add_spacefill(radius_type="vdw", scale=0.5, radius=particle_size)
-            animation.remove_ball_and_stick()
-        else:
-            animation.add_ball_and_stick()
-        if show_cell:
-            if self.structure.cell is not None:
-                animation.add_unitcell()
-        animation.camera = camera
-        return animation
 
 
 class TransformTrajectory(HasStructure):

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -318,8 +318,10 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         else:
             ValueError("There is no structure attached to the current Job.")
 
-    @deprecate("Call animate_structures() instead.  Arguments stride/center_of_mass/atom_indices/snapshot_indices/repeat "
-               "can be emulated by calling trajectory() first.")
+    @deprecate(
+        "Call animate_structures() instead.  Arguments stride/center_of_mass/atom_indices/snapshot_indices/repeat "
+        "can be emulated by calling trajectory() first."
+    )
     def animate_structure(
         self,
         spacefill: bool = True,

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -975,11 +975,8 @@ class Trajectory(HasStructure):
         show_cell: bool = True,
         center_of_mass: bool = False,
         particle_size: float = 0.5,
-        camera: str = "orthographic",
-        atom_indices: Union[list, np.ndarray] = None,
-        snapshot_indices: Union[list, np.ndarray] = None,
-        repeat: Union[int, Tuple[int, int, int]] = None,
-    ):
+        camera: str = "orthographic"
+        ):
         """
         Animates the job if a trajectory is present
 

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -370,8 +370,10 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         )
         if repeat is not None:
             traj = traj.transform(lambda s: s.repeat(repeat))
-            
-        animation = traj.animate(spacefill, show_cell, center_of_mass, particle_size, camera)
+
+        animation = traj.animate(
+            spacefill, show_cell, center_of_mass, particle_size, camera
+        )
         return animation
 
     def view_structure(self, snapshot=-1, spacefill=True, show_cell=True):
@@ -968,15 +970,15 @@ class Trajectory(HasStructure):
             :class:`~.TransformTrajectory`: trajectory that contains the transformed structures
         """
         return TransformTrajectory(self, transform)
-    
+
     def animate(
         self,
         spacefill: bool = True,
         show_cell: bool = True,
         center_of_mass: bool = False,
         particle_size: float = 0.5,
-        camera: str = "orthographic"
-        ):
+        camera: str = "orthographic",
+    ):
         """
         Animates the job if a trajectory is present
 
@@ -988,7 +990,7 @@ class Trajectory(HasStructure):
             center_of_mass (bool): False (default) if the specified positions are w.r.t. the origin
             camera (str):
                 camera perspective, choose from "orthographic" or "perspective"
-                
+
         Returns:
             animation: nglview IPython widget
 

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -367,6 +367,9 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         if repeat is not None:
             traj = traj.transform(lambda s: s.repeat(repeat))
 
+        if self.structure.cell is None:
+            show_cell = False
+
         animation = traj.animate_structures(
             spacefill, show_cell, center_of_mass, particle_size, camera
         )

--- a/pyiron_atomistics/atomistics/structure/has_structure.py
+++ b/pyiron_atomistics/atomistics/structure/has_structure.py
@@ -192,8 +192,7 @@ class HasStructure(ABC):
         else:
             animation.add_ball_and_stick()
         if show_cell:
-            if self.structure.cell is not None:
-                animation.add_unitcell()
+            animation.add_unitcell()
         animation.camera = camera
         return animation
 

--- a/pyiron_atomistics/atomistics/structure/has_structure.py
+++ b/pyiron_atomistics/atomistics/structure/has_structure.py
@@ -182,7 +182,7 @@ class HasStructure(ABC):
             animation: nglview IPython widget
         """
 
-        if self._number_of_structures <= 1:
+        if self._number_of_structures() <= 1:
             raise ValueError("job must have more than one structure to animate!")
 
         animation = nglview.show_asetraj(_TrajectoryAdapter(self))


### PR DESCRIPTION
- Within the ´animate´ method inside the Trajectory class, it wasn't possible to include ´stride´, ´atom_indices´, ´snapshot_indices´ or ´repeat´ arguments.