### PR TITLE
Do not access files accidentely in interactive output

### DIFF
--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -10,6 +10,8 @@ import os
 from typing import Callable, Union, Tuple
 from ase.io import write as ase_write
 import posixpath
+from functools import wraps
+
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
 from pyiron_atomistics.atomistics.structure.neighbors import NeighborsTrajectory
 from pyiron_atomistics.atomistics.structure.has_structure import HasStructure
@@ -1003,26 +1005,38 @@ structure=atoms # atoms, continue_final
 """
         self.load_string(file_content)
 
+def _suppress_notfound(meth):
+    @wraps(meth)
+    def f(*args, **kwargs):
+        try:
+            return meth(*args, **kwargs)
+        except ValueError:
+            return None
+    return f
 
 class GenericOutput(object):
     def __init__(self, job):
         self._job = job
 
     @property
+    @_suppress_notfound
     def cells(self):
-        return self._job["output/generic/cells"]
+        return self._job.project_hdf5["output/generic/cells"]
 
     @property
+    @_suppress_notfound
     def energy_pot(self):
-        return self._job["output/generic/energy_pot"]
+        return self._job.project_hdf5["output/generic/energy_pot"]
 
     @property
+    @_suppress_notfound
     def energy_tot(self):
-        return self._job["output/generic/energy_tot"]
+        return self._job.project_hdf5["output/generic/energy_tot"]
 
     @property
+    @_suppress_notfound
     def forces(self):
-        return self._job["output/generic/forces"]
+        return self._job.project_hdf5["output/generic/forces"]
 
     @property
     def force_max(self):
@@ -1033,40 +1047,47 @@ class GenericOutput(object):
         return np.linalg.norm(self.forces, axis=-1).max(axis=-1)
 
     @property
+    @_suppress_notfound
     def positions(self):
-        return self._job["output/generic/positions"]
+        return self._job.project_hdf5["output/generic/positions"]
 
     @property
+    @_suppress_notfound
     def pressures(self):
-        return self._job["output/generic/pressures"]
+        return self._job.project_hdf5["output/generic/pressures"]
 
     @property
+    @_suppress_notfound
     def steps(self):
-        return self._job["output/generic/steps"]
+        return self._job.project_hdf5["output/generic/steps"]
 
     @property
+    @_suppress_notfound
     def temperature(self):
-        return self._job["output/generic/temperature"]
+        return self._job.project_hdf5["output/generic/temperature"]
 
     @property
+    @_suppress_notfound
     def computation_time(self):
-        return self._job["output/generic/computation_time"]
+        return self._job.project_hdf5["output/generic/computation_time"]
 
     @property
     def unwrapped_positions(self):
-        unwrapped_positions = self._job["output/generic/unwrapped_positions"]
-        if unwrapped_positions is not None:
+        try:
+            unwrapped_positions = self._job.project_hdf5["output/generic/unwrapped_positions"]
             return unwrapped_positions
-        else:
+        except ValueError:
             return self._job.structure.positions + self.total_displacements
 
     @property
+    @_suppress_notfound
     def volume(self):
-        return self._job["output/generic/volume"]
+        return self._job.project_hdf5["output/generic/volume"]
 
     @property
+    @_suppress_notfound
     def indices(self):
-        return self._job["output/generic/indices"]
+        return self._job.project_hdf5["output/generic/indices"]
 
     @property
     def displacements(self):
@@ -1078,13 +1099,14 @@ class GenericOutput(object):
             - there are atoms which move by more than half a box length in any direction within
                 two snapshots (due to periodic boundary conditions)
         """
-        unwrapped_positions = self._job["output/generic/unwrapped_positions"]
-        if unwrapped_positions is not None:
+        try:
+            unwrapped_positions = self._job.project_hdf5["output/generic/unwrapped_positions"]
             return np.diff(
                 np.append([self._job.structure.positions], unwrapped_positions, axis=0),
                 axis=0,
             )
