### PR TITLE
A workaround to fix reloading potentials with LAMMPS

### DIFF
--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -13,7 +13,7 @@ dependencies:
 - pandas =2.0.3
 - phonopy =2.20.0
 - pint =0.18
-- pyiron_base =0.6.16
+- pyiron_base =0.7.2
 - pylammpsmpi =0.2.7
 - pyscal =2.10.4
 - scikit-learn =1.2.1

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - pandas =2.2.0
 - phonopy =2.21.0
 - pint =0.23
-- pyiron_base =0.7.1
+- pyiron_base =0.7.2
 - pylammpsmpi =0.2.11
 - pyscal =2.10.18
 - scikit-learn =1.4.0

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -740,11 +740,15 @@ class LammpsBase(AtomisticGenericJob):
         """
         super(LammpsBase, self).from_hdf(hdf=hdf, group_name=group_name)
         self._structure_from_hdf()
-        self.input.from_dict(
-            data_dict=self._hdf5.read_dict_from_hdf(
-                group_paths=["input", "input/control_inp", "input/potential_inp"]
-            )
+        data_input_dict = self._hdf5.read_dict_from_hdf(
+            ["input", "input/control_inp", "input/potential_inp"]
         )
+        data_potential_dict = self._hdf5.read_dict_from_hdf(
+            ["input/potential_inp/potential"]
+        )
+        data_input_dict["input"]["potential_inp"]["potential"] = data_potential_dict["input"]["potential_inp"][
+            "potential"]
+        self.input.from_dict(data_dict=data_input_dict)
 
     def write_restart_file(self, filename="restart.out"):
         """
@@ -1079,11 +1083,14 @@ class Input:
             hdf5:
         Returns:
         """
-        self.from_dict(
-            data_dict=hdf5.read_dict_from_hdf(
-                ["input", "input/control_inp", "input/potential_inp"]
-            )
+        data_input_dict = hdf5.read_dict_from_hdf(
+            ["input", "input/control_inp", "input/potential_inp"]
         )
+        data_potential_dict = hdf5.read_dict_from_hdf(
+            ["input/potential_inp/potential"]
+        )
+        data_input_dict["input"]["potential_inp"]["potential"] = data_potential_dict["input"]["potential_inp"]["potential"]
+        self.from_dict(data_dict=data_input_dict)
 
 
 def resolve_hierachical_dict(data_dict, group_name=""):

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -740,16 +740,9 @@ class LammpsBase(AtomisticGenericJob):
         """
         super(LammpsBase, self).from_hdf(hdf=hdf, group_name=group_name)
         self._structure_from_hdf()
-        data_input_dict = self._hdf5.read_dict_from_hdf(
-            ["input", "input/control_inp", "input/potential_inp"]
-        )
-        data_potential_dict = self._hdf5.read_dict_from_hdf(
-            ["input/potential_inp/potential"]
-        )
-        data_input_dict["input"]["potential_inp"]["potential"] = data_potential_dict[
-            "input"
-        ]["potential_inp"]["potential"]
-        self.input.from_dict(data_dict=data_input_dict)
+        self.input.from_dict(data_dict=self._hdf5.read_dict_from_hdf(
+            ["input", "input/control_inp", "input/potential_inp", "input/potential_inp/potential"]
+        ))
 
     def write_restart_file(self, filename="restart.out"):
         """
@@ -1085,14 +1078,9 @@ class Input:
             hdf5:
         Returns:
         """
-        data_input_dict = hdf5.read_dict_from_hdf(
-            ["input", "input/control_inp", "input/potential_inp"]
-        )
-        data_potential_dict = hdf5.read_dict_from_hdf(["input/potential_inp/potential"])
-        data_input_dict["input"]["potential_inp"]["potential"] = data_potential_dict[
-            "input"
-        ]["potential_inp"]["potential"]
-        self.from_dict(data_dict=data_input_dict)
+        self.from_dict(data_dict=hdf5.read_dict_from_hdf(
+            ["input", "input/control_inp", "input/potential_inp", "input/potential_inp/potential"]
+        ))
 
 
 def resolve_hierachical_dict(data_dict, group_name=""):

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -746,8 +746,9 @@ class LammpsBase(AtomisticGenericJob):
         data_potential_dict = self._hdf5.read_dict_from_hdf(
             ["input/potential_inp/potential"]
         )
-        data_input_dict["input"]["potential_inp"]["potential"] = data_potential_dict["input"]["potential_inp"][
-            "potential"]
+        data_input_dict["input"]["potential_inp"]["potential"] = data_potential_dict[
+            "input"
+        ]["potential_inp"]["potential"]
         self.input.from_dict(data_dict=data_input_dict)
 
     def write_restart_file(self, filename="restart.out"):
@@ -1086,10 +1087,10 @@ class Input:
         data_input_dict = hdf5.read_dict_from_hdf(
             ["input", "input/control_inp", "input/potential_inp"]
         )
