### PR TITLE
Refactor the VASP collect_output() parser

### DIFF
--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -3453,7 +3453,7 @@ def structure_dict_to_hdf(data_dict, hdf, group_name="structure"):
         if "new_species" in data_dict.keys():
             for el, el_dict in data_dict["new_species"].items():
                 chemical_element_dict_to_hdf(
-                    data_dict=el_dict, hdf=hdf, group_name="new_species/" + el
+                    data_dict=el_dict, hdf=hdf_structure, group_name="new_species/" + el
                 )
 
         dict_group_to_hdf(data_dict=data_dict, hdf=hdf_structure, group="tags")

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -34,6 +34,7 @@ from pyiron_atomistics.atomistics.structure.analyse import Analyse
 from pyiron_atomistics.atomistics.structure.periodic_table import (
     PeriodicTable,
     ChemicalElement,
+    chemical_element_dict_to_hdf,
 )
 from pyiron_base import state, deprecate
 from collections.abc import Sequence
@@ -447,6 +448,52 @@ class Atoms(ASEAtoms):
         """
         return self.__copy__()
 
+    def to_dict(self):
+        hdf_structure = {
+            "TYPE": str(type(self)),
+            "units": self.units,
+            "dimension": self.dimension,
+            "positions": self.positions,
+            "info": self.info,
+        }
+        for el in self.species:
+            if isinstance(el.tags, dict):
+                if "new_species" not in hdf_structure.keys():
+                    hdf_structure["new_species"] = {}
+                hdf_structure["new_species"][el.Abbreviation] = el.to_dict()
+        hdf_structure["species"] = [el.Abbreviation for el in self.species]
+        hdf_structure["indices"] = self.indices
+
+        for tag, value in self.arrays.items():
+            if tag in ["positions", "numbers", "indices"]:
+                continue
+            hdf_structure["tags"][tag] = value.tolist()
+
+        if self.cell is not None:
+            # Convert ASE cell object to numpy array before storing
+            hdf_structure["cell"] = {"cell": np.array(self.cell), "pbc": self.pbc}
+
+        if self.has("initial_magmoms"):
+            hdf_structure["spins"] = self.spins
+        # potentials with explicit bonds (TIP3P, harmonic, etc.)
+        if self.bonds is not None:
+            hdf_structure["explicit_bonds"] = self.bonds
+
+        if self._high_symmetry_points is not None:
+            hdf_structure["high_symmetry_points"] = self._high_symmetry_points
+
+        if self._high_symmetry_path is not None:
+            hdf_structure["high_symmetry_path"] = self._high_symmetry_path
+
+        if self.calc is not None:
+            calc_dict = self.calc.todict()
+            calc_dict["label"] = self.calc.label
+            calc_dict["class"] = (
+                self.calc.__class__.__module__ + "." + self.calc.__class__.__name__
+            )
+            hdf_structure["calculator"] = calc_dict
+        return hdf_structure
+
     def to_hdf(self, hdf, group_name="structure"):
         """
         Save the object in a HDF5 file
