### PR TITLE
Add an error message indicating SPHInX is not installed

### DIFF
--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1569,21 +1569,7 @@ class SphinxBase(GenericDFTJob):
 
             return len(w) == 0
 
-    def validate_ready_to_run(self):
-        """
-        Checks whether parameters are set appropriately. It does not
-        mean the simulation won't run if it returns False.
-        """
-
-        if shutil.which("sphinx") is None:
-            raise ValueError(
-                "It looks like you have not installed SPHInX on your system, "
-                "which is not included in the pyiron conda package. You can "
-                "install SPHInX via\n\nconda install -c conda-forge "
-                "sphinxdft\n\n. For more info, take a look at our page: "
-                "https://pyiron.readthedocs.io/en/latest/"
-            )
-
+    def _validate_input_ready_to_run(self):
         all_groups = {
             "job.input.pawPot": self.input.sphinx.pawPot,
             "job.input.structure": self.input.sphinx.structure,
@@ -1654,9 +1640,9 @@ class SphinxBase(GenericDFTJob):
                 != np.array(self.input.sphinx.basis.folding).tolist()
             ):
                 warnings.warn(
-                    "job.input.basis.kPoint was modified directly. "
-                    "It is recommended to set all k-point settings via "
-                    "job.set_kpoints()"
+                    "job.input.basis.kPoint was modified directly. It is"
+                    " recommended to set all k-point settings via"
+                    " job.set_kpoints()"
                 )
 
             structure_sync = str(self.input.sphinx.structure) == str(
@@ -1664,15 +1650,13 @@ class SphinxBase(GenericDFTJob):
             )
             if not structure_sync and not self.input.sphinx.structure.read_only:
                 warnings.warn(
-                    "job.input.structure != job.structure. "
-                    "The current job.structure will overwrite "
-                    "any changes you may might have made to "
-                    "job.input.structure in the meantime. "
-                    "To disable this overwrite, "
-                    "set job.input.structure.read_only = True. "
-                    "To disable this warning, call "
-                    "job.load_structure_group() after making changes "
-                    "to job.structure."
+                    "job.input.structure != job.structure. The current"
+                    " job.structure will overwrite any changes you may might"
+                    " have made to job.input.structure in the meantime. To"
+                    " disable this overwrite, set"
+                    " job.input.structure.read_only = True. To disable this"
+                    " warning, call job.load_structure_group() after making"
+                    " changes to job.structure."
                 )
 
             if len(w) > 0:
@@ -1682,6 +1666,22 @@ class SphinxBase(GenericDFTJob):
                 return False
             else:
                 return True
