### PR TITLE
Patch emmet missing custodian

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -7,6 +7,7 @@ dependencies:
 - coveralls
 - coverage
 - codacy-coverage
+- custodian =2023.10.9
 - defusedxml =0.7.1
 - h5py =3.10.0
 - matplotlib-base =3.8.1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,3 +17,4 @@ dependencies:
 - pyiron-data >=0.0.22
 - sqsgenerator
 - structuretoolkit
+- custodian

--- a/fd
+++ b/fd
@@ -1,0 +1,1 @@
+/home/bruns/.local/bin/fd

--- a/fd
+++ b/fd
@@ -1,1 +1,0 @@
-/home/bruns/.local/bin/fd

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -2019,8 +2019,12 @@ class Output:
                 "n_elect"
             ]
             if len(self.outcar.parse_dict["magnetization"]) > 0:
-                magnetization = np.array(self.outcar.parse_dict["magnetization"], dtype=object)
-                final_magmoms = np.array(self.outcar.parse_dict["final_magmoms"], dtype=object)
+                magnetization = np.array(
+                    self.outcar.parse_dict["magnetization"], dtype=object
+                )
+                final_magmoms = np.array(
+                    self.outcar.parse_dict["final_magmoms"], dtype=object
+                )
                 # magnetization[sorted_indices] = magnetization.copy()
                 if len(final_magmoms) != 0:
                     if len(final_magmoms.shape) == 3:

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'ase==3.22.1',
         'atomistics==0.0.6',
         'defusedxml==0.7.1',
+        'custodian==2023.10.09',
         'h5py==3.10.0',
         'matplotlib==3.8.1',
         'mendeleev==0.14.0',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'ase==3.22.1',
         'atomistics==0.0.6',
         'defusedxml==0.7.1',
-        'custodian==2023.10.09',
+        'custodian==2023.10.9',
         'h5py==3.10.0',
         'matplotlib==3.8.1',
         'mendeleev==0.14.0',

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ setup(
         'pint==0.22',
         'pyiron_base==0.6.8',
         'scipy==1.11.3',
-        'seekpath==2.1.0',
         'scikit-learn==1.3.2',
+        'seekpath==2.1.0',
         'spglib==2.1.0',
         'structuretoolkit==0.0.11'
     ],


### PR DESCRIPTION
The materialsproject's `emmet-core`, on which we depend via `mp-api`, is missing to declare its dependency on `custodian`. This causes our CI and notebook runs to fail, with error messages like `from custodian.vasp.jobs import VaspJob; ModuleNotFoundError: No module named 'custodian'`. This patch provides a hotfix for this.

Maybe this shouldn't be merged, as I will also raise an issue on [`emmet`'s](https://github.com/materialsproject/emmet) repo, as it's a cleaner solution if they declare this dependency explicitly. 