### PR TITLE
:memo: Add new exception for calc_minimize.

### DIFF
--- a/pyiron_atomistics/lammps/control.py
+++ b/pyiron_atomistics/lammps/control.py
@@ -247,8 +247,10 @@ class LammpsControl(GenericParameters):
 
         if pressure is not None:
             if rotation_matrix is None:
-                raise ValueError("No rotation matrix given while trying to convert pressure. "
-                                 "This is most likely due to no structure being defined.")
+                raise ValueError(
+                    "No rotation matrix given while trying to convert pressure. "
+                    "This is most likely due to no structure being defined."
+                )
             self._force_skewed = False
             pressure = self.pressure_to_lammps(pressure, rotation_matrix)
             if np.isscalar(pressure):

--- a/pyiron_atomistics/lammps/control.py
+++ b/pyiron_atomistics/lammps/control.py
@@ -246,6 +246,9 @@ class LammpsControl(GenericParameters):
         ionic_force_tolerance *= force_units
 
         if pressure is not None:
+            if rotation_matrix is None:
+                raise ValueError("No rotation matrix given while trying to convert pressure. "
+                                 "This is most likely due to no structure being defined.")
             self._force_skewed = False
             pressure = self.pressure_to_lammps(pressure, rotation_matrix)
             if np.isscalar(pressure):


### PR DESCRIPTION
Solution for #696.  Add a new exception to the calc_minimize method that is raised when pressure is about to be calculated while the rotation_matrix is None. This would raise an exception anyways, but with a more generic message. 