### PR TITLE
Refactor the lammps collect_output() parser

### DIFF
--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -25,13 +25,10 @@ from pyiron_atomistics.lammps.structure import (
     UnfoldingPrism,
     structure_to_lammps,
 )
-from pyiron_atomistics.lammps.units import UnitConverter, LAMMPS_UNIT_CONVERSIONS
+from pyiron_atomistics.lammps.units import LAMMPS_UNIT_CONVERSIONS
 from pyiron_atomistics.lammps.output import (
-    collect_output_log,
-    collect_h5md_file,
-    collect_dump_file,
-    collect_errors,
     remap_indices,
+    lammps_collect_output_parser,
 )
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal, Jan Janssen"
@@ -462,85 +459,21 @@ class LammpsBase(AtomisticGenericJob):
         log_lammps_file_name="log.lammps",
     ):
         # Parse output files
-        dump_h5_full_file_name = self.job_file_name(
-            file_name=dump_h5_file_name, cwd=cwd
+        return lammps_collect_output_parser(
+            dump_h5_full_file_name=self.job_file_name(
+                file_name=dump_h5_file_name, cwd=cwd
+            ),
+            dump_out_full_file_name=self.job_file_name(
+                file_name=dump_out_file_name, cwd=cwd
+            ),
+            log_lammps_full_file_name=self.job_file_name(
+                file_name=log_lammps_file_name, cwd=cwd
+            ),
+            prism=self._prism,
+            structure=self.structure,
+            potential_elements=self.input.potential.get_element_lst(),
+            units=self.units,
         )
-        dump_out_full_file_name = self.job_file_name(
-            file_name=dump_out_file_name, cwd=cwd
-        )
-        log_lammps_full_file_name = self.job_file_name(
-            file_name=log_lammps_file_name, cwd=cwd
-        )
-        if os.path.isfile(dump_h5_full_file_name):
-            forces, positions, steps, cells = collect_h5md_file(
-                file_name=dump_h5_full_file_name,
-                prism=self._prism,
-            )
-            dump_dict = {
-                "forces": forces,
-                "positions": positions,
-                "steps": steps,
-                "cells": cells,
-            }
-        elif os.path.exists(dump_out_full_file_name):
-            dump_dict = collect_dump_file(
-                file_name=dump_out_full_file_name,
-                prism=self._prism,
-                structure=self.structure,
-                potential_elements=self.input.potential.get_element_lst(),
-            )
-        else:
-            dump_dict = {}
-        if os.path.exists(log_lammps_full_file_name):
-            collect_errors(file_name=log_lammps_full_file_name)
-            generic_keys_lst, pressure_dict, df = collect_output_log(
-                file_name=log_lammps_full_file_name,
-                prism=self._prism,
-            )
-        else:
-            generic_keys_lst, pressure_dict, df = None, None, None
-
-        # convert output to dictionary
-        uc = UnitConverter(self.units)
-        hdf_output = {"generic": {}, "lammps": {}}
-        hdf_generic = hdf_output["generic"]
-        hdf_lammps = hdf_output["lammps"]
-
-        if "computes" in dump_dict.keys():
-            for k, v in dump_dict.pop("computes").items():
-                hdf_generic[k] = uc.convert_array_to_pyiron_units(np.array(v), label=k)
-
-        hdf_generic["steps"] = uc.convert_array_to_pyiron_units(
-            np.array(dump_dict.pop("steps"), dtype=int), label="steps"
-        )
-
-        for k, v in dump_dict.items():
-            if len(v) > 0:
-                hdf_generic[k] = uc.convert_array_to_pyiron_units(np.array(v), label=k)
-
-        if (
-            df is not None
-            and pressure_dict is not None
-            and generic_keys_lst is not None
-        ):
-            for k, v in df.items():
-                if k in generic_keys_lst:
-                    hdf_generic[k] = uc.convert_array_to_pyiron_units(
-                        np.array(v), label=k
-                    )
-            # Store pressures as numpy arrays
-            for key, val in pressure_dict.items():
-                hdf_generic[key] = uc.convert_array_to_pyiron_units(val, label=key)
-
-            # This is a hack for backward comparability
-            for k, v in df.items():
-                if k not in generic_keys_lst:
-                    hdf_lammps[k] = uc.convert_array_to_pyiron_units(
-                        np.array(v), label=k
-                    )
-        else:
-            warnings.warn("LAMMPS warning: No log.lammps output file found.")
-        return hdf_output
 
     def collect_output(self):
         """

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -455,12 +455,16 @@ class LammpsBase(AtomisticGenericJob):
         }
 
     def collect_output_parser(self):
-        dump_h5_file_name = self.job_file_name(file_name="dump.h5", cwd=self.working_directory)
-        dump_out_file_name = self.job_file_name(file_name="dump.out", cwd=self.working_directory)
-        log_lammps_file_name = self.job_file_name(file_name="log.lammps", cwd=self.working_directory)
-        if os.path.isfile(
-                dump_h5_file_name
-        ):
+        dump_h5_file_name = self.job_file_name(
+            file_name="dump.h5", cwd=self.working_directory
+        )
+        dump_out_file_name = self.job_file_name(
+            file_name="dump.out", cwd=self.working_directory
+        )
+        log_lammps_file_name = self.job_file_name(
+            file_name="log.lammps", cwd=self.working_directory
+        )
+        if os.path.isfile(dump_h5_file_name):
             forces, positions, steps, cells = collect_h5md_file(
                 file_name=dump_h5_file_name,
                 prism=self._prism,
@@ -469,7 +473,7 @@ class LammpsBase(AtomisticGenericJob):
                 "forces": forces,
                 "positions": positions,
                 "steps": steps,
-                "cells": cells
+                "cells": cells,
             }
         elif os.path.exists(dump_out_file_name):
             dump_dict = collect_dump_file(
@@ -518,7 +522,11 @@ class LammpsBase(AtomisticGenericJob):
                         np.array(v), label=k
                     )
 
-        if df is not None and pressure_dict is not None and generic_keys_lst is not None:
+        if (
+            df is not None
+            and pressure_dict is not None
+            and generic_keys_lst is not None
+        ):
             with self.project_hdf5.open("output/generic") as hdf_output:
                 # This is a hack for backward comparability
                 for k, v in df.items():

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -448,25 +448,31 @@ class TestLammps(TestWithCleanProject):
         file_directory = os.path.join(
             self.execution_path, "..", "static", "lammps_test_files"
         )
-        self.job.collect_dump_file(cwd=file_directory, file_name="dump_static.out")
-        self.assertTrue(
-            np.array_equal(self.job["output/generic/forces"].shape, (1, 2, 3))
+        output_dict = self.job.collect_output_parser(
+            cwd=file_directory,
+            dump_out_file_name="dump_static.out",
+            log_lammps_file_name="log_not_available"
         )
         self.assertTrue(
-            np.array_equal(self.job["output/generic/positions"].shape, (1, 2, 3))
+            np.array_equal(output_dict["generic"]["forces"].shape, (1, 2, 3))
         )
         self.assertTrue(
-            np.array_equal(self.job["output/generic/cells"].shape, (1, 3, 3))
+            np.array_equal(output_dict["generic"]["positions"].shape, (1, 2, 3))
         )
         self.assertTrue(
-            np.array_equal(self.job["output/generic/indices"].shape, (1, 2))
+            np.array_equal(output_dict["generic"]["cells"].shape, (1, 3, 3))
+        )
+        self.assertTrue(
+            np.array_equal(output_dict["generic"]["indices"].shape, (1, 2))
         )
         # compare to old dump parser
-        old_output = collect_dump_file_old(job=self.job, cwd=file_directory, file_name="dump_static.out")
-        with self.job.project_hdf5.open("output/generic") as hdf_out:
-            for k, v in old_output.items():
-                self.assertTrue(np.all(v == hdf_out[k]))
-
+        old_output = collect_dump_file_old(
+            job=self.job,
+            cwd=file_directory,
+            file_name="dump_static.out"
+        )
+        for k, v in old_output.items():
+            self.assertTrue(np.all(v == output_dict["generic"][k]))
 
     def test_vcsgc_input(self):
         unit_cell = Atoms(
@@ -749,8 +755,11 @@ class TestLammps(TestWithCleanProject):
         file_directory = os.path.join(
             self.execution_path, "..", "static", "lammps_test_files"
         )
-        self.job.collect_dump_file(cwd=file_directory, file_name="dump_average.out")
-        self.job.collect_output_log(cwd=file_directory, file_name="log_average.lammps")
+        _ = self.job.collect_output_parser(
+            cwd=file_directory,
+            dump_out_file_name="dump_average.out",
+            log_lammps_file_name="log_average.lammps"
+        )
 
     def test_validate(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
With this new refactoring we can now run LAMMPS inside functions: 
```python
import subprocess
from pyiron_atomistics import Project
from pyiron_base.jobs.job.util import _copy_restart_files


def initialize_job(job): 
    job.validate_ready_to_run()
    job.project_hdf5.create_working_directory()
    job.write_input()
    _copy_restart_files(job=job)

def execute_subprocess(job):
    executable, shell = job.executable.get_input_for_subprocess_call(
        cores=job.server.cores, threads=job.server.threads, gpus=job.server.gpus
    )
    out = subprocess.run(
        executable,
        cwd=job.project_hdf5.working_directory,
        shell=shell,
        stdout=subprocess.PIPE,
        stderr=subprocess.STDOUT,
        universal_newlines=True,
        check=True,
    ).stdout

def execute_job(job): 
    initialize_job(job=job)
    execute_subprocess(job=job)
    return job.collect_output_parser()


pr = Project("test")
job = pr.create.job.Lammps(job_name="lmp")
job.structure = pr.create.structure.ase.bulk("Al", cubic=True)
output_dict = execute_job(job=job)
```
Input files are written, the executable is called and the output is parsed. But there is no connection to the pyiron database or the HDF5 storage. 