### PR TITLE
Auto reload calphy output on job finishing

### DIFF
--- a/pyiron_atomistics/calphy/job.py
+++ b/pyiron_atomistics/calphy/job.py
@@ -131,7 +131,6 @@ class Calphy(GenericJob, HasStructure):
         self.input.potential_final_name = None
         self.input.structure = None
         self.output = DataContainer(table_name="output")
-        self._data = None
         self.input._pot_dict_initial = None
         self.input._pot_dict_final = None
         self.__version__ = calphy_version
@@ -704,8 +703,6 @@ class Calphy(GenericJob, HasStructure):
             routine_pscale(job)
         else:
             raise ValueError("Unknown mode")
-        # self._data = job.report
-        # del self._data["input"]
         self.run()
         self.status.collect = True
         self.run()


### PR DESCRIPTION
@srmnitc If I understood your problem correctly, this might solve it.  But it's somewhat of a quick hack.  A better way would be to augment the API of JobStatus to have a callback or so, when the job status in the database changes.