### PR TITLE
Set initial magnetic moments

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2569,7 +2569,7 @@ class Atoms(ASEAtoms):
         Args:
             magmoms (None/numpy.ndarray/list/dict/float): Default value is None (non magnetic calc).
             List, dict or single value assigning magnetic moments to the structure object.
-            
+
             Non-collinear calculations may be specified through using a dict/list (see last example)
 
         If you want to make it non-magnetic, set `None`
@@ -2584,7 +2584,7 @@ class Atoms(ASEAtoms):
         >>> structure.set_initial_magnetic_moments(spin_list)
         >>> structure.get_initial_magnetic_moments()
         array([1, 2, 3, 4])
-        
+
         Example II input: dict
         Assigns species-specific magnetic moments
         >>> from pyiron_atomistics import Project
@@ -2603,13 +2603,13 @@ class Atoms(ASEAtoms):
         >>> structure.set_initial_magnetic_moments(1)
         >>> print(structure.get_initial_magnetic_moments())
         array([1, 1, 1, 1])
-        
+
         Example IV input: dict/list for non-collinear magmoms.
         Assigns non-collinear magnetic moments to the sites in structure
         >>> from pyiron_atomistics import Project
         >>> structure = Project('.').create.structure.bulk('Ni', cubic=True)
         >>> structure[-1] = 'Fe'
