### PR TITLE
Small fixes to Vasp.calc_minimize

### DIFF
--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -953,8 +953,6 @@ class VaspBase(GenericDFTJob):
         algorithm=None,
         retain_charge_density=False,
         retain_electrostatic_potential=False,
-        ionic_energy=None,
-        ionic_forces=None,
         ionic_energy_tolerance=None,
         ionic_force_tolerance=None,
         volume_only=False,
@@ -974,8 +972,6 @@ class VaspBase(GenericDFTJob):
             retain_electrostatic_potential (boolean): True if the electrostatic potential should be written
             ionic_energy_tolerance (float): Ionic energy convergence criteria (eV)
             ionic_force_tolerance (float): Ionic forces convergence criteria (overwrites ionic energy) (ev/A)
-            ionic_energy (float): Same as ionic_energy_tolerance (deprecated)
-            ionic_forces (float): Same as ionic_force_tolerance (deprecated)
             volume_only (bool): Option to relax only the volume (keeping the relative coordinates fixed)
             cell_only (bool): Option to relax only the cell parameters (keeping the relative coordinates fixed)
         """
@@ -1019,8 +1015,6 @@ class VaspBase(GenericDFTJob):
         self.set_convergence_precision(
             ionic_force_tolerance=ionic_force_tolerance,
             ionic_energy_tolerance=ionic_energy_tolerance,
-            ionic_energy=ionic_energy,
-            ionic_forces=ionic_forces,
             electronic_energy=None,
         )
 
@@ -1253,17 +1247,11 @@ class VaspBase(GenericDFTJob):
             reciprocal=False,
         )
 
-    @deprecate(
-        ionic_forces="Use ionic_force_tolerance",
-        ionic_energy="use ionic_energy_tolerance",
-    )
     def set_convergence_precision(
         self,
         ionic_energy_tolerance=1.0e-3,
         electronic_energy=1.0e-7,
         ionic_force_tolerance=1.0e-2,
-        ionic_energy=None,
-        ionic_forces=None,
     ):
         """
         Sets the electronic and ionic convergence precision. For ionic convergence either the energy or the force
@@ -1273,15 +1261,7 @@ class VaspBase(GenericDFTJob):
             ionic_energy_tolerance (float): Ionic energy convergence precision (eV)
             electronic_energy (float/NoneType): Electronic energy convergence precision (eV)
             ionic_force_tolerance (float): Ionic force convergence precision (eV/A)
-            ionic_energy (float/NoneType): Same as ionic_energy_tolerance (deprecated)
-            ionic_forces (float/NoneType): Same as ionic_force_tolerance (deprecated)
         """
-        if ionic_forces is not None:
-            if ionic_force_tolerance is None:
-                ionic_force_tolerance = ionic_forces
-        if ionic_energy is not None:
-            if ionic_energy_tolerance is None:
-                ionic_energy_tolerance = ionic_energy
         if ionic_force_tolerance is not None:
             self.input.incar["EDIFFG"] = -1.0 * abs(ionic_force_tolerance)
         elif ionic_energy_tolerance is not None:

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -194,6 +194,8 @@ class VaspInteractive(VaspBase, GenericInteractive):
                 algorithm=algorithm,
                 retain_charge_density=retain_charge_density,
                 retain_electrostatic_potential=retain_electrostatic_potential,
+                ionic_energy_tolerance=ionic_energy_tolerance,
+                ionic_force_tolerance=ionic_force_tolerance,
                 ionic_energy=ionic_energy,
                 ionic_forces=ionic_forces,
                 volume_only=volume_only,

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -157,6 +157,7 @@ class VaspInteractive(VaspBase, GenericInteractive):
         ionic_energy_tolerance=None,
         ionic_force_tolerance=None,
         volume_only=False,
+        cell_only=False,
     ):
         """
         Function to setup the hamiltonian to perform ionic relaxations using DFT. The ISIF tag has to be supplied
