### PR TITLE
Update the temperature reading in outcar.py

### DIFF
--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -647,7 +647,7 @@ class Outcar(object):
                 try:
                     temperatures.append(float(output_string))
                 except ValueError:
-                    warnings.warn(f"Temperature too high. Vasp output: {line}") 
+                    warnings.warn(f"Temperature too high. Vasp output: {line}")
                     temperatures.append(np.nan)
         else:
             temperatures = np.zeros(

--- a/pyiron_atomistics/vasp/outcar.py
+++ b/pyiron_atomistics/vasp/outcar.py
@@ -643,7 +643,12 @@ class Outcar(object):
             for j in trigger_indices:
                 line = lines[j].strip()
                 line = _clean_line(line)
-                temperatures.append(float(line.split()[-2]))
+                output_string = line.split('temperature')[-1].split()[0]
+                try:
+                    temperatures.append(float(output_string))
+                except ValueError:
+                    warnings.warn(f"Temperature too high. Vasp output: {line}") 
+                    temperatures.append(np.nan)
         else:
             temperatures = np.zeros(
                 len(


### PR DESCRIPTION
Changed the reading of temperature in OUTCAR. When vasp outputs too high temperature, the parser can now read it and throw a warning when the output is "******"