-        data_potential_dict = hdf5.read_dict_from_hdf(
-            ["input/potential_inp/potential"]
-        )
-        data_input_dict["input"]["potential_inp"]["potential"] = data_potential_dict["input"]["potential_inp"]["potential"]
+        data_potential_dict = hdf5.read_dict_from_hdf(["input/potential_inp/potential"])
+        data_input_dict["input"]["potential_inp"]["potential"] = data_potential_dict[
+            "input"
+        ]["potential_inp"]["potential"]
         self.from_dict(data_dict=data_input_dict)
 
 

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -740,9 +740,16 @@ class LammpsBase(AtomisticGenericJob):
         """
         super(LammpsBase, self).from_hdf(hdf=hdf, group_name=group_name)
         self._structure_from_hdf()
-        self.input.from_dict(data_dict=self._hdf5.read_dict_from_hdf(
-            ["input", "input/control_inp", "input/potential_inp", "input/potential_inp/potential"]
-        ))
+        self.input.from_dict(
+            data_dict=self._hdf5.read_dict_from_hdf(
+                [
+                    "input",
+                    "input/control_inp",
+                    "input/potential_inp",
+                    "input/potential_inp/potential",
+                ]
+            )
+        )
 
     def write_restart_file(self, filename="restart.out"):
         """
@@ -1078,9 +1085,16 @@ class Input:
             hdf5:
         Returns:
         """
-        self.from_dict(data_dict=hdf5.read_dict_from_hdf(
-            ["input", "input/control_inp", "input/potential_inp", "input/potential_inp/potential"]
-        ))
+        self.from_dict(
+            data_dict=hdf5.read_dict_from_hdf(
+                [
+                    "input",
+                    "input/control_inp",
+                    "input/potential_inp",
+                    "input/potential_inp/potential",
+                ]
+            )
+        )
 
 
 def resolve_hierachical_dict(data_dict, group_name=""):

--- a/pyiron_atomistics/lammps/potential.py
+++ b/pyiron_atomistics/lammps/potential.py
@@ -199,7 +199,7 @@ class LammpsPotential(GenericParameters):
 
     def from_dict(self, obj_dict, version: str = None):
         super(LammpsPotential, self).from_dict(obj_dict=obj_dict, version=version)
-        if "potential" in obj_dict.keys():
+        if "potential" in obj_dict.keys() and "Config" in obj_dict["potential"].keys():
             entry_dict = {
                 key: [obj_dict["potential"][key]]
                 for key in ["Config", "Filename", "Name", "Model", "Species"]

--- a/pyiron_atomistics/lammps/potential.py
+++ b/pyiron_atomistics/lammps/potential.py
@@ -187,10 +187,12 @@ class LammpsPotential(GenericParameters):
     def to_dict(self):
         super_dict = super(LammpsPotential, self).to_dict()
         if self._df is not None:
-            super_dict.update({
-                "potential/" + key: self._df[key].values[0]
-                for key in ["Config", "Filename", "Name", "Model", "Species"]
-            })
+            super_dict.update(
+                {
+                    "potential/" + key: self._df[key].values[0]
+                    for key in ["Config", "Filename", "Name", "Model", "Species"]
+                }
+            )
             if "Citations" in self._df.columns.values:
                 super_dict["potential/Citations"] = self._df["Citations"].values[0]
         return super_dict

--- a/pyiron_atomistics/lammps/potential.py
+++ b/pyiron_atomistics/lammps/potential.py
@@ -184,6 +184,28 @@ class LammpsPotential(GenericParameters):
             )
             raise NameError(msg) from None
 
+    def to_dict(self):
+        super_dict = super(LammpsPotential, self).to_dict()
+        if self._df is not None:
+            super_dict.update({
+                "potential/" + key: self._df[key].values[0]
+                for key in ["Config", "Filename", "Name", "Model", "Species"]
+            })
+            if "Citations" in self._df.columns.values:
+                super_dict["potential/Citations"] = self._df["Citations"].values[0]
+        return super_dict
+
+    def from_dict(self, obj_dict, version: str = None):
+        super(LammpsPotential, self).from_dict(obj_dict=obj_dict, version=version)
+        if "potential" in obj_dict.keys():
+            entry_dict = {
+                key: [obj_dict["potential"][key]]
+                for key in ["Config", "Filename", "Name", "Model", "Species"]
+            }
+            if "Citations" in obj_dict["potential"].keys():
+                entry_dict["Citations"] = [obj_dict["potential"]["Citations"]]
+            self._df = pd.DataFrame(entry_dict)
+
     def to_hdf(self, hdf, group_name=None):
         if self._df is not None:
             with hdf.open("potential") as hdf_pot:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "pandas==2.2.0",
     "phonopy==2.21.0",
     "pint==0.23",
-    "pyiron_base==0.7.1",
+    "pyiron_base==0.7.2",
     "pylammpsmpi==0.2.11",
     "scipy==1.12.0",
     "scikit-learn==1.4.0",


### PR DESCRIPTION
The `LammpsPotential` class extends the `GenericParameters` class, so it requires extending the `to_dict()` and `from_dict()` methods. 

Waiting for https://github.com/pyiron/pyiron_base/pull/1304