### PR TITLE
Add new arguments to by_id()

### DIFF
--- a/pyiron_atomistics/atomistics/structure/factories/materialsproject.py
+++ b/pyiron_atomistics/atomistics/structure/factories/materialsproject.py
@@ -165,7 +165,9 @@ class MaterialsProjectFactory:
             if final:
                 return pymatgen_to_pyiron(
                     mpr.get_structure_by_material_id(
-                        material_id=material_id, final=final, conventional_unit_cell=conventional_unit_cell
+                        material_id=material_id,
+                        final=final,
+                        conventional_unit_cell=conventional_unit_cell,
                     )
                 )
             else:
@@ -173,7 +175,9 @@ class MaterialsProjectFactory:
                     pymatgen_to_pyiron(mpr_structure)
                     for mpr_structure in (
                         mpr.get_structure_by_material_id(
-                            material_id=material_id, final=final, conventional_unit_cell=conventional_unit_cell
+                            material_id=material_id,
+                            final=final,
+                            conventional_unit_cell=conventional_unit_cell,
                         )
                     )
                 ]

--- a/pyiron_atomistics/atomistics/structure/factories/materialsproject.py
+++ b/pyiron_atomistics/atomistics/structure/factories/materialsproject.py
@@ -173,7 +173,7 @@ class MaterialsProjectFactory:
                     pymatgen_to_pyiron(mpr_structure)
                     for mpr_structure in (
                         mpr.get_structure_by_material_id(
-                            material_id, final, conventional_unit_cell
+                            material_id=material_id, final=final, conventional_unit_cell=conventional_unit_cell
                         )
                     )
                 ]

--- a/pyiron_atomistics/atomistics/structure/factories/materialsproject.py
+++ b/pyiron_atomistics/atomistics/structure/factories/materialsproject.py
@@ -150,8 +150,8 @@ class MaterialsProjectFactory:
             (Default is False)
 
         Returns:
-            :class:`~.Atoms`: requested final structure if final is True or
-            a list of initial structures if final is False
+            :class:`~.Atoms`: requested final structure if final is True
+            list of :class:~.Atoms`:  a list of initial (pre-relaxation) structures if final is False
 
         Raises:
             ValueError: material id does not exist

--- a/pyiron_atomistics/atomistics/structure/factories/materialsproject.py
+++ b/pyiron_atomistics/atomistics/structure/factories/materialsproject.py
@@ -165,7 +165,7 @@ class MaterialsProjectFactory:
             if final:
                 return pymatgen_to_pyiron(
                     mpr.get_structure_by_material_id(
-                        material_id, final, conventional_unit_cell
+                        material_id=material_id, final=final, conventional_unit_cell=conventional_unit_cell
                     )
                 )
             else:


### PR DESCRIPTION
Made all arguments from the materials project side available in the by_id() method. I was unsure of how to add the new optional Union return type to the docstring, so a quick check here would be appreciated! This closes pyiron/pyiron_atomistics#950.