-        
+
         Option 1: List input sets vectors for each individual site
         >>> non_coll_magmom_vect = [[1, 2, 3]
                                     [2, 3, 4],
@@ -2618,13 +2618,13 @@ class Atoms(ASEAtoms):
         >>> structure.set_initial_magnetic_moments(non_coll_magmom_vect)
         >>> print(structure.get_initial_magnetic_moments())
         array([[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]])
-        
+
         Option 2: Dict input sets magmom vectors for individual species:
         >>> print(structure.get_initial_magnetic_moments())
         >>> non_coll_spin_dict = {'Fe': [2, 3, 4], 'Ni': [1, 2, 3]}
         >>> structure.set_initial_magnetic_moments(non_coll_spin_dict)
-        >>> print(structure.get_initial_magnetic_moments()) 
-        array([[1, 2, 3], [1, 2, 3], [1, 2, 3], [2, 3, 4]])       
+        >>> print(structure.get_initial_magnetic_moments())
+        array([[1, 2, 3], [1, 2, 3], [1, 2, 3], [2, 3, 4]])
         """
         # pyiron part
         if magmoms is not None:

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2561,7 +2561,7 @@ class Atoms(ASEAtoms):
             else:
                 return np.zeros(len(self))
 
-    def set_initial_magnetic_moments(self, magmoms=None):
+    def set_initial_magnetic_moments(self, magmoms):
         """
         Set array of initial magnetic moments.
 
@@ -2569,13 +2569,12 @@ class Atoms(ASEAtoms):
             magmoms (numpy.ndarray/list): List of magneric moments
         """
         # pyiron part
-        if magmoms is not None:
-            if len(magmoms) != len(self):
-                raise ValueError("magmons can be collinear or non-collinear.")
-            if "spin" not in self._tag_list._lists.keys():
-                self.add_tag(spin=None)
-            for ind, spin in enumerate(magmoms):
-                self.spin[ind] = spin
+        if len(magmoms) != len(self):
+            raise ValueError("magmons can be collinear or non-collinear.")
+        if "spin" not in self._tag_list._lists.keys():
+            self.add_tag(spin=None)
+        for ind, spin in enumerate(magmoms):
+            self.spin[ind] = spin
         self.spins = magmoms
 
     def rotate(

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2570,7 +2570,7 @@ class Atoms(ASEAtoms):
             magmoms (None/numpy.ndarray/list/dict/float): Default value is None (non magnetic calc).
             List, dict or single value assigning magnetic moments to the structure object.
             
-            Non-collinear calculations may be specified through using a dict (see last example)
+            Non-collinear calculations may be specified through using a dict/list (see last example)
 
         If you want to make it non-magnetic, set `None`
         >>> structure.set_initial_magnetic_moments(None)

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2605,7 +2605,7 @@ class Atoms(ASEAtoms):
         # pyiron part
         if magmoms is not None:
             if isinstance(magmoms, dict):
-                if set(self.get_chemical_symbols()) != set(magmoms.keys()):
+                if set(self.get_species_symbols()) != set(magmoms.keys()):
                     raise ValueError(
                         "Elements in structure {} not equal to those in dict {}".format(
                             set(self.get_chemical_symbols()), set(magmoms.keys())

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2582,7 +2582,7 @@ class Atoms(ASEAtoms):
         >>> structure.set_initial_magnetic_moments(spin_list)
         >>> structure.get_initial_magnetic_moments()
         array([1, 2, 3, 4])
-        
+
         Example II input: dict
         Assigns species-specific magnetic moments species
         >>> from pyiron_atomistics import Project

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2622,7 +2622,7 @@ class Atoms(ASEAtoms):
         Option 2: Dict input sets magmom vectors for individual species:
         >>> print(structure.get_initial_magnetic_moments())
         >>> non_coll_spin_dict = {'Fe': [2, 3, 4], 'Ni': [1, 2, 3]}
-        >>> structure.set_initial_magnetic_moments(spin_dict)
+        >>> structure.set_initial_magnetic_moments(non_coll_spin_dict)
         >>> print(structure.get_initial_magnetic_moments()) 
         array([[1, 2, 3], [1, 2, 3], [1, 2, 3], [2, 3, 4]])       
         """

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2606,18 +2606,24 @@ class Atoms(ASEAtoms):
         atoms (like in Example II)
         """
         # pyiron part
-        if isinstance(magmoms, dict):
-            if set(self.get_chemical_symbols()) != set(magmoms.keys()):
-                raise ValueError("Dict input must contain all the chemical species")
-            magmoms = [magmoms[c] for c in self.get_chemical_symbols()]
-        elif not hasattr(magmoms, '__len__') or (len(magmoms) == 3 and len(self) != 3):
-            magmoms = len(self) * [magmoms]
-        if len(magmoms) != len(self):
-            raise ValueError("magmons can be collinear or non-collinear.")
-        if "spin" not in self._tag_list._lists.keys():
-            self.add_tag(spin=None)
-        for ind, spin in enumerate(magmoms):
-            self.spin[ind] = spin
+        if magmoms is not None:
+            if isinstance(magmoms, dict):
+                if set(self.get_chemical_symbols()) != set(magmoms.keys()):
+                    raise ValueError(
+                        "Elements in structure {} not equal to those in dict {}".format(
+                            set(self.get_chemical_symbols()), set(magmoms.keys())
+                        )
+                    )
+                magmoms = [magmoms[c] for c in self.get_chemical_symbols()]
+            elif not hasattr(magmoms, '__len__') or (len(magmoms) == 3 and len(self) != 3):
+                magmoms = len(self) * [magmoms]
+            if len(magmoms) != len(self):
+                raise ValueError("magmons can be collinear or non-collinear.")
+            if "spin" not in self._tag_list._lists.keys():
+                self.add_tag(spin=None)
+            for ind, spin in enumerate(magmoms):
+                self.spin[ind] = spin # For self._tag_list.spin
+        self.spins = magmoms # For self.array['initial_magmoms']
 
 
     def rotate(

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -29,6 +29,7 @@ from pyiron_atomistics.atomistics.structure.periodic_table import (
 from pyiron_base import state, deprecate, deprecate_soon
 from pyiron_atomistics.atomistics.structure.pyironase import publication
 from pymatgen.io.ase import AseAtomsAdaptor
+from collections.abc import Sequence
 
 from scipy.spatial import cKDTree, Voronoi
 
@@ -2604,7 +2605,7 @@ class Atoms(ASEAtoms):
                         )
                     )
                 magmoms = [magmoms[c] for c in self.get_chemical_symbols()]
-            elif not hasattr(magmoms, "__len__"):
+            elif not isinstance(magmoms, (np.ndarray, Sequence)):
                 magmoms = len(self) * [magmoms]
             if len(magmoms) != len(self):
                 raise ValueError("magmons can be collinear or non-collinear.")

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2567,33 +2567,40 @@ class Atoms(ASEAtoms):
         Set array of initial magnetic moments.
 
         Args:
-            magmoms (numpy.ndarray/list/dict/float/None): List, dict or single
-                value of magnetic moments
+            magmoms (None/numpy.ndarray/list/dict/float): Default value is None (non magnetic calc).
+            List, dict or single value assigning magnetic moments to the structure object.
 
+        If you want to make it non-magnetic, set `None`
+        >>> structure.set_initial_magnetic_moments(None)
 
-        Example I:
-
+        Example I input: np.ndarray / List
+        Assigns site moments via corresponding list of same length as number of sites in structure
         >>> from pyiron_atomistics import Project
         >>> structure = Project('.').create.structure.bulk('Ni', cubic=True)
         >>> structure[-1] = 'Fe'
-        >>> v_dict = {'Fe': 1, 'Ni': 2}
-        >>> structure.set_initial_magnetic_moments(v_dict)
+        >>> spin_list = [1, 2, 3, 4]
+        >>> structure.set_initial_magnetic_moments(spin_list)
+        >>> structure.get_initial_magnetic_moments()
+        array([1, 2, 3, 4])
+        
+        Example II input: dict
+        Assigns species-specific magnetic moments species
+        >>> from pyiron_atomistics import Project
+        >>> structure = Project('.').create.structure.bulk('Ni', cubic=True)
+        >>> structure[-1] = 'Fe'
+        >>> spin_dict = {'Fe': 1, 'Ni': 2}
+        >>> structure.set_initial_magnetic_moments(spin_dict)
         >>> structure.get_initial_magnetic_moments()
         array([2, 2, 2, 1])
 
-
-        Example II:
-
+        Example III input: float
+        Assigns the same magnetic moment to all atoms in the structure
         >>> from pyiron_atomistics import Project
         >>> structure = Project('.').create.structure.bulk('Ni', cubic=True)
         >>> structure[-1] = 'Fe'
         >>> structure.set_initial_magnetic_moments(1)
         >>> print(structure.get_initial_magnetic_moments())
         array([1, 1, 1, 1])
-
-        If you want to make it non-magnetic, set `None`:
-
-        >>> structure.set_initial_magnetic_moments(None)
         """
         # pyiron part
         if magmoms is not None:

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2566,7 +2566,44 @@ class Atoms(ASEAtoms):
         Set array of initial magnetic moments.
 
         Args:
-            magmoms (numpy.ndarray/list): List of magneric moments
+            magmoms (numpy.ndarray/list/dict/float): List, dict or single value
+                of magneric moments
+
+
+        Example I:
+
+        >>> from pyiron_atomistics import Project
+        >>> structure = Project('.').create.structure.bulk('Ni', cubic=True)
+        >>> structure[-1] = 'Fe'
+        >>> v_dict = {'Fe': 1, 'Ni': 2}
+        >>> structure.set_initial_magnetic_moments(v_dict)
+        >>> print(structure.get_initial_magnetic_moments())
+
+        Output:
+
+        >>> array([2, 2, 2, 1])
+
+
+        Example II:
+
+        >>> from pyiron_atomistics import Project
+        >>> structure = Project('.').create.structure.bulk('Ni', cubic=True)
+        >>> structure[-1] = 'Fe'
+        >>> structure.set_initial_magnetic_moments(1)
+        >>> print(structure.get_initial_magnetic_moments())
+
+        Output:
+
+        >>> array([1, 1, 1, 1])
+
+        If you want to make it non-magnetic, set `None`:
+        
+        >>> structure.set_initial_magnetic_moments(None)
+
+        If a list or an array of length 3 (e.g. [1, 2, 3]) is set and the
+        number of atoms is not 3, it will be considered as a non-collinear
+        magnetic moments, and the values will be distributed to all the
+        atoms (like in Example II)
         """
         # pyiron part
         if isinstance(magmoms, dict):

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2577,11 +2577,8 @@ class Atoms(ASEAtoms):
         >>> structure[-1] = 'Fe'
         >>> v_dict = {'Fe': 1, 'Ni': 2}
         >>> structure.set_initial_magnetic_moments(v_dict)
-        >>> print(structure.get_initial_magnetic_moments())
-
-        Output:
-
-        >>> array([2, 2, 2, 1])
+        >>> structure.get_initial_magnetic_moments()
+        array([2, 2, 2, 1])
 
 
         Example II:

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2561,13 +2561,13 @@ class Atoms(ASEAtoms):
             else:
                 return np.zeros(len(self))
 
-    def set_initial_magnetic_moments(self, magmoms):
+    def set_initial_magnetic_moments(self, magmoms=None):
         """
         Set array of initial magnetic moments.
 
         Args:
-            magmoms (numpy.ndarray/list/dict/float): List, dict or single value
-                of magneric moments
+            magmoms (numpy.ndarray/list/dict/float/None): List, dict or single
+                value of magneric moments
 
 
         Example I:

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2597,7 +2597,7 @@ class Atoms(ASEAtoms):
         >>> array([1, 1, 1, 1])
 
         If you want to make it non-magnetic, set `None`:
-        
+
         >>> structure.set_initial_magnetic_moments(None)
 
         If a list or an array of length 3 (e.g. [1, 2, 3]) is set and the
@@ -2615,16 +2615,17 @@ class Atoms(ASEAtoms):
                         )
                     )
                 magmoms = [magmoms[c] for c in self.get_chemical_symbols()]
