### PR TITLE
Supply default, in case of loading old murnaghans

### DIFF
--- a/pyiron_atomistics/atomistics/master/murnaghan.py
+++ b/pyiron_atomistics/atomistics/master/murnaghan.py
@@ -833,7 +833,7 @@ class Murnaghan(AtomisticParallelMaster):
                 vol_lst.append(volume)
                 id_lst.append(job_id)
             aborted_children = (
-                self.input.get("allow_aborted") - allowed_aborted_children
+                self.input.get("allow_aborted", 0) - allowed_aborted_children
             )
             if aborted_children > 0:
                 self.logger.warning(


### PR DESCRIPTION
#1106 introduces a small backwards compat bug, because it didn't provide a default in one location for the newly added input flag.