### PR TITLE
Iteratively parse vasprun instead of having entire object in memory

### DIFF
--- a/pyiron_atomistics/vasp/vasprun.py
+++ b/pyiron_atomistics/vasp/vasprun.py
@@ -58,8 +58,6 @@ class Vasprun(object):
         if not (os.path.isfile(filename)):
             raise AssertionError()
         try:
-            
-            #root = ETree.parse(filename).getroot()
             self.parse_root_to_dict(filename)
         except ParseError:
             raise VasprunError(

--- a/pyiron_atomistics/vasp/vasprun.py
+++ b/pyiron_atomistics/vasp/vasprun.py
@@ -66,8 +66,6 @@ class Vasprun(object):
                 "The vasprun.xml file is either corrupted or the simulation has failed"
             )
 
-        self.parse_root_to_dict(root)
-
     def parse_root_to_dict(self, filename):
         """
         Parses from the main xml root.


### PR DESCRIPTION
Iteratively parses vasprun.xml, reduces memory usage by an order of magnitude. Notes/proof appended later