### PR TITLE
Call `collect_output` when VASP job is not compressed at restart

### DIFF
--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -1551,6 +1551,9 @@ class VaspBase(GenericDFTJob):
             new_ham (vasp.vasp.Vasp instance): New job
         """
         new_ham = super(VaspBase, self).restart(job_name=job_name, job_type=job_type)
+        if not self.is_compressed():
+            self.collect_output()
+            self.compress()
         if new_ham.__name__ == self.__name__:
             new_ham.input.potcar["xc"] = self.input.potcar["xc"]
         if new_ham.input.incar["MAGMOM"] is not None:


### PR DESCRIPTION
When a job is aborted due to runtime, usually `collect_output` is not called at the end, in which case `restart` fails. Here we make sure to call `collect_output` if the job is not compressed.