### PR TITLE
Not allow empty tag in sparse list

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -406,7 +406,7 @@ class Atoms(ASEAtoms):
 
         self._high_symmetry_path.update(path)
 
-    def add_tag(self, *args, **qwargs):
+    def add_tag(self, **qwargs):
         """
         Add tags to the atoms object.
 
@@ -417,7 +417,24 @@ class Atoms(ASEAtoms):
             >>> self.add_tag(selective_dynamics=[False, False, False])
 
         """
-        self._tag_list.add_tag(*args, **qwargs)
+        self._tag_list.add_tag(**qwargs)
+
+    def remove_tag(self, tag: str) -> None:
+        """
+        Remove tags to the atoms object.
+
+        Args:
+            tag (str): tag to remove
+
+        Examples:
+
+            For selective dynamics::
+
+            >>> self.add_tag(selective_dynamics=[False, False, False])
+            >>> self.remove_tag(key="selective_dynamics")
+
+        """
+        self._tag_list.remove_tag(**qwargs)
 
     # @staticmethod
     def numbers_to_elements(self, numbers):

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -419,23 +419,6 @@ class Atoms(ASEAtoms):
         """
         self._tag_list.add_tag(**qwargs)
 
-    def remove_tag(self, key: str) -> None:
-        """
-        Remove tags to the atoms object.
-
-        Args:
-            key (str): tag to remove
-
-        Examples:
-
-            For selective dynamics::
-
-            >>> self.add_tag(selective_dynamics=[False, False, False])
-            >>> self.remove_tag(key="selective_dynamics")
-
-        """
-        self._tag_list.remove_tag(key)
-
     # @staticmethod
     def numbers_to_elements(self, numbers):
         """

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -419,12 +419,12 @@ class Atoms(ASEAtoms):
         """
         self._tag_list.add_tag(**qwargs)
 
-    def remove_tag(self, tag: str) -> None:
+    def remove_tag(self, key: str) -> None:
         """
         Remove tags to the atoms object.
 
         Args:
-            tag (str): tag to remove
+            key (str): tag to remove
 
         Examples:
 
@@ -434,7 +434,7 @@ class Atoms(ASEAtoms):
             >>> self.remove_tag(key="selective_dynamics")
 
         """
-        self._tag_list.remove_tag(**qwargs)
+        self._tag_list.remove_tag(key)
 
     # @staticmethod
     def numbers_to_elements(self, numbers):

--- a/pyiron_atomistics/atomistics/structure/sparse_list.py
+++ b/pyiron_atomistics/atomistics/structure/sparse_list.py
@@ -563,24 +563,16 @@ class SparseArray(object):
         if isinstance(other, Integral):
             return self * other
 
-    def add_tag(self, *args, **qwargs):
-        for key in args:
-            self._lists[key] = SparseList({}, length=len(self))
-
+    def add_tag(self, **qwargs):
         for key, default in qwargs.items():
             self._lists[key] = SparseList({}, default=default, length=len(self))
 
-    def remove_tag(self, *args, **qwargs):
+    def remove_tag(self, key):
         """
+        Remove tags to the atoms object.
 
         Args:
-            *args:
-            **qwargs:
-
-        Returns:
+            tag (str): tag to remove
 
         """
-        for key in args:
-            del self._lists[key]
-        for key, default in qwargs.items():
-            del self._lists[key]
+        del self._lists[key]

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -274,7 +274,6 @@ class TestAtoms(unittest.TestCase):
             cell=np.identity(3),
         )
         self.Fe_bcc.add_tag(group=0)
-        self.Fe_bcc.remove_tag("group")
 
     def test_convert_formula(self):
         self.assertEqual(self.CO2.convert_formula("C"), ["C"])

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -273,8 +273,8 @@ class TestAtoms(unittest.TestCase):
             scaled_positions=[[0, 0, 0], [0.25, 0.25, 0.25]],
             cell=np.identity(3),
         )
-        self.Fe_bcc.add_tag("group")
-        self.Fe_bcc.group[:] = 0
+        self.Fe_bcc.add_tag(group=0)
+        self.Fe_bcc.remove_tag("group")
 
     def test_convert_formula(self):
         self.assertEqual(self.CO2.convert_formula("C"), ["C"])

--- a/tests/atomistics/structure/test_sparse_list.py
+++ b/tests/atomistics/structure/test_sparse_list.py
@@ -137,8 +137,6 @@ class TestSparseArray(unittest.TestCase):
         self.assertEqual(
             self.aMatrix.spin.list(), [False, True, False, True, False, True]
         )
-        self.aMatrix.remove_tag('spin')
-        self.assertFalse('spin' in self.aMatrix._lists.keys())
 
     def test_keys(self):
         self.assertEqual(

--- a/tests/atomistics/structure/test_sparse_list.py
+++ b/tests/atomistics/structure/test_sparse_list.py
@@ -102,11 +102,6 @@ class TestSparseArray(unittest.TestCase):
         self.assertEqual(len(self.aMatrix), 6)
 
     def test_add_tag(self):
-        self.aMatrix.add_tag("coordinates")
-        self.assertTrue("coordinates" in self.aMatrix.keys())
-        self.assertTrue(len(self.aMatrix.coordinates) == 6)
-        self.assertTrue(isinstance(self.aMatrix.coordinates, SparseList))
-
         self.aMatrix.add_tag(rel=[True, True, True])
         self.assertTrue(self.aMatrix.rel[1] == [True, True, True])
 
@@ -136,13 +131,14 @@ class TestSparseArray(unittest.TestCase):
         self.assertEqual(bMatrix.list_1, fac * [5, 4, 3, 4, 5, 6])
 
     def test__getattr__(self):
-        self.aMatrix.add_tag("spin")
+        self.aMatrix.add_tag(spin=True)
         self.assertEqual(len(self.aMatrix.spin), 6)
-        self.aMatrix.spin[1::2] = True
         self.aMatrix.spin[0::2] = False
         self.assertEqual(
             self.aMatrix.spin.list(), [False, True, False, True, False, True]
         )
+        self.aMatrix.remove_tag('spin')
+        self.assertFalse('spin' in self.aMatrix._lists.keys())
 
     def test_keys(self):
         self.assertEqual(


### PR DESCRIPTION
- Remove `*args` in `add_tag` in `SparseList`, because it makes no sense to make an empty sparse list, which is also not offered anywhere.
- Add `remove_tag` on the `Atoms` level, which was hidden behind `_tag_lists` before.