@@ -457,53 +504,7 @@ class Atoms(ASEAtoms):
                 Group name with which the object should be stored. This same name should be used to retrieve the object
 
         """
-        # import time
-        with hdf.open(group_name) as hdf_structure:
-            hdf_structure["TYPE"] = str(type(self))
-            for el in self.species:
-                if isinstance(el.tags, dict):
-                    with hdf_structure.open("new_species") as hdf_species:
-                        el.to_hdf(hdf_species)
-            hdf_structure["species"] = [el.Abbreviation for el in self.species]
-            hdf_structure["indices"] = self.indices
-
-            with hdf_structure.open("tags") as hdf_tags:
-                for tag, value in self.arrays.items():
-                    if tag in ["positions", "numbers", "indices"]:
-                        continue
-                    hdf_tags[tag] = value.tolist()
-            hdf_structure["units"] = self.units
-            hdf_structure["dimension"] = self.dimension
-
-            if self.cell is not None:
-                with hdf_structure.open("cell") as hdf_cell:
-                    # Convert ASE cell object to numpy array before storing
-                    hdf_cell["cell"] = np.array(self.cell)
-                    hdf_cell["pbc"] = self.pbc
-
-            # hdf_structure["coordinates"] = self.positions  # "Atomic coordinates"
-            hdf_structure["positions"] = self.positions  # "Atomic coordinates"
-            if self.has("initial_magmoms"):
-                hdf_structure["spins"] = self.spins
-            # potentials with explicit bonds (TIP3P, harmonic, etc.)
-            if self.bonds is not None:
-                hdf_structure["explicit_bonds"] = self.bonds
-
-            if self._high_symmetry_points is not None:
-                hdf_structure["high_symmetry_points"] = self._high_symmetry_points
-
-            if self._high_symmetry_path is not None:
-                hdf_structure["high_symmetry_path"] = self._high_symmetry_path
-
-            hdf_structure["info"] = self.info
-
-            if self.calc is not None:
-                calc_dict = self.calc.todict()
-                calc_dict["label"] = self.calc.label
-                calc_dict["class"] = (
-                    self.calc.__class__.__module__ + "." + self.calc.__class__.__name__
-                )
-                hdf_structure["calculator"] = calc_dict
+        structure_dict_to_hdf(data_dict=self.to_dict(), hdf=hdf, group_name=group_name)
 
     def from_hdf(self, hdf, group_name="structure"):
         """
@@ -3439,3 +3440,26 @@ class Symbols(ASESymbols):
             )
             for i, el in enumerate(replace_elements):
                 self._structure[index_array[i]] = el
+
+
+def structure_dict_to_hdf(data_dict, hdf, group_name="structure"):
+    with hdf.open(group_name) as hdf_structure:
+        for k, v in data_dict.items():
+            if k not in ["new_species", "cell", "tags"]:
+                hdf_structure[k] = v
+
+        if "new_species" in data_dict.keys():
+            for el, el_dict in data_dict["new_species"].items():
+                chemical_element_dict_to_hdf(
+                    data_dict=el_dict, hdf=hdf, group_name="new_species/" + el
+                )
+
+        dict_group_to_hdf(data_dict=data_dict, hdf=hdf_structure, group="tags")
+        dict_group_to_hdf(data_dict=data_dict, hdf=hdf_structure, group="cell")
+
+
+def dict_group_to_hdf(data_dict, hdf, group):
+    if group in data_dict.keys():
+        with hdf.open(group) as hdf_tags:
+            for k, v in data_dict[group].items():
+                hdf_tags[k] = v

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -467,6 +467,8 @@ class Atoms(ASEAtoms):
         for tag, value in self.arrays.items():
             if tag in ["positions", "numbers", "indices"]:
                 continue
+            if "tags" not in hdf_structure.keys():
+                hdf_structure["tags"] = {}
             hdf_structure["tags"][tag] = value.tolist()
 
         if self.cell is not None:

--- a/pyiron_atomistics/atomistics/structure/periodic_table.py
+++ b/pyiron_atomistics/atomistics/structure/periodic_table.py
@@ -160,10 +160,11 @@ class ChemicalElement(object):
         if self.Parent is not None:
             self._dataset = {"Parameter": ["Parent"], "Value": [self.Parent]}
             hdf_el["elementData"] = self._dataset
-        for key in self.tags.keys():
-            hdf_el["tagData"][key] = self.tags[
-                key
-            ]  # "Dictionary of element tag static"
+        # "Dictionary of element tag static"
+        hdf_el["tagData"] = {
+            key: self.tags[key]
+            for key in self.tags.keys()
+        }
         return hdf_el
 
     def to_hdf(self, hdf):

--- a/pyiron_atomistics/atomistics/structure/periodic_table.py
+++ b/pyiron_atomistics/atomistics/structure/periodic_table.py
@@ -161,10 +161,7 @@ class ChemicalElement(object):
             self._dataset = {"Parameter": ["Parent"], "Value": [self.Parent]}
             hdf_el["elementData"] = self._dataset
         # "Dictionary of element tag static"
