### PR TITLE
Store data only in given hdf

### DIFF
--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -801,9 +801,13 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         """
         ProjectGUI(self)
 
-    def _structure_to_hdf(self):
+    def _structure_to_hdf(self, hdf=None, group_name=None):
+        if hdf is None:
+            hdf = self.project_hdf5
+        if group_name is not None:
+            hdf = hdf.open(group_name)
         if self.structure is not None and self._generic_input["structure"] == "atoms":
-            with self.project_hdf5.open("input") as hdf5_input:
+            with hdf.open("input") as hdf5_input:
                 self.structure.to_hdf(hdf5_input)
 
     def _structure_from_hdf(self):

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -984,8 +984,8 @@ class LammpsBase(AtomisticGenericJob):
 
         """
         super(LammpsBase, self).to_hdf(hdf=hdf, group_name=group_name)
-        self._structure_to_hdf()
-        self.input.to_hdf(self._hdf5)
+        self._structure_to_hdf(hdf=hdf, group_name=group_name)
+        self.input.to_hdf(hdf)
 
     def from_hdf(self, hdf=None, group_name=None):  # TODO: group_name should be removed
         """


### PR DESCRIPTION
The problem in [this PR](https://github.com/pyiron/pyiron_base/pull/903) was due to the coexistence of `self._hdf5` (aka `self.project_hdf5`) and `hdf`, which is passed as a function argument. Here, I propose to unite to it the function argument variation. I hope this is in line with what @pmrv wrote [here](https://github.com/pyiron/pyiron_atomistics/issues/924)).