-            elif not hasattr(magmoms, '__len__') or (len(magmoms) == 3 and len(self) != 3):
+            elif not hasattr(magmoms, "__len__") or (
+                len(magmoms) == 3 and len(self) != 3
+            ):
                 magmoms = len(self) * [magmoms]
             if len(magmoms) != len(self):
                 raise ValueError("magmons can be collinear or non-collinear.")
             if "spin" not in self._tag_list._lists.keys():
                 self.add_tag(spin=None)
             for ind, spin in enumerate(magmoms):
-                self.spin[ind] = spin # For self._tag_list.spin
-        self.spins = magmoms # For self.array['initial_magmoms']
-
+                self.spin[ind] = spin  # For self._tag_list.spin
+        self.spins = magmoms  # For self.array['initial_magmoms']
 
     def rotate(
         self, a=0.0, v=None, center=(0, 0, 0), rotate_cell=False, index_list=None

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2567,16 +2567,19 @@ class Atoms(ASEAtoms):
         Set array of initial magnetic moments.
 
         Args:
-            magmoms (None/numpy.ndarray/list/dict/float): Default value is None (non magnetic calc).
-            List, dict or single value assigning magnetic moments to the structure object.
+            magmoms (None/numpy.ndarray/list/dict/float): Default value is
+                None (non magnetic calc). List, dict or single value assigning
+                magnetic moments to the structure object.
 
-            Non-collinear calculations may be specified through using a dict/list (see last example)
+        Non-collinear calculations may be specified through using a dict/list
+        (see last example)
 
         If you want to make it non-magnetic, set `None`
         >>> structure.set_initial_magnetic_moments(None)
 
         Example I input: np.ndarray / List
-        Assigns site moments via corresponding list of same length as number of sites in structure
+        Assigns site moments via corresponding list of same length as number
+        of sites in structure
         >>> from pyiron_atomistics import Project
         >>> structure = Project('.').create.structure.bulk('Ni', cubic=True)
         >>> structure[-1] = 'Fe'

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2586,7 +2586,7 @@ class Atoms(ASEAtoms):
         array([1, 2, 3, 4])
         
         Example II input: dict
-        Assigns species-specific magnetic moments species
+        Assigns species-specific magnetic moments
         >>> from pyiron_atomistics import Project
         >>> structure = Project('.').create.structure.bulk('Ni', cubic=True)
         >>> structure[-1] = 'Fe'
@@ -2596,7 +2596,7 @@ class Atoms(ASEAtoms):
         array([2, 2, 2, 1])
 
         Example III input: float
-        Assigns the same magnetic moment to all atoms in the structure
+        Assigns the same magnetic moment to all sites in the structure
         >>> from pyiron_atomistics import Project
         >>> structure = Project('.').create.structure.bulk('Ni', cubic=True)
         >>> structure[-1] = 'Fe'
@@ -2610,7 +2610,7 @@ class Atoms(ASEAtoms):
         >>> structure = Project('.').create.structure.bulk('Ni', cubic=True)
         >>> structure[-1] = 'Fe'
         
-        Option 1: List input sets vectors for each individual atom
+        Option 1: List input sets vectors for each individual site
         >>> non_coll_magmom_vect = [[1, 2, 3]
                                     [2, 3, 4],
                                     [3, 4, 5],

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2608,11 +2608,9 @@ class Atoms(ASEAtoms):
         # pyiron part
         if isinstance(magmoms, dict):
             if set(self.get_chemical_symbols()) != set(magmoms.keys()):
-                raise ValueError('Dict input must contain all the chemical species')
+                raise ValueError("Dict input must contain all the chemical species")
             magmoms = [magmoms[c] for c in self.get_chemical_symbols()]
-        elif not hasattr(magmoms, '__len__') or (
-                len(magmoms) == 3 and len(self) != 3
-            ):
+        elif not hasattr(magmoms, '__len__') or (len(magmoms) == 3 and len(self) != 3):
             magmoms = len(self) * [magmoms]
         if len(magmoms) != len(self):
             raise ValueError("magmons can be collinear or non-collinear.")

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2567,7 +2567,7 @@ class Atoms(ASEAtoms):
 
         Args:
             magmoms (numpy.ndarray/list/dict/float/None): List, dict or single
-                value of magneric moments
+                value of magnetic moments
 
 
         Example I:

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2569,13 +2569,21 @@ class Atoms(ASEAtoms):
             magmoms (numpy.ndarray/list): List of magneric moments
         """
         # pyiron part
+        if isinstance(magmoms, dict):
+            if set(self.get_chemical_symbols()) != set(magmoms.keys()):
+                raise ValueError('Dict input must contain all the chemical species')
+            magmoms = [magmoms[c] for c in self.get_chemical_symbols()]
+        elif not hasattr(magmoms, '__len__') or (
+                len(magmoms) == 3 and len(self) != 3
+            ):
+            magmoms = len(self) * [magmoms]
         if len(magmoms) != len(self):
             raise ValueError("magmons can be collinear or non-collinear.")
         if "spin" not in self._tag_list._lists.keys():
             self.add_tag(spin=None)
         for ind, spin in enumerate(magmoms):
             self.spin[ind] = spin
-        self.spins = magmoms
+
 
     def rotate(
         self, a=0.0, v=None, center=(0, 0, 0), rotate_cell=False, index_list=None

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -2588,19 +2588,11 @@ class Atoms(ASEAtoms):
         >>> structure[-1] = 'Fe'
         >>> structure.set_initial_magnetic_moments(1)
         >>> print(structure.get_initial_magnetic_moments())
-
-        Output:
-
-        >>> array([1, 1, 1, 1])
+        array([1, 1, 1, 1])
 
         If you want to make it non-magnetic, set `None`:
 
         >>> structure.set_initial_magnetic_moments(None)
-
-        If a list or an array of length 3 (e.g. [1, 2, 3]) is set and the
-        number of atoms is not 3, it will be considered as a non-collinear
-        magnetic moments, and the values will be distributed to all the
-        atoms (like in Example II)
         """
         # pyiron part
         if magmoms is not None:
@@ -2612,9 +2604,7 @@ class Atoms(ASEAtoms):
                         )
                     )
                 magmoms = [magmoms[c] for c in self.get_chemical_symbols()]