-        return self.get_displacements(self._job.structure, self.positions, self.cells)
+        except ValueError:
+            return self.get_displacements(self._job.structure, self.positions, self.cells)
 
     @staticmethod
     def get_displacements(structure, positions, cells):
@@ -1129,14 +1151,15 @@ class GenericOutput(object):
             - there are atoms which move by more than half a box length in any direction within
                 two snapshots (due to periodic boundary conditions)
         """
-        unwrapped_positions = self._job["output/generic/unwrapped_positions"]
-        if unwrapped_positions is not None:
+        try:
+            unwrapped_positions = self._job.project_hdf5["output/generic/unwrapped_positions"]
             return unwrapped_positions - self._job.structure.positions
-        return np.cumsum(self.displacements, axis=0)
+        except ValueError:
+            return np.cumsum(self.displacements, axis=0)
 
     def __dir__(self):
-        hdf5_path = self._job["output/generic"]
-        if hdf5_path is not None:
+        try:
+            hdf5_path = self._job.project_hdf5["output/generic"]
             return hdf5_path.list_nodes()
-        else:
+        except ValueError:
             return []

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -21,6 +21,7 @@ from pyiron_base import (
     GenericJob as GenericJobCore,
 )
 from pyiron_snippets.deprecate import deprecate
+from pyiron_snippets.logger import logger
 
 try:
     from pyiron_base import ProjectGUI
@@ -1011,6 +1012,7 @@ def _suppress_notfound(meth):
         try:
             return meth(*args, **kwargs)
         except ValueError:
+            logger.warning(f"Could not access {meth.__name__}, returning None!")
             return None
     return f
 

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -1006,6 +1006,7 @@ structure=atoms # atoms, continue_final
 """
         self.load_string(file_content)
 
+
 def _suppress_notfound(meth):
     @wraps(meth)
     def f(*args, **kwargs):
@@ -1014,7 +1015,9 @@ def _suppress_notfound(meth):
         except ValueError:
             logger.warning(f"Could not access {meth.__name__}, returning None!")
             return None
+
     return f
+
 
 class GenericOutput(object):
     def __init__(self, job):
@@ -1076,7 +1079,9 @@ class GenericOutput(object):
     @property
     def unwrapped_positions(self):
         try:
-            unwrapped_positions = self._job.project_hdf5["output/generic/unwrapped_positions"]
+            unwrapped_positions = self._job.project_hdf5[
+                "output/generic/unwrapped_positions"
+            ]
             return unwrapped_positions
         except ValueError:
             return self._job.structure.positions + self.total_displacements
@@ -1102,13 +1107,17 @@ class GenericOutput(object):
                 two snapshots (due to periodic boundary conditions)
         """
         try:
-            unwrapped_positions = self._job.project_hdf5["output/generic/unwrapped_positions"]
+            unwrapped_positions = self._job.project_hdf5[
+                "output/generic/unwrapped_positions"
+            ]
             return np.diff(
                 np.append([self._job.structure.positions], unwrapped_positions, axis=0),
                 axis=0,
             )
         except ValueError:
-            return self.get_displacements(self._job.structure, self.positions, self.cells)
+            return self.get_displacements(
+                self._job.structure, self.positions, self.cells
+            )
 
     @staticmethod
     def get_displacements(structure, positions, cells):
@@ -1154,7 +1163,9 @@ class GenericOutput(object):
                 two snapshots (due to periodic boundary conditions)
         """
         try:
-            unwrapped_positions = self._job.project_hdf5["output/generic/unwrapped_positions"]
+            unwrapped_positions = self._job.project_hdf5[
+                "output/generic/unwrapped_positions"
+            ]
             return unwrapped_positions - self._job.structure.positions
         except ValueError:
             return np.cumsum(self.displacements, axis=0)

