### PR TITLE
new sx structure parser that tolerates unexpected items

### DIFF
--- a/pyiron_atomistics/sphinx/parser_base.py
+++ b/pyiron_atomistics/sphinx/parser_base.py
@@ -1,0 +1,188 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+__author__ = "Christoph Freysoldt"
+__copyright__ = (
+    "Copyright 2023, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Christoph Freysoldt"
+__email__ = "freysoldt@mpie.de"
+__status__ = "production"
+__date__ = "Dec 8, 2023"
+
+import re
+from types import GeneratorType
+import numpy
+
+class keyword_tree_parser:
+    """
+    A base class to parse files block by block via keyword-triggered
+    parsing routines organized in a tree. Parsing routines can
+    add more levels of keyword->parse function maps. The file
+    is read line by line on demand while parsing, so large files will not clobber
+    memory.
+
+    A parser routine can either return or yield (once!) to continue parsing. If it yields,
+    the rest of the routine (after yield) will be executed when the next keyword
+    of the current or a higher level is found.
+
+    Every parser routine MUST remove the keyword from the lineview.
+
+    A typical use will be
+
+    class my_parser(keyword_tree_parser):
+        def __init__(self,file)
+            super ().__init__({
+                    "key1" : self.parse_key1,
+                    "key2" : self.parse_key2  })
+            self.parse (file)
+
+    """
+    def __init__ (self,keylevels=[]):
+        if isinstance(keylevels,dict):
+            keylevels = [ keylevels ]
+        elif not isinstance(keylevels,list):
+            raise TypeError
+        self.keylevels = keylevels
+
+    def parse(self,filename):
+        """
+        Parse a file using the current keylevels
+
+        Args:
+            filename ... the filename of the file to parse
+        Returns: nothing
+        """
+        # --- initialization
+        if len(self.keylevels) == 0:
+           raise KeyError("No parsing functions available in keylevels")
+        filehandle = open(filename)
+        self.line = filehandle.__iter__ ()
+        self.lineview = ''
+        self.filename = filename
+        self.lineno = 0
+        while True:
+            for keymap in self.keylevels:
+                for key,func in keymap.items ():
+                    if key in self.lineview:
+                        self._cleanup(keymap)
+                        res = func ()
+                        if isinstance(res,GeneratorType):
+                            res.send (None)
+                            keymap['%finalize!'] = res
+                        break
+                else:
+                    continue
+                break
+            else:
+                try:
+                    self.lineview = next(self.line)
+                    self.lineno += 1
+                    self.line_from = self.lineno
+                except StopIteration:
+                    break
+        self._cleanup(self.keylevels[0])
+        if (hasattr(self,'finalize')):
+            self.finalize ()
+
+    def location(self):
+        """ Return the current parsing location (for error messages)"""
+        return f"in file '{self.filename}' line" + \
+               ( f" {self.lineno}" if self.lineno == self.line_from else
+                 f"s {self.line_from}..{self.lineno}" )
+
+    def read_until(self, match):
+        """
+        Appends more lines from input until match is found
+
+        Args:
+           match ... (str) what to wait for
+        Returns: nothing
+        """
+        while not match in self.lineview:
+            self.lineview += next(self.line)
+            self.lineno += 1
+            self.lineFrom = self.line
+
+    def extract_via_regex(self, regex):
+        """
+        Extracts and removes some text from current lineview
+
+        Args:
+           regex ... regular expression
+        Returns:
+           the extracted text
+        """
+        if isinstance(regex, str):
+            regex = re.compile (regex, re.DOTALL)
+        result = regex.search(self.lineview)
+        if result is None:
+            raise RuntimeError(f"Failed to extract '{regex.pattern}' "
+                               + self.location ()
+                               + "\n" + self.lineview)
+        self.lineview = regex.sub ('',self.lineview, count=1)
+        return result.group ()
+
+    def _cleanup(self, active):
+        """
+        (internal routine) remove levels below the current (active) level, and
+         call (optional) final blocks up to the current level
+
+        Args:
+           active ... the currently active map
+        Returns:
+           the extracted text
+        """
+        def try_finalize(keymap):
+            if '%finalize!' in keymap:
+                try:
+                    next(keymap['%finalize!'])
+                except StopIteration:
+                    pass
+                del keymap['%finalize!']
+        # roll back keylevels until active level
+        while (self.keylevels[-1] is not active):
+            try_finalize (self.keylevels[-1])
+            del self.keylevels[-1]
+        # and call optional finalize of currently active level
+        try_finalize(active)
+
+    def get_vector (self, key, txt):
+        """
+        (auxiliary function) Get a vector from 'key = [ ... ] ;'
+
+        Args:
+           key ... the key to look for
+        Returns:
+           one-dimensional vector containing the numbers
+        """
+        # get the relevant part between '=' and ';'
+        vecstring = re.sub ('.*' + key + r"\s*=\s*([^;]+);.*", r"\1", txt)
+        if vecstring is None:
+            raise RuntimeError(f"Cannot parse {key} from '{txt}' as vector "
+                               + self.location ())
+        # remove special characters [] , ; =
+        vecstring = re.sub(r"[][=,;$]",' ',vecstring)
+        return numpy.fromstring(vecstring, sep=' ')
+
+    def extract_var(self, key, startend='=;'):
+        """
+        Extract a block 'key = ... ;'
+
+        If the end pattern is not found in lineview, more lines are read.
+
+        Args:
+            key      ... the keyword
+            startend ... (optional) Override the = ; pair by two different patterns
+        Returns:
+            the extracted block
+        """
+        self.read_until (startend[1])
+        return self.extract_via_regex (key + r"\s*" + startend[0]
+                                       + r"\s*[^" + startend[1] + ']+'
+                                       + startend[1])
+
+

--- a/pyiron_atomistics/sphinx/parser_base.py
+++ b/pyiron_atomistics/sphinx/parser_base.py
@@ -17,7 +17,7 @@ import re
 from types import GeneratorType
 import numpy
 
-class keyword_tree_parser:
+class KeywordTreeParser:
     """
     A base class to parse files block by block via keyword-triggered
     parsing routines organized in a tree. Parsing routines can
@@ -33,7 +33,7 @@ class keyword_tree_parser:
 
     A typical use will be
 
-    class my_parser(keyword_tree_parser):
+    class my_parser(KeywordTreeParser):
         def __init__(self,file)
             super ().__init__({
                     "key1" : self.parse_key1,
@@ -60,10 +60,12 @@ class keyword_tree_parser:
         if len(self.keylevels) == 0:
            raise KeyError("No parsing functions available in keylevels")
         filehandle = open(filename)
+        # the following properties only exist while parsing
         self.line = filehandle.__iter__ ()
         self.lineview = ''
         self.filename = filename
         self.lineno = 0
+        self.line_from = 0
         while True:
             for keymap in self.keylevels:
                 for key,func in keymap.items ():
@@ -87,6 +89,9 @@ class keyword_tree_parser:
         self._cleanup(self.keylevels[0])
         if (hasattr(self,'finalize')):
             self.finalize ()
+        close(filehandle)
+        # clean up object properties that only exist during parsing
+        del (self.filename, self.line, self.lineno, self.line_from, self.lineview)
 
     def location(self):
         """ Return the current parsing location (for error messages)"""
@@ -105,7 +110,7 @@ class keyword_tree_parser:
         while not match in self.lineview:
             self.lineview += next(self.line)
             self.lineno += 1
-            self.lineFrom = self.line
+            self.line_from = self.line
 
     def extract_via_regex(self, regex):
         """

--- a/pyiron_atomistics/sphinx/parser_base.py
+++ b/pyiron_atomistics/sphinx/parser_base.py
@@ -15,7 +15,7 @@ __date__ = "Dec 8, 2023"
 
 import re
 from types import GeneratorType
-import numpy
+import numpy as np
 
 
 class KeywordTreeParser:
@@ -181,7 +181,7 @@ class KeywordTreeParser:
             )
         # remove special characters [] , ; =
         vecstring = re.sub(r"[][=,;$]", " ", vecstring)