-        hdf_el["tagData"] = {
-            key: self.tags[key]
-            for key in self.tags.keys()
-        }
+        hdf_el["tagData"] = {key: self.tags[key] for key in self.tags.keys()}
         return hdf_el
 
     def to_hdf(self, hdf):

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -2325,7 +2325,7 @@ class GenericOutput:
             hdf_dft[key] = val
         hdf_go["dft"] = hdf_dft
         if self.bands.eigenvalue_matrix is not None:
-            hdf_go["bands"] = self.bands.to_dict()
+            hdf_go["dft"]["bands"] = self.bands.to_dict()
         return hdf_go
 
     def from_hdf(self, hdf):

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -2318,11 +2318,12 @@ class GenericOutput:
         )
 
     def to_dict(self):
-        hdf_go = {}
+        hdf_go, hdf_dft = {}, {}
         for key, val in self.log_dict.items():
             hdf_go[key] = val
         for key, val in self.dft_log_dict.items():
-            hdf_go["dft"][key] = val
+            hdf_dft[key] = val
+        hdf_go["dft"] = hdf_dft
         if self.bands.eigenvalue_matrix is not None:
             hdf_go["bands"] = self.bands.to_dict()
         return hdf_go
@@ -2571,7 +2572,13 @@ def generic_output_dict_to_hdf(data_dict, hdf, group_name="generic"):
 def output_dict_to_hdf(data_dict, hdf, group_name="output"):
     with hdf.open(group_name) as hdf5_output:
         for k, v in data_dict.items():
-            if k not in ["structure"]:
+            if k not in [
+                "structure",
+                "electrostatic_potential",
+                "charge_density",
+                "electronic_structure",
+                "outcar",
+            ]:
                 hdf5_output[k] = v
 
         if "structure" in data_dict.keys():

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -2561,7 +2561,7 @@ def generic_output_dict_to_hdf(data_dict, hdf, group_name="generic"):
                 if k not in ["bands"]:
                     hdf_dft[k] = v
 
-            if "bands" in data_dict["dft"].keys:
+            if "bands" in data_dict["dft"].keys():
                 electronic_structure_dict_to_hdf(
                     data_dict=data_dict["dft"]["bands"],
                     hdf=hdf_dft,
@@ -2573,6 +2573,7 @@ def output_dict_to_hdf(data_dict, hdf, group_name="output"):
     with hdf.open(group_name) as hdf5_output:
         for k, v in data_dict.items():
             if k not in [
+                "generic",
                 "structure",
                 "electrostatic_potential",
                 "charge_density",
@@ -2580,6 +2581,13 @@ def output_dict_to_hdf(data_dict, hdf, group_name="output"):
                 "outcar",
             ]:
                 hdf5_output[k] = v
+
+        if "generic" in data_dict.keys():
+            generic_output_dict_to_hdf(
+                data_dict=data_dict["generic"],
+                hdf=hdf5_output,
+                group_name="generic",
+            )
 
         if "structure" in data_dict.keys():
             structure_dict_to_hdf(

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -2595,10 +2595,11 @@ def output_dict_to_hdf(data_dict, hdf, group_name="output"):
                 group_name="charge_density",
             )
 
-        electronic_structure_dict_to_hdf(
-            data_dict=data_dict["electronic_structure"],
-            hdf=hdf5_output,
-            group_name="electronic_structure",
-        )
+        if "electronic_structure" in data_dict.keys():
+            electronic_structure_dict_to_hdf(
+                data_dict=data_dict["electronic_structure"],
+                hdf=hdf5_output,
+                group_name="electronic_structure",
+            )
 
         dict_group_to_hdf(data_dict=data_dict, hdf=hdf5_output, group="outcar")

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -16,7 +16,12 @@ from pyiron_atomistics.vasp.potential import (
     Potcar,
     strip_xc_from_potential_name,
 )
-from pyiron_atomistics.atomistics.structure.atoms import Atoms, CrystalStructure
+from pyiron_atomistics.atomistics.structure.atoms import (
+    Atoms,
+    CrystalStructure,
+    structure_dict_to_hdf,
+    dict_group_to_hdf,
+)
 from pyiron_base import state, GenericParameters, deprecate
 from pyiron_atomistics.vasp.outcar import Outcar
 from pyiron_atomistics.vasp.oszicar import Oszicar
@@ -24,9 +29,15 @@ from pyiron_atomistics.vasp.procar import Procar
 from pyiron_atomistics.vasp.structure import read_atoms, write_poscar, vasp_sorter
 from pyiron_atomistics.vasp.vasprun import Vasprun as Vr
 from pyiron_atomistics.vasp.vasprun import VasprunError, VasprunWarning
-from pyiron_atomistics.vasp.volumetric_data import VaspVolumetricData
+from pyiron_atomistics.vasp.volumetric_data import (
+    VaspVolumetricData,
+    volumetric_data_dict_to_hdf,
+)
 from pyiron_atomistics.vasp.potential import get_enmax_among_potentials
-from pyiron_atomistics.dft.waves.electronic import ElectronicStructure
+from pyiron_atomistics.dft.waves.electronic import (
+    ElectronicStructure,
+    electronic_structure_dict_to_hdf,
+)
 from pyiron_atomistics.dft.waves.bandstructure import Bandstructure
 from pyiron_atomistics.dft.bader import Bader
 import warnings
@@ -376,8 +387,7 @@ class VaspBase(GenericDFTJob):
             modified_elements=modified_elements,
         )
 