-            elif not hasattr(magmoms, "__len__") or (
-                len(magmoms) == 3 and len(self) != 3
-            ):
+            elif not hasattr(magmoms, "__len__"):
                 magmoms = len(self) * [magmoms]
             if len(magmoms) != len(self):
                 raise ValueError("magmons can be collinear or non-collinear.")

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -523,6 +523,7 @@ class TestAtoms(unittest.TestCase):
         basis = Atoms(elements=3 * ["Ni"] + ["Fe"], positions=np.random.random((4, 3)), cell=np.eye(3))
         basis.set_initial_magnetic_moments({'Fe': 1, 'Ni': 2})
         self.assertEqual(basis.get_initial_magnetic_moments().tolist(), [2, 2, 2, 1])
+        self.assertRaises(ValueError, basis.set_initial_magnetic_moments, {'Fe': 1})
         basis = Atoms(elements=3 * ["Ni"] + ["Fe"], positions=np.random.random((4, 3)), cell=np.eye(3))
         basis.set_initial_magnetic_moments(1)
         self.assertEqual(basis.get_initial_magnetic_moments().tolist(), [1, 1, 1, 1])

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -520,6 +520,12 @@ class TestAtoms(unittest.TestCase):
         basis.set_repeat(2)
         self.assertTrue(np.array_equal(basis.spins, np.hstack([0.0, 2.0] * 8)))
         self.assertRaises(ValueError, basis.set_initial_magnetic_moments, magmoms=[4] * (len(basis) - 1))