--- a/pyiron_atomistics/atomistics/job/interactive.py
+++ b/pyiron_atomistics/atomistics/job/interactive.py
@@ -410,7 +410,10 @@ class GenericInteractiveOutput(GenericOutput):
         Returns:
 
         """
-        fetched = self._job["output/interactive/" + key]
+        try:
+            fetched = self._job.project_hdf5["output/interactive/" + key]
+        except ValueError:
+            fetched = None
         if fetched is None or len(fetched) == 0:
             fetched = getattr(super(), key)
         return fetched

--- a/pyiron_atomistics/sphinx/interactive.py
+++ b/pyiron_atomistics/sphinx/interactive.py
@@ -375,14 +375,15 @@ class SphinxOutput(Output, GenericInteractiveOutput):
         """
         import matplotlib.pylab as plt
 
-        elec_dict = self._job["output/generic/dft"]["n_valence"]
-        if elec_dict is None:
+        try:
+            elec_dict = self._job.project_hdf5["output/generic/dft"]["n_valence"]
+        except ValueError:
             raise AssertionError("Number of electrons not parsed")
         n_elec = np.sum(
             [elec_dict[k] for k in self._job.structure.get_chemical_symbols()]
         )
         n_elec = int(np.ceil(n_elec / 2))
-        bands = self._job["output/generic/dft/bands_occ"][-1]
+        bands = self._job.project_hdf5["output/generic/dft/bands_occ"][-1]
         bands = bands.reshape(-1, bands.shape[-1])
         max_occ = np.sum(~np.isclose(bands, 0), axis=-1).max()
         n_bands = bands.shape[-1]

--- a/pyiron_atomistics/sphinx/interactive.py
+++ b/pyiron_atomistics/sphinx/interactive.py
@@ -378,7 +378,7 @@ class SphinxOutput(Output, GenericInteractiveOutput):
         try:
             elec_dict = self._job.project_hdf5["output/generic/dft"]["n_valence"]
         except ValueError:
-            raise AssertionError("Number of electrons not parsed")
+            raise AssertionError("Number of electrons not parsed") from None
         n_elec = np.sum(
             [elec_dict[k] for k in self._job.structure.get_chemical_symbols()]
         )

--- a/pyiron_atomistics/sphinx/interactive.py
+++ b/pyiron_atomistics/sphinx/interactive.py
@@ -376,14 +376,14 @@ class SphinxOutput(Output, GenericInteractiveOutput):
         import matplotlib.pylab as plt
 
         try:
-            elec_dict = self._job.project_hdf5["output/generic/dft"]["n_valence"]
+            elec_dict = self._job.content["output/generic/dft"]["n_valence"]
         except ValueError:
             raise AssertionError("Number of electrons not parsed") from None
         n_elec = np.sum(
             [elec_dict[k] for k in self._job.structure.get_chemical_symbols()]
         )
         n_elec = int(np.ceil(n_elec / 2))
-        bands = self._job.project_hdf5["output/generic/dft/bands_occ"][-1]
+        bands = self._job.content["output/generic/dft/bands_occ"][-1]
         bands = bands.reshape(-1, bands.shape[-1])
         max_occ = np.sum(~np.isclose(bands, 0), axis=-1).max()
         n_bands = bands.shape[-1]

--- a/pyiron_atomistics/sphinx/interactive.py
+++ b/pyiron_atomistics/sphinx/interactive.py
@@ -383,7 +383,7 @@ class SphinxOutput(Output, GenericInteractiveOutput):
             [elec_dict[k] for k in self._job.structure.get_chemical_symbols()]
         )
         n_elec = int(np.ceil(n_elec / 2))
-        bands = self._job.content["output/generic/dft/bands_occ"][-1]
+        bands = self._job.content["output/generic/dft"]["bands_occ"][-1]
         bands = bands.reshape(-1, bands.shape[-1])
         max_occ = np.sum(~np.isclose(bands, 0), axis=-1).max()
         n_bands = bands.shape[-1]


### PR DESCRIPTION
Previously we indexed into the job itself, but that also triggers a search for (possibly) compressed files and is slow.  Since we only intend to look into the HDF anyway, we just do it directly now.

May fix https://github.com/pyiron/pyiron_base/issues/1347