@@ -173,6 +174,7 @@ class VaspInteractive(VaspBase, GenericInteractive):
             ionic_energy_tolerance (float): Ionic energy convergence criteria (eV)
             ionic_force_tolerance (float): Ionic forces convergence criteria (overwrites ionic energy) (ev/A)
             volume_only (bool): Option to relax only the volume (keeping the relative coordinates fixed
+            cell_only (bool): Option to relax only the cell parameters (keeping the relative coordinates fixed)
         """
         if (
             self.server.run_mode.interactive
@@ -193,6 +195,7 @@ class VaspInteractive(VaspBase, GenericInteractive):
                 ionic_energy_tolerance=ionic_energy_tolerance,
                 ionic_force_tolerance=ionic_force_tolerance,
                 volume_only=volume_only,
+                cell_only=cell_only
             )
 
     def calc_md(

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -195,7 +195,7 @@ class VaspInteractive(VaspBase, GenericInteractive):
                 ionic_energy_tolerance=ionic_energy_tolerance,
                 ionic_force_tolerance=ionic_force_tolerance,
                 volume_only=volume_only,
-                cell_only=cell_only
+                cell_only=cell_only,
             )
 
     def calc_md(

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -154,8 +154,6 @@ class VaspInteractive(VaspBase, GenericInteractive):
         algorithm=None,
         retain_charge_density=False,
         retain_electrostatic_potential=False,
-        ionic_energy=None,
-        ionic_forces=None,
         ionic_energy_tolerance=None,
         ionic_force_tolerance=None,
         volume_only=False,
@@ -174,8 +172,6 @@ class VaspInteractive(VaspBase, GenericInteractive):
             retain_electrostatic_potential (boolean): True if the electrostatic potential should be written
             ionic_energy_tolerance (float): Ionic energy convergence criteria (eV)
             ionic_force_tolerance (float): Ionic forces convergence criteria (overwrites ionic energy) (ev/A)
-            ionic_energy (float): Same as ionic_energy_tolerance (deprecated)
-            ionic_forces (float): Same as ionic_force_tolerance (deprecated)
             volume_only (bool): Option to relax only the volume (keeping the relative coordinates fixed
         """
         if (
@@ -196,8 +192,6 @@ class VaspInteractive(VaspBase, GenericInteractive):
                 retain_electrostatic_potential=retain_electrostatic_potential,
                 ionic_energy_tolerance=ionic_energy_tolerance,
                 ionic_force_tolerance=ionic_force_tolerance,
-                ionic_energy=ionic_energy,
-                ionic_forces=ionic_forces,
                 volume_only=volume_only,
             )
 

--- a/tests/vasp/test_vasp.py
+++ b/tests/vasp/test_vasp.py
@@ -420,12 +420,16 @@ class TestVasp(unittest.TestCase):
         self.job.set_convergence_precision(electronic_energy=1e-7, ionic_force_tolerance=0.1)
         self.assertEqual(self.job.input.incar["EDIFF"], 1e-7)
         self.assertEqual(self.job.input.incar["EDIFFG"], -0.1)
+        self.job.set_convergence_precision(ionic_force_tolerance=0.001)
+        self.assertEqual(self.job.input.incar["EDIFFG"], -0.001)
         self.job.calc_minimize()
         self.assertEqual(self.job.input.incar["EDIFFG"], -0.01)
-        self.job.calc_minimize(ionic_energy=1e-4)
-        self.assertEqual(self.job.input.incar["EDIFFG"], 0.0001)
-        self.job.calc_minimize(ionic_forces=1e-3)
-        self.assertEqual(self.job.input.incar["EDIFFG"], -0.001)
+        self.job.calc_minimize(ionic_energy_tolerance=1e-5)
+        self.assertEqual(self.job.input.incar["EDIFFG"], 1e-5,
+                         'ionic energy tolerance not set correctly by calc_minimize')
+        self.job.calc_minimize(ionic_force_tolerance=1e-3)
+        self.assertEqual(self.job.input.incar["EDIFFG"], -0.001,
+                         'ionic force tolerance not set correctly by calc_minimize')
         self.assertEqual(self.job.input.incar["EDIFF"], 1e-7)
 
     def test_mixing_parameter(self):

--- a/tests/vasp/test_vasp.py
+++ b/tests/vasp/test_vasp.py
@@ -418,19 +418,19 @@ class TestVasp(unittest.TestCase):
 
     def test_setting_input(self):
         self.job.set_convergence_precision(electronic_energy=1e-7, ionic_force_tolerance=0.1)
-        self.assertEqual(self.job.input.incar["EDIFF"], 1e-7)
-        self.assertEqual(self.job.input.incar["EDIFFG"], -0.1)
+        self.assertAlmostEqual(self.job.input.incar["EDIFF"], 1e-7)
+        self.assertAlmostEqual(self.job.input.incar["EDIFFG"], -0.1)
         self.job.set_convergence_precision(ionic_force_tolerance=0.001)
-        self.assertEqual(self.job.input.incar["EDIFFG"], -0.001)
+        self.assertAlmostEqual(self.job.input.incar["EDIFFG"], -0.001)
         self.job.calc_minimize()
-        self.assertEqual(self.job.input.incar["EDIFFG"], -0.01)
+        self.assertAlmostEqual(self.job.input.incar["EDIFFG"], -0.01)
         self.job.calc_minimize(ionic_energy_tolerance=1e-5)
-        self.assertEqual(self.job.input.incar["EDIFFG"], 1e-5,
+        self.assertAlmostEqual(self.job.input.incar["EDIFFG"], 1e-5,
                          'ionic energy tolerance not set correctly by calc_minimize')
         self.job.calc_minimize(ionic_force_tolerance=1e-3)
-        self.assertEqual(self.job.input.incar["EDIFFG"], -0.001,
+        self.assertAlmostEqual(self.job.input.incar["EDIFFG"], -0.001,
                          'ionic force tolerance not set correctly by calc_minimize')
-        self.assertEqual(self.job.input.incar["EDIFF"], 1e-7)
+        self.assertAlmostEqual(self.job.input.incar["EDIFF"], 1e-7)
 
     def test_mixing_parameter(self):
         job = self.project.create_job('Vasp', 'mixing_parameter')


### PR DESCRIPTION
1. ionic_{energy,force}_tolerance were previously not propagated; adds also tests for this
2. add the `cell_only` flag to VaspInteractive, `VaspBase` had it already for a while
3. remove the deprecated `ionic_energy` and `ionic_forces` flags, which were the old way of setting 1.  According to git blame we flag this as soon to be removed since at least three years.  I call that long enough.