-    # define routines that collect all output files
-    def collect_output(self):
+    def collect_output_parser(self):
         """
         Collects the outputs and stores them to the hdf file
         """
@@ -431,7 +441,16 @@ class VaspBase(GenericDFTJob):
                 self._output_parser.generic_output.dft_log_dict[
                     "bader_volumes"
                 ] = volumes
-        self._output_parser.to_hdf(self._hdf5)
+        return self._output_parser.to_dict()
+
+    # define routines that collect all output files
+    def collect_output(self):
+        """
+        Collects the outputs and stores them to the hdf file
+        """
+        output_dict_to_hdf(
+            data_dict=self.collect_output_parser(), hdf=self._hdf5, group_name="output"
+        )
         if len(self._exclude_groups_hdf) > 0 or len(self._exclude_nodes_hdf) > 0:
             self.project_hdf5.rewrite_hdf5()
 
@@ -2199,6 +2218,30 @@ class Output:
             )
         self.generic_output.bands = self.electronic_structure
 
+    def to_dict(self):
+        hdf5_output = {
+            "description": self.description,
+            "generic": self.generic_output.to_dict(),
+        }
+
+        if self._structure is not None:
+            hdf5_output["structure"] = self.structure.to_dict()
+
+        if self.electrostatic_potential.total_data is not None:
+            hdf5_output[
+                "electrostatic_potential"
+            ] = self.electrostatic_potential.to_dict()
+
+        if self.charge_density.total_data is not None:
+            hdf5_output["charge_density"] = self.charge_density.to_dict()
+
+        if len(self.electronic_structure.kpoint_list) > 0:
+            hdf5_output["electronic_structure"] = self.electronic_structure.to_dict()
+
+        if len(self.outcar.parse_dict.keys()) > 0:
+            hdf5_output["outcar"] = self.outcar.to_dict_minimal()
+        return hdf5_output
+
     def to_hdf(self, hdf):
         """
         Save the object in a HDF5 file
@@ -2207,34 +2250,7 @@ class Output:
             hdf (pyiron_base.generic.hdfio.ProjectHDFio): HDF path to which the object is to be saved
 
         """
