### PR TITLE
Fix ase selective dynamics read bug

### DIFF
--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -110,7 +110,7 @@ class StructureFactory(PyironFactory):
             # For stuff that pymatgen can't read it raises
             # ValueError: Unrecognized file extension!
             # backwards compatibility for notebooks.
-            # TypeError: IStructure.from_file() got an unexpected keyword argument 'format' 
+            # TypeError: IStructure.from_file() got an unexpected keyword argument 'format'
             structure = self.read_using_ase(*args, **kwargs)
         return structure
 
@@ -118,10 +118,10 @@ class StructureFactory(PyironFactory):
 
     def read_using_pymatgen(self, *args, **kwargs):
         return pymatgen_to_pyiron(Structure.from_file(*args, **kwargs))
-    
+
     def read_using_ase(self, *args, **kwargs):
         return self.ase.read(*args, **kwargs)
-    
+
     @deprecate(message="Please use .read or .ase.read", version="0.2.2")
     def ase_read(self, *args, **kwargs):
         return self.ase.read(*args, **kwargs)

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -103,6 +103,7 @@ class StructureFactory(PyironFactory):
     stack.__doc__ = AseFactory.stack.__doc__
 
     def read(self, *args, **kwargs):
+        # This looks weird, but it's because ASE doesn't handle selective dynamics properly, so we replace it with the pymatgen read equivalent.
         return pymatgen_to_pyiron(Structure.from_file(*args, **kwargs))
 
     read.__doc__ = AseFactory.read.__doc__

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -46,6 +46,7 @@ from pyiron_atomistics.atomistics.structure.atoms import (
     ovito_to_pyiron,
     pyiron_to_pymatgen,
 )
+from pymatgen.core import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pyiron_atomistics.atomistics.structure.periodic_table import PeriodicTable
 from pyiron_base import state, PyironFactory, deprecate
@@ -102,7 +103,7 @@ class StructureFactory(PyironFactory):
     stack.__doc__ = AseFactory.stack.__doc__
 
     def read(self, *args, **kwargs):
-        return self.ase.read(*args, **kwargs)
+        return pymatgen_to_pyiron(Structure.from_file(*args, **kwargs))
 
     read.__doc__ = AseFactory.read.__doc__
 

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -104,10 +104,24 @@ class StructureFactory(PyironFactory):
 
     def read(self, *args, **kwargs):
         # This looks weird, but it's because ASE doesn't handle selective dynamics properly, so we replace it with the pymatgen read equivalent.
-        return pymatgen_to_pyiron(Structure.from_file(*args, **kwargs))
+        try:
+            structure = self.read_using_pymatgen(*args, **kwargs)
+        except (ValueError, TypeError):
+            # For stuff that pymatgen can't read it raises
+            # ValueError: Unrecognized file extension!
+            # backwards compatibility for notebooks.
+            # TypeError: IStructure.from_file() got an unexpected keyword argument 'format' 
+            structure = self.read_using_ase(*args, **kwargs)
+        return structure
 
     read.__doc__ = AseFactory.read.__doc__
 
+    def read_using_pymatgen(self, *args, **kwargs):
+        return pymatgen_to_pyiron(Structure.from_file(*args, **kwargs))
+    
+    def read_using_ase(self, *args, **kwargs):
+        return self.ase.read(*args, **kwargs)
+    
     @deprecate(message="Please use .read or .ase.read", version="0.2.2")
     def ase_read(self, *args, **kwargs):
         return self.ase.read(*args, **kwargs)


### PR DESCRIPTION
#932 replaces read() in StructureFactory with pymatgen reader which handles selective dynamics properly.