+
+    def validate_ready_to_run(self):
+        """
+        Checks whether parameters are set appropriately. It does not
+        mean the simulation won't run if it returns False.
+        """
+
+        if shutil.which("sphinx") is None:
+            raise ValueError(
+                "It looks like you have not installed SPHInX on your system, "
+                "which is not included in the pyiron conda package. You can "
+                "install SPHInX via\n\nconda install -c conda-forge "
+                "sphinxdft\n\n. For more info, take a look at our page: "
+                "https://pyiron.readthedocs.io/en/latest/"
+            )
+        return self._validate_input_ready_to_run()
 
     def compress(self, files_to_compress=None):
         """

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1836,7 +1836,7 @@ class SphinxBase(GenericDFTJob):
                 # move output to working directory for successful runs
                 if out.returncode == 0:
                     for file in os.listdir(tempd):
-                        shutil.movefile(os.path.join(tempd, file), self.working_directory)
+                        shutil.move(os.path.join(tempd, file), self.working_directory)
                         if not silent:
                             print("Copying " + file + " to " + self.working_directory)
                 else:

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -1943,7 +1943,9 @@ class InputWriter(object):
                     path=potentials.find_default(elem)["Filename"].values[0][0]
                 )
             if potformat == "JTH":
-                shutil.copyfile(potential_path, posixpath.join(cwd, elem + "_GGA.atomicdata"))
+                shutil.copyfile(
+                    potential_path, posixpath.join(cwd, elem + "_GGA.atomicdata")
+                )
             else:
                 shutil.copyfile(potential_path, posixpath.join(cwd, elem + "_POTCAR"))
 

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -2429,6 +2429,16 @@ class Output:
 
         with open(posixpath.join(cwd, file_name), "r") as sphinx_log_file:
             log_file = "".join(sphinx_log_file.readlines())
+            if len(log_file) == 0:
+                raise ValueError(
+                    "There is a sphinx log file, but it is empty. It is likely "
+                    "that you have not installed SPHInX on your system, which "
+                    "is not included in the pyiron conda package. You can "
+                    "also take a look at the log file to look for "
+                    "indications. To find how to install SPHInX, take a look "
+                    "at the installation page of our website. Here's the "
+                    "homepage: https://pyiron.readthedocs.io/en/latest/"
+                )
         try:
             self._spx_log_parser = _SphinxLogParser(log_file)
         except AssertionError as e:

--- a/tests/sphinx/test_base.py
+++ b/tests/sphinx/test_base.py
@@ -458,6 +458,10 @@ class TestSphinx(unittest.TestCase):
 
     def test_validate_ready_to_run(self):
 
+        self.assertRaises(
+            ValueError, self.sphinx_band_structure.validate_ready_to_run
+        )
+
         backup = self.sphinx_band_structure.structure.copy()
         self.sphinx_band_structure.structure = None
         self.assertRaises(

--- a/tests/sphinx/test_base.py
+++ b/tests/sphinx/test_base.py
@@ -461,59 +461,59 @@ class TestSphinx(unittest.TestCase):
         backup = self.sphinx_band_structure.structure.copy()
         self.sphinx_band_structure.structure = None
         self.assertRaises(
-            AssertionError, self.sphinx_band_structure.validate_ready_to_run
+            AssertionError, self.sphinx_band_structure._validate_input_ready_to_run
         )
         self.sphinx_band_structure.structure = backup
 
         self.sphinx_band_structure.input["THREADS"] = 20
         self.sphinx_band_structure.server.cores = 10
         self.assertRaises(
-            AssertionError, self.sphinx_band_structure.validate_ready_to_run
+            AssertionError, self.sphinx_band_structure._validate_input_ready_to_run
         )
 
         self.sphinx_band_structure.input.sphinx.main.clear()
         self.assertRaises(
-            AssertionError, self.sphinx_band_structure.validate_ready_to_run
+            AssertionError, self.sphinx_band_structure._validate_input_ready_to_run
         )
 
         backup = self.sphinx.input.sphinx.basis.eCut
         self.sphinx.input.sphinx.basis.eCut = 400
-        self.assertFalse(self.sphinx.validate_ready_to_run())
+        self.assertFalse(self.sphinx._validate_input_ready_to_run())
         self.sphinx.input.sphinx.basis.eCut = backup
 
         backup = self.sphinx.input.sphinx.basis.kPoint.copy()
         self.sphinx.input.sphinx.basis.kPoint.clear()
         self.sphinx.input.sphinx.basis.kPoint.coords = [0.5, 0.5, 0.25]
         self.sphinx.input.sphinx.basis.kPoint.weight = 1
-        self.assertFalse(self.sphinx.validate_ready_to_run())
+        self.assertFalse(self.sphinx._validate_input_ready_to_run())
         self.sphinx.input.sphinx.basis.kPoint = backup
 
         backup = self.sphinx.input.sphinx.PAWHamiltonian.ekt
         self.sphinx.input.sphinx.PAWHamiltonian.ekt = 0.0001
-        self.assertFalse(self.sphinx.validate_ready_to_run())
+        self.assertFalse(self.sphinx._validate_input_ready_to_run())
         self.sphinx.input.sphinx.PAWHamiltonian.ekt = backup
 
         backup = self.sphinx.input.sphinx.PAWHamiltonian.xc
         self.sphinx.input.sphinx.PAWHamiltonian.xc = "Wrong"
-        self.assertFalse(self.sphinx.validate_ready_to_run())
+        self.assertFalse(self.sphinx._validate_input_ready_to_run())
         self.sphinx.input.sphinx.PAWHamiltonian.xc = backup
 
         backup = self.sphinx.input.sphinx.PAWHamiltonian.xc
         self.sphinx.input.sphinx.PAWHamiltonian.xc = "Wrong"
-        self.assertFalse(self.sphinx.validate_ready_to_run())
+        self.assertFalse(self.sphinx._validate_input_ready_to_run())
         self.sphinx.input.sphinx.PAWHamiltonian.xc = backup
 
         backup = self.sphinx.input.sphinx.PAWHamiltonian.nEmptyStates
         self.sphinx.input.sphinx.PAWHamiltonian.nEmptyStates = 100
-        self.assertFalse(self.sphinx.validate_ready_to_run())
+        self.assertFalse(self.sphinx._validate_input_ready_to_run())
         self.sphinx.input.sphinx.PAWHamiltonian.nEmptyStates = backup
 
         backup = self.sphinx.input.sphinx.structure.copy()
         self.sphinx.input.sphinx.structure.cell = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
-        self.assertFalse(self.sphinx.validate_ready_to_run())
+        self.assertFalse(self.sphinx._validate_input_ready_to_run())
         self.sphinx.input.sphinx.structure = backup
 
-        self.assertTrue(self.sphinx.validate_ready_to_run())
+        self.assertTrue(self.sphinx._validate_input_ready_to_run())
 
     def test_set_mixing_parameters(self):
         self.assertRaises(


### PR DESCRIPTION
Based on [this discussion](https://github.com/pyiron/pyiron/pull/1479) with @liamhuber, I added an error message in SPHInX (Liam's inner voice: "we were talking about GPAW!!").

I put it in the log parser, because that's where the error is usually shown first, but to be honest I find is a bit clumsy, because it's more the symptom and not the error itself. If there's someone who has a better idea, let me know.