-        with hdf.open("output") as hdf5_output:
-            hdf5_output["description"] = self.description
-            self.generic_output.to_hdf(hdf5_output)
-            try:
-                self.structure.to_hdf(hdf5_output)
-            except AttributeError:
-                pass
-
-            # with hdf5_output.open("vasprun") as hvr:
-            #  if self.vasprun.dict_vasprun is not None:
-            #     for key, val in self.vasprun.dict_vasprun.items():
-            #        hvr[key] = val
-
-            if self.electrostatic_potential.total_data is not None:
-                self.electrostatic_potential.to_hdf(
-                    hdf5_output, group_name="electrostatic_potential"
-                )
-
-            if self.charge_density.total_data is not None:
-                self.charge_density.to_hdf(hdf5_output, group_name="charge_density")
-
-            if len(self.electronic_structure.kpoint_list) > 0:
-                self.electronic_structure.to_hdf(
-                    hdf=hdf5_output, group_name="electronic_structure"
-                )
-
-            if len(self.outcar.parse_dict.keys()) > 0:
-                self.outcar.to_hdf_minimal(hdf=hdf5_output, group_name="outcar")
+        output_dict_to_hdf(data_dict=self.to_dict(), hdf=hdf, group_name="output")
 
     def from_hdf(self, hdf):
         """
@@ -2297,15 +2313,19 @@ class GenericOutput:
             hdf (pyiron_base.generic.hdfio.ProjectHDFio): HDF path to which the object is to be saved
 
         """
-        with hdf.open("generic") as hdf_go:
-            # hdf_go["description"] = self.description
-            for key, val in self.log_dict.items():
-                hdf_go[key] = val
-            with hdf_go.open("dft") as hdf_dft:
-                for key, val in self.dft_log_dict.items():
-                    hdf_dft[key] = val
-                if self.bands.eigenvalue_matrix is not None:
-                    self.bands.to_hdf(hdf_dft, "bands")
+        generic_output_dict_to_hdf(
+            data_dict=self.to_dict(), hdf=hdf, group_name="generic"
+        )
+
+    def to_dict(self):
+        hdf_go = {}
+        for key, val in self.log_dict.items():
+            hdf_go[key] = val
+        for key, val in self.dft_log_dict.items():
+            hdf_go["dft"][key] = val
+        if self.bands.eigenvalue_matrix is not None:
+            hdf_go["bands"] = self.bands.to_dict()
+        return hdf_go
 
     def from_hdf(self, hdf):
         """
@@ -2527,3 +2547,58 @@ def get_k_mesh_by_cell(cell, kspace_per_in_ang=0.10):
 
 class VaspCollectError(ValueError):
     pass
+
+
+def generic_output_dict_to_hdf(data_dict, hdf, group_name="generic"):
+    with hdf.open(group_name) as hdf_go:
+        for k, v in data_dict.items():
+            if k not in ["dft"]:
+                hdf_go[k] = v
+
+        with hdf_go.open("dft") as hdf_dft:
+            for k, v in data_dict["dft"].items():
+                if k not in ["bands"]:
+                    hdf_dft[k] = v
+
+            if "bands" in data_dict["dft"].keys:
+                electronic_structure_dict_to_hdf(
+                    data_dict=data_dict["dft"]["bands"],
+                    hdf=hdf_dft,
+                    group_name="bands",
+                )
+
+
+def output_dict_to_hdf(data_dict, hdf, group_name="output"):
+    with hdf.open(group_name) as hdf5_output:
+        for k, v in data_dict.items():
+            if k not in ["structure"]:
+                hdf5_output[k] = v
+
+        if "structure" in data_dict.keys():
+            structure_dict_to_hdf(
+                data_dict=data_dict["structure"],
+                hdf=hdf5_output,
+                group_name="structure",
+            )
+
+        if "electrostatic_potential" in data_dict.keys():
+            volumetric_data_dict_to_hdf(
+                data_dict=data_dict["electrostatic_potential"],
+                hdf=hdf5_output,
+                group_name="electrostatic_potential",
+            )
+
+        if "charge_density" in data_dict.keys():
+            volumetric_data_dict_to_hdf(
+                data_dict=data_dict["charge_density"],
+                hdf=hdf5_output,
+                group_name="charge_density",
+            )
+
+        electronic_structure_dict_to_hdf(
+            data_dict=data_dict["electronic_structure"],
+            hdf=hdf5_output,
+            group_name="electronic_structure",
+        )
+
+        dict_group_to_hdf(data_dict=data_dict, hdf=hdf5_output, group="outcar")

--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -152,6 +152,12 @@ class Outcar(object):
             hdf (pyiron_base.generic.hdfio.FileHDFio): HDF5 group or file
             group_name (str): Name of the HDF5 group
         """
