### PR TITLE
Correctly scale output from phonopy jobs in QuasiHarmonic

### DIFF
--- a/pyiron_atomistics/atomistics/master/quasi.py
+++ b/pyiron_atomistics/atomistics/master/quasi.py
@@ -110,6 +110,12 @@ class QuasiHarmonicJob(AtomisticParallelMaster):
         free_energy_lst, entropy_lst, cv_lst, volume_lst = [], [], [], []
         for job_id in self.child_ids:
             job = self.project_hdf5.load(job_id)
+            # the underlying phonopy job might create a supercell; if its
+            # reference job is interactive this is reflected in its
+            # job.structure and the output quantities, so we need to rescale
+            # all the output here; if the structure did not change the
+            # conversion_factor will simply be 1.
+            conversion_factor = len(self.structure) / len(job.structure)
             thermal_properties = job.get_thermal_properties(
                 temperatures=np.linspace(
                     self.input["temperature_start"],
@@ -117,10 +123,10 @@ class QuasiHarmonicJob(AtomisticParallelMaster):
                     int(self.input["temperature_steps"]),
                 )
             )
-            free_energy_lst.append(thermal_properties.free_energies)
-            entropy_lst.append(thermal_properties.entropy)
-            cv_lst.append(thermal_properties.cv)
-            volume_lst.append(job.structure.get_volume())
+            free_energy_lst.append(thermal_properties.free_energies * conversion_factor)
+            entropy_lst.append(thermal_properties.entropy * conversion_factor)
+            cv_lst.append(thermal_properties.cv * conversion_factor)
+            volume_lst.append(job.structure.get_volume() * conversion_factor)
 
         arg_lst = np.argsort(volume_lst)
 

--- a/pyiron_atomistics/atomistics/master/quasi.py
+++ b/pyiron_atomistics/atomistics/master/quasi.py
@@ -183,10 +183,17 @@ class QuasiHarmonicJob(AtomisticParallelMaster):
                 fit_funct=fit, x=v, save_range=0.0, return_ind=True
             )
 
-            v0_lst.append(v0)
-            free_eng_lst.append(fit([v0]))
-            entropy_lst.append(entropy[ind])
-            cv_lst.append(cv[ind])
+            if v0 is not None:
+                v0_lst.append(v0)
+                free_eng_lst.append(fit(v0))
+                entropy_lst.append(entropy[ind])
+                cv_lst.append(cv[ind])
+            else:
+                v0_lst.append(np.nan)
+                free_eng_lst.append(np.nan)
+                entropy_lst.append(np.nan)
+                cv_lst.append(np.nan)
+
         return v0_lst, free_eng_lst, entropy_lst, cv_lst
 
     def plot_free_energy_volume_temperature(


### PR DESCRIPTION
This issue pops up if you run QuasiHarmonic/Phonopy with an interactive Lammps reference job. If you then call `optimize_volume` with the energies from a murnaghan with the same structure that you provided to the QuasiHarmonicJob the optimization will fail, because the free energies from phonopy might be for a larger supercell.  I don't know if the issue also exists with other combinations of run modes.  I'm also not sure if the heat capacities need to be rescaled or if phonopy already outputs a size normalized value.