### PR TITLE
VASP: Parse the number of steps correctly from OUTCAR

### DIFF
--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -664,18 +664,16 @@ class Outcar(object):
         nblock_trigger = "NBLOCK ="
         trigger = "FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)"
         trigger_indices = list()
-        read_nblock = True
         n_block = 1
         lines = _get_lines_from_file(filename=filename, lines=lines)
         for i, line in enumerate(lines):
             line = line.strip()
             if trigger in line:
                 trigger_indices.append(i)
-            if read_nblock is None:
-                if nblock_trigger in line:
-                    line = _clean_line(line)
-                    n_block = int(line.split(nblock_trigger)[-1])
-        return n_block * np.linspace(0, len(trigger_indices))
+            if nblock_trigger in line:
+                line = _clean_line(line)
+                n_block = int(line.split(nblock_trigger)[-1])
+        return n_block * np.arange(0, len(trigger_indices))
 
     def get_time(self, filename="OUTCAR", lines=None):
         """

--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -672,7 +672,7 @@ class Outcar(object):
                 trigger_indices.append(i)
             if nblock_trigger in line:
                 line = _clean_line(line)
-                n_block = int(line.split(nblock_trigger)[-1])
+                n_block = int(line.split(nblock_trigger.split(";", maxsplit=1)[0])[-1])
         return np.arange(0, len(trigger_indices) * n_block, n_block)
 
     def get_time(self, filename="OUTCAR", lines=None):

--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -690,15 +690,14 @@ class Outcar(object):
 
         """
         potim_trigger = "POTIM  ="
-        read_potim = True
         potim = 1.0
         lines = _get_lines_from_file(filename=filename, lines=lines)
         for i, line in enumerate(lines):
-            line = line.strip()
-            if read_potim is None:
-                if potim_trigger in line:
-                    line = _clean_line(line)
-                    potim = float(line.split(potim_trigger)[0])
+            if potim_trigger in line:
+                line = line.strip()
+                line = _clean_line(line)
+                potim = float(line.split(potim_trigger)[0])
+                break
         return potim * self.get_steps(filename)
 
     @staticmethod

--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -673,7 +673,7 @@ class Outcar(object):
             if nblock_trigger in line:
                 line = _clean_line(line)
                 n_block = int(line.split(nblock_trigger)[-1])
-        return n_block * np.arange(0, len(trigger_indices))
+        return np.arange(0, len(trigger_indices) * n_block, n_block)
 
     def get_time(self, filename="OUTCAR", lines=None):
         """

--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -666,11 +666,11 @@ class Outcar(object):
         steps = 0
         nblock = None
         lines = _get_lines_from_file(filename=filename, lines=lines)
-        for i, line in enumerate(lines):
-            line = line.strip()
+        for line in lines:
             if trigger in line:
                 steps += 1
-            if nblock is not None:
+            if nblock is None and "NBLOCK" in line:
+                line = line.strip()
                 line = _clean_line(line)
                 nblock = int(nblock_regex.findall(line)[0])
         if nblock is None:
@@ -696,7 +696,7 @@ class Outcar(object):
             if potim_trigger in line:
                 line = line.strip()
                 line = _clean_line(line)
-                potim = float(line.split(potim_trigger)[0])
+                potim = float(line.split(potim_trigger)[1].strip().split()[0])
                 break
         return potim * self.get_steps(filename)
 

--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -661,19 +661,21 @@ class Outcar(object):
         Returns:
             numpy.ndarray: Steps during the simulation
         """
-        nblock_trigger = "NBLOCK ="
+        nblock_regex = re.compile(r"NBLOCK =\s+(\d+);")
         trigger = "FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)"
         trigger_indices = list()
-        n_block = 1
+        nblock = None
         lines = _get_lines_from_file(filename=filename, lines=lines)
         for i, line in enumerate(lines):
             line = line.strip()
             if trigger in line:
                 trigger_indices.append(i)
-            if nblock_trigger in line:
+            if nblock is not None:
                 line = _clean_line(line)
-                n_block = int(line.split(nblock_trigger.split(";", maxsplit=1)[0])[-1])
-        return np.arange(0, len(trigger_indices) * n_block, n_block)
+                nblock = int(nblock_regex.findall(line)[0])
+        if nblock is None:
+            nblock = 1
+        return np.arange(0, len(trigger_indices) * nblock, nblock)
 
     def get_time(self, filename="OUTCAR", lines=None):
         """

--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -663,19 +663,19 @@ class Outcar(object):
         """
         nblock_regex = re.compile(r"NBLOCK =\s+(\d+);")
         trigger = "FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)"
-        trigger_indices = list()
+        steps = 0
         nblock = None
         lines = _get_lines_from_file(filename=filename, lines=lines)
         for i, line in enumerate(lines):
             line = line.strip()
             if trigger in line:
