### PR TITLE
Rename master to main

### DIFF
--- a/.github/delete-merged-branch-config.yml
+++ b/.github/delete-merged-branch-config.yml
@@ -1,3 +1,3 @@
 exclude: 
-  - master
+  - main
 delete_closed_pr: false

--- a/.github/workflows/UpdateDependabotPR.yml
+++ b/.github/workflows/UpdateDependabotPR.yml
@@ -2,7 +2,7 @@ name: UpdateDependabotPR
 
 on:
   pull_request_target:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/backwards.yml
+++ b/.github/workflows/backwards.yml
@@ -4,9 +4,9 @@ name: Backwards
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,9 +4,9 @@ name: Benchmark tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   benchmark:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -5,9 +5,9 @@ name: Black
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,9 @@ name: Docs
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,9 +4,9 @@ name: Notebooks for Integration Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     types: [labeled, opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/integration_unittests.yml
+++ b/.github/workflows/integration_unittests.yml
@@ -5,9 +5,9 @@ name: Integration Tests using Unittest
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     types: [labeled, opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/label_integration.yml
+++ b/.github/workflows/label_integration.yml
@@ -8,7 +8,7 @@
 name: Automatic Labeler
 on: 
   pull_request:
-      branches: [ master ]
+      branches: [ main ]
 
 jobs:
   label:

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -4,9 +4,9 @@ name: Notebooks
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/pypicheck.yml
+++ b/.github/workflows/pypicheck.yml
@@ -4,9 +4,9 @@ name: Pip check
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -4,9 +4,9 @@ name: Unittests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -300,8 +300,8 @@ Build status
 
 The build status for pyiron and all sub packages are given below
 
-.. image:: https://coveralls.io/repos/github/pyiron/pyiron/badge.svg?branch=master
-    :target: https://coveralls.io/github/pyiron/pyiron?branch=master
+.. image:: https://coveralls.io/repos/github/pyiron/pyiron/badge.svg?branch=main
+    :target: https://coveralls.io/github/pyiron/pyiron?branch=main
     :alt: Coverage Status
 
 .. image:: https://api.codacy.com/project/badge/Grade/c513254f10004df5a1f5c76425c6584b
@@ -312,7 +312,7 @@ The build status for pyiron and all sub packages are given below
     :target: https://anaconda.org/conda-forge/pyiron/
     :alt: Release_Date
 
-.. image:: https://travis-ci.org/pyiron/pyiron.svg?branch=master
+.. image:: https://travis-ci.org/pyiron/pyiron.svg?branch=main
     :target: https://travis-ci.org/pyiron/pyiron
     :alt: Build Status
 
@@ -341,15 +341,15 @@ For the automated versioning we use::
 
 So the configuration of the release is included in setup.cfg::
 
-   https://github.com/pyiron/pyiron_base/blob/master/setup.cfg
+   https://github.com/pyiron/pyiron_base/blob/main/setup.cfg
 
 As the pyiron packages are pure python packages – we use only the Linux Python 3.7 job to build the packages, as defined in the .travis.yml file::
 
-   https://github.com/pyiron/pyiron_base/blob/master/.travis.yml
+   https://github.com/pyiron/pyiron_base/blob/main/.travis.yml
 
 The python 3.7 linux tests therefore takes more time, compared to the other tests on travis.
 
-Just like each other commit to the master branch the tagged releases are pushed to pypi.org and anaconda.org::
+Just like each other commit to the main branch the tagged releases are pushed to pypi.org and anaconda.org::
 
    https://pypi.org/project/pyiron-base/#history
    https://anaconda.org/pyiron/pyiron_base

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 pyiron
 ======
 
-.. image:: https://coveralls.io/repos/github/pyiron/pyiron_atomistics/badge.svg?branch=master
-    :target: https://coveralls.io/github/pyiron/pyiron_atomistics?branch=master
+.. image:: https://coveralls.io/repos/github/pyiron/pyiron_atomistics/badge.svg?branch=main
+    :target: https://coveralls.io/github/pyiron/pyiron_atomistics?branch=main
     :alt: Coverage Status
 
 .. image:: https://api.codacy.com/project/badge/Grade/c513254f10004df5a1f5c76425c6584b
@@ -47,7 +47,7 @@ See the `Documentation <http://pyiron.org>`_ page for more details.
 
 Installation
 ------------
-You can test pyiron on `Mybinder.org (beta) <https://mybinder.org/v2/gh/pyiron/pyiron_atomistics/master?urlpath=lab>`_.
+You can test pyiron on `Mybinder.org (beta) <https://mybinder.org/v2/gh/pyiron/pyiron_atomistics/main?urlpath=lab>`_.
 For a local installation we recommend to install pyiron inside an `anaconda <https://www.anaconda.com>`_  environment::
 
     conda install -c conda-forge pyiron
@@ -92,7 +92,7 @@ Getting started:
 Test pyiron with mybinder:
 
 .. image:: https://mybinder.org/badge_logo.svg
-     :target: https://mybinder.org/v2/gh/pyiron/pyiron_atomistics/master
+     :target: https://mybinder.org/v2/gh/pyiron/pyiron_atomistics/main
      :alt: mybinder
 
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,4 @@
-# pip install master
+# pip install
 pip install .
 
 # ngl view for jupyter

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -107,7 +107,7 @@ Read more about `citing individual modules/ plugins of pyiron and the implemente
    source/faq.rst
    Contributing <https://pyiron.readthedocs.io/en/latest/source/developers.html>
    Citing <https://pyiron.readthedocs.io/en/latest/source/citation.html>
-   License (BSD) <https://github.com/pyiron/pyiron/blob/master/LICENSE>
+   License (BSD) <https://github.com/pyiron/pyiron/blob/main/LICENSE>
    source/indices.rst
    Imprint <https://www.mpie.de/impressum>
    Data protection <https://www.mpie.de/3392182/data-protection>

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -401,9 +401,9 @@ When you import pyiron in any python shell or jupyter notebook it should load th
 
 .. code-block:: bash
 
-    git checkout -b master
+    git checkout -b main
 
-In this case we switch to the master branch.  
+In this case we switch to the main branch.
 
 Download pyiron Parameter Files
 ===============================
@@ -432,7 +432,7 @@ For workshops, tutorials, and lectures it is sometimes necessary to setup multip
 
 Cloud Solutions
 ===============
-You can test pyiron on `Mybinder.org (beta) <https://mybinder.org/v2/gh/pyiron/pyiron/master?urlpath=lab>`_, without the need for a local installation. It is a flexible way to get a first impression of pyiron but it does not provide any permanent storage by default. Loading the pyiron environment on mybinder can take 5 to 15 minutes in case a new docker container needs to be built. Mybinder is a free service, so sessions on its servers are limited in duration and memory limits, and their stability is not guaranteed. We recommend having a backup plan when using mybinder for presentations/interactive tutorials, since the mybinder instance might be shutdown if it is idle for too long. 
+You can test pyiron on `Mybinder.org (beta) <https://mybinder.org/v2/gh/pyiron/pyiron/main?urlpath=lab>`_, without the need for a local installation. It is a flexible way to get a first impression of pyiron but it does not provide any permanent storage by default. Loading the pyiron environment on mybinder can take 5 to 15 minutes in case a new docker container needs to be built. Mybinder is a free service, so sessions on its servers are limited in duration and memory limits, and their stability is not guaranteed. We recommend having a backup plan when using mybinder for presentations/interactive tutorials, since the mybinder instance might be shutdown if it is idle for too long.
 
 Docker Container
 ================
@@ -469,7 +469,7 @@ To setup a local lab with pyiron when the internet connection is limited, we pro
 ***************
 Getting Started
 ***************
-Finally once you have installed pyiron you can quickly test your installation with the following minimalistic example. Many more examples are available in the `Github repository <https://github.com/pyiron/pyiron/tree/master/notebooks>`_.
+Finally once you have installed pyiron you can quickly test your installation with the following minimalistic example. Many more examples are available in the `Github repository <https://github.com/pyiron/pyiron/tree/main/notebooks>`_.
 
 First Calculation
 =================

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -352,7 +352,7 @@ So far we discussed the installation of pyiron on an individual workstation via 
 
 Install from Source 
 ===================
-For development, it is recommended to first create a conda environment containing all of pyiron's dependencies. The dependencies are available in pyiron's `environment.yml <https://github.com/pyiron/pyiron/blob/master/.ci_support/environment.yml>`_ file.
+For development, it is recommended to first create a conda environment containing all of pyiron's dependencies. The dependencies are available in pyiron's `environment.yml <https://github.com/pyiron/pyiron/blob/main/.ci_support/environment.yml>`_ file.
 
 .. code-block:: bash
     git clone https://github.com/pyiron/pyiron.git
@@ -368,7 +368,7 @@ The default installation via pip installs the latest release version of pyiron. 
 
     pip install pyiron
 
-For those who want to test the nightly releases of pyiron which include the latest status of the master branch you can install those via pip as well: 
+For those who want to test the nightly releases of pyiron which include the latest status of the main branch you can install those via pip as well:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Also for a couple references to github.com/pyiron/pyiron/tree/master, which worked because github kindly redirects us, but should still be main now.