+        basis = Atoms(elements=3 * ["Ni"] + ["Fe"], positions=np.random.random((4, 3)), cell=np.eye(3))
+        basis.set_initial_magnetic_moments({'Fe': 1, 'Ni': 2})
+        self.assertEqual(basis.get_initial_magnetic_moments().tolist(), [2, 2, 2, 1])
+        basis = Atoms(elements=3 * ["Ni"] + ["Fe"], positions=np.random.random((4, 3)), cell=np.eye(3))
+        basis.set_initial_magnetic_moments(1)
+        self.assertEqual(basis.get_initial_magnetic_moments().tolist(), [1, 1, 1, 1])
 
     def test_get_parent_basis(self):
         periodic_table = PeriodicTable()


### PR DESCRIPTION
This allow the user to set the magnetic moments via single value or `dict`:

Example I

```python
structure = pr.create.structure.bulk('Ni', cubic=True)
structure[-1] = 'Fe'
v_dict = {'Fe': 1, 'Ni': 2}
structure.set_initial_magnetic_moments(v_dict)
print(structure.get_initial_magnetic_moments())
```

Output: `array([2, 2, 2, 1])`

Example II

```python
structure = pr.create.structure.bulk('Ni', cubic=True)
structure[-1] = 'Fe'
structure.set_initial_magnetic_moments(1)
structure.get_initial_magnetic_moments()
```

Output `array([1, 1, 1, 1])`

Moreover, I saw that the default behaviour was setting the system non-magnetic, i.e. regardless of what was set for the magnetic moments, `structure.set_initial_magnetic_moments()` would make the structure non-magnetic. This is now disabled, i.e. if the user wants to make it non-magnetic, they are required to explicitly set `structure.set_initial_magnetic_moments(None)`