### PR TITLE
More eam inits

### DIFF
--- a/pyiron_atomistics/lammps/potentials.py
+++ b/pyiron_atomistics/lammps/potentials.py
@@ -458,7 +458,7 @@ class Library(LammpsPotentials):
                     f"available choices."
                 )
             df = self._df_candidates.iloc[choice]
-            if len(self._df_candidates) > 1:
+            if self._choice is None and len(self._df_candidates) > 1:
                 warnings.warn(
                     f"Potential not uniquely specified - use default {df.Name}"
                 )

--- a/pyiron_atomistics/lammps/potentials.py
+++ b/pyiron_atomistics/lammps/potentials.py
@@ -13,6 +13,8 @@ __email__ = "surendralal@mpie.de"
 __status__ = "production"
 __date__ = "Sep 1, 2017"
 
+from typing import Optional
+
 import pandas as pd
 from pyiron_atomistics.lammps.potential import LammpsPotentialFile
 import numpy as np
@@ -358,7 +360,12 @@ class EAM(LammpsPotentials):
                 )
         return
 
-    def __init__(self, *chemical_elements, name=None, pair_style=None):
+    def __init__(
+            self,
+            *chemical_elements: str,
+            name: Optional[str] = None,
+            pair_style: Optional[str] = None
+    ):
         if name is not None:
             self._df_candidates = LammpsPotentialFile().find_by_name(name)
         else:

--- a/pyiron_atomistics/lammps/potentials.py
+++ b/pyiron_atomistics/lammps/potentials.py
@@ -16,6 +16,7 @@ __date__ = "Sep 1, 2017"
 from typing import Optional
 
 import pandas as pd
+from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.lammps.potential import LammpsPotentialFile
 import numpy as np
 import warnings
@@ -364,11 +365,15 @@ class EAM(LammpsPotentials):
             self,
             *chemical_elements: str,
             name: Optional[str] = None,
+            structure: Optional[Atoms] = None
     ):
         if name is not None:
             self._df_candidates = LammpsPotentialFile().find_by_name(name)
         else:
-            self._df_candidates = LammpsPotentialFile().find(list(chemical_elements))
+            structure_elements = [] if structure is None \
+                else list(structure.get_species_symbols())
+            chemical_elements = list(set(list(chemical_elements) + structure_elements))
+            self._df_candidates = LammpsPotentialFile().find(chemical_elements)
 
     def list_potentials(self):
         return self._df_candidates.Name

--- a/pyiron_atomistics/lammps/potentials.py
+++ b/pyiron_atomistics/lammps/potentials.py
@@ -429,7 +429,7 @@ class Library(LammpsPotentials):
     def __init__(
             self,
             *chemical_elements: str,
-            choice: int = 0,
+            choice: Optional[int] = None,
             name: Optional[str] = None,
             structure: Optional[Atoms] = None
     ):
@@ -451,12 +451,13 @@ class Library(LammpsPotentials):
     @property
     def df(self):
         if self._df is None:
-            if self._choice > len(self._df_candidates):
+            choice = 0 if self._choice is None else self._choice
+            if choice > len(self._df_candidates):
                 raise ValueError(
                     f"Cannot choose {self._choice} among {len(self._df_candidates)} "
                     f"available choices."
                 )
-            df = self._df_candidates.iloc[self._choice]
+            df = self._df_candidates.iloc[choice]
             if len(self._df_candidates) > 1:
                 warnings.warn(
                     f"Potential not uniquely specified - use default {df.Name}"

--- a/pyiron_atomistics/lammps/potentials.py
+++ b/pyiron_atomistics/lammps/potentials.py
@@ -364,9 +364,11 @@ class EAM(LammpsPotentials):
     def __init__(
             self,
             *chemical_elements: str,
+            choice: int = 0,
             name: Optional[str] = None,
             structure: Optional[Atoms] = None
     ):
+        self._choice = choice
         if name is not None:
             self._df_candidates = LammpsPotentialFile().find_by_name(name)
         else:
@@ -384,7 +386,12 @@ class EAM(LammpsPotentials):
     @property
     def df(self):
         if self._df is None:
-            df = self._df_candidates.iloc[0]
+            if self._choice > len(self._df_candidates):
+                raise ValueError(
+                    f"Cannot choose {self._choice} among {len(self._df_candidates)} "
+                    f"available choices."
+                )
+            df = self._df_candidates.iloc[self._choice]
             if len(self._df_candidates) > 1:
                 warnings.warn(
                     f"Potential not uniquely specified - use default {df.Name}"

--- a/pyiron_atomistics/lammps/potentials.py
+++ b/pyiron_atomistics/lammps/potentials.py
@@ -364,7 +364,6 @@ class EAM(LammpsPotentials):
             self,
             *chemical_elements: str,
             name: Optional[str] = None,
-            pair_style: Optional[str] = None
     ):
         if name is not None:
             self._df_candidates = LammpsPotentialFile().find_by_name(name)


### PR DESCRIPTION
Allow users to pass a structure for chemical elements -- this augments the `*chemical_elements` args, and I think it will be super useful for people who want to check if there is an EAM potential available for their structure should they want to add X to it, i.e. `EAM("X", structure=my_struct)`.

Allow users to select among candidates by index. Because the heart wants what the heart wants.