+        with hdf.open(group_name) as hdf5_output:
+            for k, v in self.to_dict_minimal().items():
+                hdf5_output[k] = v
+
+    def to_dict_minimal(self):
+        hdf5_output = {}
         unique_quantities = [
             "kin_energy_error",
             "broyden_mixing",
@@ -162,10 +168,10 @@ class Outcar(object):
             "energy_components",
             "resources",
         ]
-        with hdf.open(group_name) as hdf5_output:
-            for key in self.parse_dict.keys():
-                if key in unique_quantities:
-                    hdf5_output[key] = self.parse_dict[key]
+        for key in self.parse_dict.keys():
+            if key in unique_quantities:
+                hdf5_output[key] = self.parse_dict[key]
+        return hdf5_output
 
     def from_hdf(self, hdf, group_name="outcar"):
         """

--- a/pyiron_atomistics/vasp/volumetric_data.py
+++ b/pyiron_atomistics/vasp/volumetric_data.py
@@ -277,6 +277,15 @@ class VaspVolumetricData(VolumetricData):
     def diff_data(self, val):
         self._diff_data = val
 
+    def to_dict(self):
+        volumetric_data_dict = {
+            "TYPE": str(type(self)),
+            "total": self.total_data,
+        }
+        if self.diff_data is not None:
+            volumetric_data_dict["diff"] = self.diff_data
+        return volumetric_data_dict
+
     def to_hdf(self, hdf, group_name="volumetric_data"):
         """
         Writes the data as a group to a HDF5 file
@@ -286,11 +295,11 @@ class VaspVolumetricData(VolumetricData):
             group_name (str): The name of the group under which the data must be stored as
 
         """
-        with hdf.open(group_name) as hdf_vd:
-            hdf_vd["TYPE"] = str(type(self))
-            hdf_vd["total"] = self.total_data
-            if self.diff_data is not None:
-                hdf_vd["diff"] = self.diff_data
+        volumetric_data_dict_to_hdf(
+            data_dict=self.to_dict(),
+            hdf=hdf,
+            group_name=group_name,
+        )
 
     def from_hdf(self, hdf, group_name="volumetric_data"):
         """
@@ -308,3 +317,9 @@ class VaspVolumetricData(VolumetricData):
             self._total_data = hdf_vd["total"]
             if "diff" in hdf_vd.list_nodes():
                 self._diff_data = hdf_vd["diff"]
+
+
+def volumetric_data_dict_to_hdf(data_dict, hdf, group_name="volumetric_data"):
+    with hdf.open(group_name) as hdf_vd:
+        for k, v in data_dict.items():
+            hdf_vd[k] = v


### PR DESCRIPTION
Example:
```python
import subprocess
from pyiron_atomistics import Project
from pyiron_base.jobs.job.util import _copy_restart_files

def initialize_job(job): 
    job.validate_ready_to_run()
    job.project_hdf5.create_working_directory()
    job.write_input()
    _copy_restart_files(job=job)

def execute_subprocess(job):
    executable, shell = job.executable.get_input_for_subprocess_call(
        cores=job.server.cores, threads=job.server.threads, gpus=job.server.gpus
    )
    out = subprocess.run(
        executable,
        cwd=job.project_hdf5.working_directory,
        shell=shell,
        stdout=subprocess.PIPE,
        stderr=subprocess.STDOUT,
        universal_newlines=True,
        check=True,
    ).stdout

def execute_job(job): 
    initialize_job(job=job)
    execute_subprocess(job=job)
    return job.collect_output_parser(cwd=job.working_directory)


pr = Project("test")
job = pr.create.job.Vasp("vasp")
job.structure = pr.create.structure.ase.bulk("Al", cubic=True)
output_dict = execute_job(job)
output_dict
```