-        return numpy.fromstring(vecstring, sep=" ")
+        return np.fromstring(vecstring, sep=" ")
 
     def extract_var(self, key, startend="=;"):
         """

--- a/pyiron_atomistics/sphinx/parser_base.py
+++ b/pyiron_atomistics/sphinx/parser_base.py
@@ -89,11 +89,14 @@ class KeywordTreeParser:
                 except StopIteration:
                     break
         self._cleanup(self.keylevels[0])
-        if hasattr(self, "finalize"):
-            self.finalize()
+        # call optional finalize routine
+        self.finalize()
         close(filehandle)
         # clean up object properties that only exist during parsing
         del (self.filename, self.line, self.lineno, self.line_from, self.lineview)
+
+    def finalize(self):
+        pass
 
     def location(self):
         """Return the current parsing location (for error messages)"""

--- a/pyiron_atomistics/sphinx/structure.py
+++ b/pyiron_atomistics/sphinx/structure.py
@@ -5,7 +5,7 @@
 import re
 import numpy as np
 import scipy.constants
-from pyiron_atomistics.atomistics.structure.parser_base import keyword_tree_parser
+from pyiron_atomistics.atomistics.structure.parser_base import KeywordTreeParser
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.atomistics.structure.periodic_table import PeriodicTable
 
@@ -24,7 +24,7 @@ BOHR_TO_ANGSTROM = (
     scipy.constants.physical_constants["Bohr radius"][0] / scipy.constants.angstrom
 )
 
-class struct_parser(keyword_tree_parser):
+class StructParser(KeywordTreeParser):
     """
     This class reads one or more structures in sx format.
     """
@@ -96,5 +96,5 @@ def read_atoms(filename="structure.sx"):
         pyiron_atomistics.objects.structure.atoms.Atoms instance (or a list of them)
 
     """
-    configs = struct_parser(filename).configs
+    configs = StructParser(filename).configs
     return configs[0] if len(configs) == 1 else configs


### PR DESCRIPTION
In part, this is an experiment on parsing.

Idea 1 is to parse while reading the file, instead of reading the entire file first.
Idea 2 is to use a more tabular way of programming, by creating a table of keywords with associated parsing routines. 
Whenever the keyword is encountered, the corresponding parsing routine is called.
This is organized in a multi-level way, so certain keywords will simply add additional keywords and their associated parsing routines, which will be removed again from the when the next higher-level keyword appears. This allows to parse larger sections that have multiple subitems. The hope is to produce more readable (and thus maintainable) parsing routines.

I have implemented this for the rarely used sphinx.structure.read_atoms routines, which we need to parse 
some old data I created outside of pyiron. The new version supports multiple structures in the same file and ignores unexpected stuff (such as labels) much more reliably than the old version.

