### PR TITLE
Use input structure for get_number_of_species

### DIFF
--- a/pyiron_atomistics/table/funct.py
+++ b/pyiron_atomistics/table/funct.py
@@ -109,7 +109,7 @@ def get_convergence_check(job):
 
 
 def get_number_of_species(job):
-    return {"Number_of_species": len(job["output/structure/species"])}
+    return {"Number_of_species": len(job["input/structure/species"])}
 
 
 def get_number_of_ionic_steps(job):


### PR DESCRIPTION
This fixes an issue where tables are getting slowed down a lot for jobs run before #1341 was merged.  For those jobs output/structure/species is missing and accidentally trigger decompression of the jobs.