### PR TITLE
Lammps: Add method to save per atom kinetic energy

### DIFF
--- a/pyiron_atomistics/lammps/control.py
+++ b/pyiron_atomistics/lammps/control.py
@@ -764,11 +764,20 @@ class LammpsControl(GenericParameters):
 
     def energy_pot_per_atom(self):
         """
-        Enable the output of atomic energies.  This will add an additional key 'energy_pot_per_atom' to the HDF output.
+        Enable the output of per atom potential energies.  This will add an additional key 'energy_pot_per_atom' to the HDF output.
         """
         if self["compute___energy_pot_per_atom"] is None:
             self["compute___energy_pot_per_atom"] = "all pe/atom"
             self["dump___1"] += " c_energy_pot_per_atom"
+            self["dump_modify___1"] = self["dump_modify___1"][:-1] + ' %20.15g"'
+
+    def energy_kin_per_atom(self):
+        """
+        Enable the output of per atom kinetic energies.  This will add an additional key 'energy_kin_per_atom' to the HDF output.
+        """
+        if self["compute___energy_kin_per_atom"] is None:
+            self["compute___energy_kin_per_atom"] = "all ke/atom"
+            self["dump___1"] += " c_energy_kin_per_atom"
             self["dump_modify___1"] = self["dump_modify___1"][:-1] + ' %20.15g"'
 
     def _set_group_by_id(self, group_name, ids):

--- a/pyiron_atomistics/lammps/units.py
+++ b/pyiron_atomistics/lammps/units.py
@@ -133,6 +133,7 @@ _conversion_dict["energy"] = [
     "energy_tot",
     "energy_pot",
     "energy_pot_per_atom",
+    "energy_kin_per_atom",
     "mean_energy_pot",
 ]
 _conversion_dict["temperature"] = ["temperature", "temperatures"]


### PR DESCRIPTION
This is simply analogous to `energy_pot_per_atom`.  An alternative (with less storage req) might be to compute the kinetic energy after the simulation from the velocities (which we save anyway).  Not really knowing my way around lammps however, I'd prefer the pedestrian way.

@lfzhu-phys Can you give this a try?  I'm afraid it would take some time for this to be available by default on the cluster, because we still have conda problems there.  Do you know how to set up a custom branch of pyiron?

Closes #1102 