-                trigger_indices.append(i)
+                steps += 1
             if nblock is not None:
                 line = _clean_line(line)
                 nblock = int(nblock_regex.findall(line)[0])
         if nblock is None:
             nblock = 1
-        return np.arange(0, len(trigger_indices) * nblock, nblock)
+        return np.arange(0, steps * nblock, nblock)
 
     def get_time(self, filename="OUTCAR", lines=None):
         """

--- a/tests/vasp/test_outcar.py
+++ b/tests/vasp/test_outcar.py
@@ -566,6 +566,7 @@ class TestOutcar(unittest.TestCase):
             8: 0.0,
             9: 787952.0,
             10: 1036056.0,
+            11: 39113.0
         }
         for filename in self.file_list:
             self.assertEqual(
@@ -822,7 +823,7 @@ class TestOutcar(unittest.TestCase):
         def naive_parse(filename):
             with open(filename) as f:
                 nblock = 1
-                steps = 1
+                steps = 0
                 for l in f:
                     if "NBLOCK" in l:
                         nblock = int(l.split(";")[0].split("=")[1])
@@ -1173,7 +1174,7 @@ class TestOutcar(unittest.TestCase):
                 self.assertEqual(output_all.__str__(), output.__str__())
 
     def test_get_nelect(self):
-        n_elect_list = [40.0, 16.0, 16.0, 16.0, 16.0, 16.0, 224.0, 358.0, 8, 1]
+        n_elect_list = [40.0, 16.0, 16.0, 16.0, 16.0, 16.0, 224.0, 358.0, 8, 1, 324.0]
         for filename in self.file_list:
             i = int(filename.split("_")[-1]) - 1
             self.assertEqual(n_elect_list[i], self.outcar_parser.get_nelect(filename))

--- a/tests/vasp/test_outcar.py
+++ b/tests/vasp/test_outcar.py
@@ -830,76 +830,36 @@ class TestOutcar(unittest.TestCase):
                 return steps, nblock
 
         for filename in self.file_list:
-            output = self.outcar_parser.get_steps(filename)
-            self.assertIsInstance(output, np.ndarray, "steps has to be an array!")
-            nblock, steps = naive_parse(filename)
-            total = steps * nblock
-            self.assertTrue(
-                    np.array_equal(output, np.arange(0, total, nblock)),
-                    "Parsed output steps do not match numpy.arange(0, {total}, {nblock})!"
-            )
+            with self.subTest(filename=filename):
+                output = self.outcar_parser.get_steps(filename)
+                self.assertIsInstance(output, np.ndarray, "steps has to be an array!")
+                steps, nblock = naive_parse(filename)
+                total = steps * nblock
+                self.assertEqual(
+                        output, np.arange(0, total, nblock),
+                        f"Parsed output steps do not match numpy.arange(0, {total}, {nblock})!"
+                )
 
 
     def test_get_time(self):
+        def naive_parse(filename):
+            with open(filename) as f:
+                for l in f:
+                    if "POTIM" in l:
+                        return float(
+                            l.split("=")[1].strip().split()[0]
+                        )
+                return 1.0
         for filename in self.file_list:
-            output = self.outcar_parser.get_time(filename)
-            self.assertIsInstance(output, np.ndarray)
-            if int(filename.split("/OUTCAR_")[-1]) in [1, 2, 3, 4, 5, 6]:
-                time = np.array(
-                    [
-                        0.0,
-                        0.02040816,
-                        0.04081633,
-                        0.06122449,
-                        0.08163265,
-                        0.10204082,
-                        0.12244898,
-                        0.14285714,
-                        0.16326531,
-                        0.18367347,
-                        0.20408163,
-                        0.2244898,
-                        0.24489796,
-                        0.26530612,
-                        0.28571429,
-                        0.30612245,
-                        0.32653061,
-                        0.34693878,
-                        0.36734694,
-                        0.3877551,
-                        0.40816327,
-                        0.42857143,
-                        0.44897959,
-                        0.46938776,
-                        0.48979592,
-                        0.51020408,
-                        0.53061224,
-                        0.55102041,
-                        0.57142857,
-                        0.59183673,
-                        0.6122449,
-                        0.63265306,
-                        0.65306122,
-                        0.67346939,
-                        0.69387755,
-                        0.71428571,
-                        0.73469388,
-                        0.75510204,
-                        0.7755102,
-                        0.79591837,
-                        0.81632653,
-                        0.83673469,
-                        0.85714286,
-                        0.87755102,
-                        0.89795918,
-                        0.91836735,
-                        0.93877551,
-                        0.95918367,
-                        0.97959184,
-                        1.0,
-                    ]
-                )
-                self.assertEqual(time.__str__(), output.__str__())
+            with self.subTest(filename=filename):
+                potim = naive_parse(filename)
+                time = self.outcar_parser.get_time(filename)
+                step = self.outcar_parser.get_steps(filename)
+                for t, s in zip(time, step):
+                    self.assertEqual(
+                        t, s * potim,
+                        f"Time {t} is not equal to steps times POTIM {potim * s}!"
+                    )
 
     def test_get_fermi_level(self):
         for filename in self.file_list:

--- a/tests/vasp/test_outcar.py
+++ b/tests/vasp/test_outcar.py
@@ -819,65 +819,26 @@ class TestOutcar(unittest.TestCase):
                 self.assertEqual(temperatures.__str__(), output.__str__())
 
     def test_get_steps(self):
+        def naive_parse(filename):
+            with open(filename) as f:
+                nblock = 1
+                steps = 1
+                for l in f:
+                    if "NBLOCK" in l:
+                        nblock = int(l.split(";")[0].split("=")[1])
+                    steps += "FREE ENERGIE OF THE ION-ELECTRON SYSTEM" in l
+                return steps, nblock
+
         for filename in self.file_list:
             output = self.outcar_parser.get_steps(filename)
-            self.assertIsInstance(output, np.ndarray)
-            if int(filename.split("/OUTCAR_")[-1]) in [1, 2, 3, 4, 5, 6]:
-                steps = np.array(
-                    [
-                        0.0,
-                        0.02040816,
-                        0.04081633,
-                        0.06122449,
-                        0.08163265,
-                        0.10204082,
-                        0.12244898,
-                        0.14285714,
-                        0.16326531,
-                        0.18367347,
-                        0.20408163,
-                        0.2244898,
-                        0.24489796,
-                        0.26530612,
-                        0.28571429,
-                        0.30612245,
-                        0.32653061,
-                        0.34693878,
-                        0.36734694,
-                        0.3877551,
-                        0.40816327,
-                        0.42857143,
-                        0.44897959,
-                        0.46938776,
-                        0.48979592,
-                        0.51020408,
-                        0.53061224,
-                        0.55102041,
-                        0.57142857,
-                        0.59183673,
-                        0.6122449,
-                        0.63265306,
-                        0.65306122,
-                        0.67346939,
-                        0.69387755,
-                        0.71428571,
-                        0.73469388,
-                        0.75510204,
-                        0.7755102,
-                        0.79591837,
-                        0.81632653,
-                        0.83673469,
-                        0.85714286,
-                        0.87755102,
-                        0.89795918,
-                        0.91836735,
-                        0.93877551,
-                        0.95918367,
-                        0.97959184,
-                        1.0,
-                    ]
-                )
-                self.assertEqual(steps.__str__(), output.__str__())
+            self.assertIsInstance(output, np.ndarray, "steps has to be an array!")
+            nblock, steps = naive_parse(filename)
+            total = steps * nblock
+            self.assertEqual(
+                    (output == np.arange(0, total, nblock)).all(),
+                    "Parsed output steps do not match numpy.arange(0, {total}, {nblock})!"
+            )
+
 
     def test_get_time(self):
         for filename in self.file_list:

--- a/tests/vasp/test_outcar.py
+++ b/tests/vasp/test_outcar.py
@@ -834,8 +834,8 @@ class TestOutcar(unittest.TestCase):
             self.assertIsInstance(output, np.ndarray, "steps has to be an array!")
             nblock, steps = naive_parse(filename)
             total = steps * nblock
-            self.assertEqual(
-                    (output == np.arange(0, total, nblock)).all(),
+            self.assertTrue(
+                    np.array_equal(output, np.arange(0, total, nblock)),
                     "Parsed output steps do not match numpy.arange(0, {total}, {nblock})!"
             )
 


### PR DESCRIPTION
For VASP jobs output/generic/steps is generated in either of two ways:
1. vasprun.xml can be parsed -> np.arange(len(output/generic/energy_tot))
2. vasprun.xml cannot be parsed -> np.linspace(0, #trigger)

where #trigger is the number of times the string

FREE ENERGIE OF THE ION-ELECTRON SYSTEM (eV)

occurs in the OUTCAR file.

The latter leads to fractional output and always 50 entries in that array.  Both is contradictory to the first way and seems absurd.  This commit changes this to align with the first way.  Also this fixes a bug where the intent of the previous code seems to have been to multiply the step indices by the value of NBLOCK.  This however is not done in the first way.

For some reason there is an explicit unit test (that will now fail) that checks the output of `output/generic/steps` is always an array of length 50 with fractional values.  I cannot begin to understand why.  I would remove, but I'd like some input first.