### PR TITLE
Allow some Murnaghan children to fail

### DIFF
--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -832,9 +832,13 @@ class Murnaghan(AtomisticParallelMaster):
                 err_lst.append(np.var(energy))
                 vol_lst.append(volume)
                 id_lst.append(job_id)
-            aborted_children = self.input.get('allow_aborted') - allowed_aborted_children
+            aborted_children = (
+                self.input.get("allow_aborted") - allowed_aborted_children
+            )
             if aborted_children > 0:
-                self.logger.warning(f"{aborted_children} aborted, but proceeding anyway.")
+                self.logger.warning(
+                    f"{aborted_children} aborted, but proceeding anyway."
+                )
             vol_lst = np.array(vol_lst)
             erg_lst = np.array(erg_lst)
             err_lst = np.array(err_lst)

--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -816,9 +816,9 @@ class Murnaghan(AtomisticParallelMaster):
             allowed_unfinished_children = self.input.get("allow_unfinished", 0)
             for job_id in self.child_ids:
                 ham = self.project_hdf5.inspect(job_id)
-                if ham.status in ["aborted", "not_converged"]:
+                if ham.status == "aborted":
                     if allowed_unfinished_children == 0:
-                        raise ValueError(f"Child {ham.name}({job_id}) is {ham.status}!")
+                        raise ValueError(f"Child {ham.name}({job_id}) is aborted!")
                     allowed_unfinished_children -= 1
                     continue
                 if "energy_tot" in ham["output/generic"].list_nodes():
@@ -832,6 +832,9 @@ class Murnaghan(AtomisticParallelMaster):
                 err_lst.append(np.var(energy))
                 vol_lst.append(volume)
                 id_lst.append(job_id)
+            failed_children = self.input.get('allow_unfinished') - allowed_unfinished_children
+            if failed_children > 0:
+                self.logger.warning(f"{failed_children} failed, but proceeding anyway.")
             vol_lst = np.array(vol_lst)
             erg_lst = np.array(erg_lst)
             err_lst = np.array(err_lst)

--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -681,7 +681,7 @@ class Murnaghan(AtomisticParallelMaster):
         )
         self.input["allow_aborted"] = (
             0,
-            "The number of child jobs that are allowed to fail or not converge, before this job is considered aborted or not converged.",
+            "The number of child jobs that are allowed to abort, before the whole job is considered aborted.",
         )
 
         self.debye_model = DebyeModel(self)

--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -681,7 +681,7 @@ class Murnaghan(AtomisticParallelMaster):
         )
         self.input["allow_unfinished"] = (
             0,
-            "The number of child jobs that are allowed to fail or not converge, before this job is considered aborted or not converged."
+            "The number of child jobs that are allowed to fail or not converge, before this job is considered aborted or not converged.",
         )
 
         self.debye_model = DebyeModel(self)


### PR DESCRIPTION
I sometimes don't care if actually all the strains in a Murnaghan calculation work out, so I added an extra flag to allow some failures.  By default it's still zero.  I would have preferred to make this general for all masters, but since the collection logic is not central I can't really do that easily.