### PR TITLE
Accelerate import by only loading mendeleev and pymatgen when needed

### DIFF
--- a/pyiron_atomistics/atomistics/structure/factories/materialsproject.py
+++ b/pyiron_atomistics/atomistics/structure/factories/materialsproject.py
@@ -1,5 +1,4 @@
 from typing import Union, List
-from mp_api.client import MPRester
 from pyiron_atomistics.atomistics.structure.has_structure import HasStructure
 from pyiron_atomistics.atomistics.structure.structurestorage import StructureStorage
 from pyiron_atomistics.atomistics.structure.atoms import pymatgen_to_pyiron, Atoms
@@ -107,6 +106,7 @@ class MaterialsProjectFactory:
         Returns:
             :class:`~.MPQueryResults`: resulting structures from the query
         """
+        from mp_api.client import MPRester
         rest_kwargs = {
             "use_document_model": False,  # returns results as dictionaries
             "include_user_agent": True,  # send some additional software version info to MP

--- a/pyiron_atomistics/atomistics/structure/factories/materialsproject.py
+++ b/pyiron_atomistics/atomistics/structure/factories/materialsproject.py
@@ -107,6 +107,7 @@ class MaterialsProjectFactory:
             :class:`~.MPQueryResults`: resulting structures from the query
         """
         from mp_api.client import MPRester
+
         rest_kwargs = {
             "use_document_model": False,  # returns results as dictionaries
             "include_user_agent": True,  # send some additional software version info to MP

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -119,6 +119,7 @@ class StructureFactory(PyironFactory):
 
     def read_using_pymatgen(self, *args, **kwargs):
         from pymatgen.core import Structure
+
         return pymatgen_to_pyiron(Structure.from_file(*args, **kwargs))
 
     def read_using_ase(self, *args, **kwargs):

--- a/pyiron_atomistics/atomistics/structure/factory.py
+++ b/pyiron_atomistics/atomistics/structure/factory.py
@@ -49,7 +49,6 @@ from pyiron_atomistics.atomistics.structure.atoms import (
     pymatgen_to_pyiron,
     ovito_to_pyiron,
 )
-from pymatgen.core import Structure
 from pyiron_atomistics.atomistics.structure.periodic_table import PeriodicTable
 from pyiron_base import state, PyironFactory, deprecate
 import types
@@ -119,6 +118,7 @@ class StructureFactory(PyironFactory):
     read.__doc__ = AseFactory.read.__doc__
 
     def read_using_pymatgen(self, *args, **kwargs):
+        from pymatgen.core import Structure
         return pymatgen_to_pyiron(Structure.from_file(*args, **kwargs))
 
     def read_using_ase(self, *args, **kwargs):

--- a/pyiron_atomistics/atomistics/structure/periodic_table.py
+++ b/pyiron_atomistics/atomistics/structure/periodic_table.py
@@ -6,7 +6,6 @@ from __future__ import print_function, unicode_literals
 import numpy as np
 import os
 from pyiron_base import state
-import mendeleev
 import pandas
 from functools import lru_cache
 
@@ -26,6 +25,7 @@ pandas.options.mode.chained_assignment = None
 
 @lru_cache(maxsize=118)
 def element(*args):
+    import mendeleev
     return mendeleev.element(*args)
 
 

--- a/pyiron_atomistics/atomistics/structure/periodic_table.py
+++ b/pyiron_atomistics/atomistics/structure/periodic_table.py
@@ -26,6 +26,7 @@ pandas.options.mode.chained_assignment = None
 @lru_cache(maxsize=118)
 def element(*args):
     import mendeleev
+
     return mendeleev.element(*args)
 
 


### PR DESCRIPTION
These changes speed up the import of pyiron by approximately a factor 4. 