### PR TITLE
Handle KeyError in __getattr__

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atom.py
+++ b/pyiron_atomistics/atomistics/structure/atom.py
@@ -108,7 +108,10 @@ class Atom(ASEAtom):
             self.data[key] = val
 
     def __getattr__(self, key):
-        return self.data[key]
+        try:
+            return self.data[key]
+        except KeyError:
+            raise AttributeError(key)
 
     @property
     def mass(self):


### PR DESCRIPTION
Raising the wrong type of error will trip proper attribute access, e.g. in the previous state you couldn't call `hasattr(Atom(), 'foo')`, because that look up gives a `KeyError`, but python will at most expect an `AttributeError`.

This happened to be triggered by pretty printing `Atoms`, in this case via sticking them in a pandas table.