### PR TITLE
Use `set_array` instead of setting `structure.arrays` directly & change position reading in `from_hdf` when scaled positions are to be read

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -249,21 +249,10 @@ class Atoms(ASEAtoms):
 
     @spins.setter
     def spins(self, val):
-        if val is not None:
-            val = np.asarray(val)
-            if self.has("initial_magmoms"):
-                try:
-                    self.arrays["initial_magmoms"][:] = val
-                except ValueError as err:
-                    if len(self.arrays["initial_magmoms"]) == len(val):
-                        self.set_array("initial_magmoms", None)
-                        self.arrays["initial_magmoms"] = val
-                    else:
-                        raise err
-            else:
-                self.new_array("initial_magmoms", val)
-        else:
-            self.set_array("initial_magmoms", None)
+        self.set_array(
+            "initial_magmoms",
+            np.asarray(val) if val is not None else None
+        )
 
     @property
     def visualize(self):

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -538,7 +538,7 @@ class Atoms(ASEAtoms):
                 if "is_absolute" in hdf_atoms.list_nodes() and not tr_dict[hdf_atoms["is_absolute"]]:
                     self.set_scaled_positions(hdf_atoms[position_tag])
                 else:
-                    self.set_positions(hdf_atoms[position_tag])
+                    self.set_array("positions", hdf_atoms[position_tag])
 
                 self.set_array("numbers", self.get_atomic_numbers())
 

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -532,13 +532,12 @@ class Atoms(ASEAtoms):
                 position_tag = "positions"
                 if position_tag not in hdf_atoms.list_nodes():
                     position_tag = "coordinates"
+                self.arrays["positions"] = hdf_atoms[position_tag]
                 if (
                     "is_absolute" in hdf_atoms.list_nodes()
                     and not tr_dict[hdf_atoms["is_absolute"]]
                 ):
-                    self.set_scaled_positions(hdf_atoms[position_tag])
-                else:
-                    self.set_array("positions", hdf_atoms[position_tag])
+                    self.set_scaled_positions(self.arrays["positions"])
 
                 self.set_array("numbers", self.get_atomic_numbers())
 

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -249,7 +249,9 @@ class Atoms(ASEAtoms):
 
     @spins.setter
     def spins(self, val):
-        self.set_array("initial_magmoms", np.asarray(val) if val is not None else None)
+        self.set_array("initial_magmoms", None)
+        if val is not None:
+            self.set_array("initial_magmoms", np.asarray(val))
 
     @property
     def visualize(self):

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -539,7 +539,7 @@ class Atoms(ASEAtoms):
                 ):
                     self.set_scaled_positions(self.arrays["positions"])
 
-                self.set_array("numbers", self.get_atomic_numbers())
+                self.arrays["numbers"] = self.get_atomic_numbers()
 
                 if "explicit_bonds" in hdf_atoms.list_nodes():
                     # print "bonds: "

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -535,15 +535,12 @@ class Atoms(ASEAtoms):
                 position_tag = "positions"
                 if position_tag not in hdf_atoms.list_nodes():
                     position_tag = "coordinates"
-                if "is_absolute" in hdf_atoms.list_nodes():
-                    if not tr_dict[hdf_atoms["is_absolute"]]:
-                        self.set_scaled_positions(hdf_atoms[position_tag])
-                    else:
-                        self.arrays["positions"] = hdf_atoms[position_tag]
+                if "is_absolute" in hdf_atoms.list_nodes() and not tr_dict[hdf_atoms["is_absolute"]]:
+                    self.set_scaled_positions(hdf_atoms[position_tag])
                 else:
-                    self.arrays["positions"] = hdf_atoms[position_tag]
+                    self.set_positions(hdf_atoms[position_tag])
 
-                self.arrays["numbers"] = self.get_atomic_numbers()
+                self.set_array("numbers", self.get_atomic_numbers())
 
                 if "explicit_bonds" in hdf_atoms.list_nodes():
                     # print "bonds: "

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -249,10 +249,7 @@ class Atoms(ASEAtoms):
 
     @spins.setter
     def spins(self, val):
-        self.set_array(
-            "initial_magmoms",
-            np.asarray(val) if val is not None else None
-        )
+        self.set_array("initial_magmoms", np.asarray(val) if val is not None else None)
 
     @property
     def visualize(self):
@@ -535,7 +532,10 @@ class Atoms(ASEAtoms):
                 position_tag = "positions"
                 if position_tag not in hdf_atoms.list_nodes():
                     position_tag = "coordinates"
-                if "is_absolute" in hdf_atoms.list_nodes() and not tr_dict[hdf_atoms["is_absolute"]]:
+                if (
+                    "is_absolute" in hdf_atoms.list_nodes()
+                    and not tr_dict[hdf_atoms["is_absolute"]]
+                ):
                     self.set_scaled_positions(hdf_atoms[position_tag])
                 else:
                     self.set_positions(hdf_atoms[position_tag])

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -15,6 +15,7 @@ from pyiron_atomistics.lammps.output import to_amat
 from pyiron_atomistics.lammps.units import LAMMPS_UNIT_CONVERSIONS, UnitConverter
 import ase.units as units
 from pyiron_base._tests import TestWithCleanProject
+import unittest
 
 
 class TestLammps(TestWithCleanProject):

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -1004,3 +1004,7 @@ def collect_dump_file_old(job, file_name="dump.out", cwd=None):
         output[k] = uc.convert_array_to_pyiron_units(array=v, label=k)
 
     return output
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
While working on [this PR](https://github.com/pyiron/pyiron_atomistics/pull/981), I realized that we use `structure.arrays['tag'] = xyz` very often. Since there is this function `set_array` in ASE, which checks the shape of the value etc., we should also use it.

After I did the change above, I realized that ASE does not allow a redefinition of positions, which is apparently initialized to an empty list. So for `from_hdf` we have to stick to the old notation. I also changed `set_scaled_positions` in `from_hdf` because it does not work for the same reason.