### PR TITLE
vasp_6_4 ML parser - sphinx  eigenvalues parser

### DIFF
--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -2286,6 +2286,7 @@ class _SphinxLogParser:
         arr = np.loadtxt(re.findall(term, self.log_main, re.MULTILINE))
         shape = (-1, len(self.k_points), arr.shape[-1])
         if self.spin_enabled:
+            arr = np.vstack((arr[::2], arr[1::2]))
             shape = (-1, 2, len(self.k_points), shape[-1])
         return arr.reshape(shape)
 


### PR DESCRIPTION
This is a draft (work still under progress) for the sphinx eigenvalues parser and vasp 6.4 ML potential parser. 
- Changes to take into consideration (and also test):
1. running ML job print out the following: for each DFT step you have two outputs: 1. DFT results 2. Dummy zeroes with ML label and for each ML step, you have only one output. This confuses the already existing parser.
2. To fix this, two new variables: ml_steps, dft_steps to track the indices in the outcar steps of which values are to parse as ML or DFT
3. Other quantities: volume change, stresses, and temperature come from DFT and ML
4. We also parse all energies and from that, we parse only DFT and ML energies
5. This becomes problematic with the new (and also old) get_steps function (needs to be fixed).
6. It is also important to note that certain quantities only get printed out from DFT steps: scf_energies, magnetization??, and eigenvalues?? (here dft_steps comes to play).
7. We currently don't know if this DFT+ML run can go back and rerun DFT steps after some ML steps (active learning style) or only go in one direction: training -> production fashion.
8. Whether this parser will be problematic with regular Vasp jobs or not is also to be tested.
9. get_energy_without_entropy_from_line parsing (line splitting) was changed as the additional ML string at the beginning breaks the parser.
10. def get_index_type(filename="OUTCAR", lines=None): was introduced to save the ml_steps/dft_steps
11. selective parsing is currently done in this fashion: self.parse_dict["energies_int"] = [energies_int[i] for i in dft_index] whether a nicer way to do it should also be done (filter function)??

- Changes to consider for the sphinx parser
12.  This fix should fix the eigenvalues for the static calculations (shape: n_electronic_steps) but for the minimization calculation (shape: n_ionic_stepsxn_electronic_steps) this fix still does not work.
13. Sphinx does not parse eigenvalues for all steps, it currently only parses the last step.
