### PR TITLE
Ignore eddrmm warning by default

### DIFF
--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -1873,6 +1873,8 @@ class Input:
         self.kpoints = Kpoints(table_name="kpoints")
         self.potcar = Potcar(table_name="potcar")
 
+        # "official" recommendation of VASP devs is to just ignore this warning
+        # https://www.vasp.at/forum/viewtopic.php?f=3&t=17822
         self._eddrmm = "ignore"
 
     def write(self, structure, modified_elements, directory=None):

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -1873,7 +1873,7 @@ class Input:
         self.kpoints = Kpoints(table_name="kpoints")
         self.potcar = Potcar(table_name="potcar")
 
-        self._eddrmm = "warn"
+        self._eddrmm = "ignore"
 
     def write(self, structure, modified_elements, directory=None):
         """


### PR DESCRIPTION
This is the recommended behavior from upstream:
https://www.vasp.at/forum/viewtopic.php?f=3&t=17822