### PR TITLE
AtomisticGenericJob, Lammps and Vasp: Implement from_dict()

### DIFF
--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -223,7 +223,7 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
             self._generic_input["max_iter"] = max_iter
         if isinstance(pressure, list):
             self._generic_input["pressure"] = [
-                float(p) if not None else p for p in pressure
+                float(p) if p is not None else p for p in pressure
             ]
         elif pressure is not None:
             self._generic_input["pressure"] = float(pressure)
@@ -279,7 +279,7 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         )
         if isinstance(pressure, list):
             self._generic_input["pressure"] = [
-                float(p) if not None else p for p in pressure
+                float(p) if p is not None else p for p in pressure
             ]
         elif pressure is not None:
             self._generic_input["pressure"] = float(pressure)

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -217,8 +217,8 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
                 "f_tol is deprecated as of vers. 0.3.0. It is not guaranteed to be in service in vers. 0.4.0"
             )
         self._generic_input["calc_mode"] = "minimize"
-        self._generic_input["max_iter"] = max_iter
-        self._generic_input["pressure"] = pressure
+        self._generic_input["max_iter"] = int(max_iter)
+        self._generic_input["pressure"] = float(pressure)
         self._generic_input.remove_keys(
             ["temperature", "n_ionic_steps", "n_print", "velocity"]
         )
@@ -256,20 +256,20 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         langevin=False,
     ):
         self._generic_input["calc_mode"] = "md"
-        self._generic_input["temperature"] = temperature
-        self._generic_input["n_ionic_steps"] = n_ionic_steps
-        self._generic_input["n_print"] = n_print
-        self._generic_input["temperature_damping_timescale"] = (
+        self._generic_input["temperature"] = float(temperature)
+        self._generic_input["n_ionic_steps"] = int(n_ionic_steps)
+        self._generic_input["n_print"] = int(n_print)
+        self._generic_input["temperature_damping_timescale"] = float(
             temperature_damping_timescale
         )
         if pressure is not None:
-            self._generic_input["pressure"] = pressure
+            self._generic_input["pressure"] = float(pressure)
         if pressure_damping_timescale is not None:
-            self._generic_input["pressure_damping_timescale"] = (
+            self._generic_input["pressure_damping_timescale"] = float(
                 pressure_damping_timescale
             )
         if time_step is not None:
-            self._generic_input["time_step"] = time_step
+            self._generic_input["time_step"] = int(time_step)
         self._generic_input.remove_keys(["max_iter"])
 
     def from_dict(self, job_dict):

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -217,8 +217,16 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
                 "f_tol is deprecated as of vers. 0.3.0. It is not guaranteed to be in service in vers. 0.4.0"
             )
         self._generic_input["calc_mode"] = "minimize"
-        self._generic_input["max_iter"] = int(max_iter)
-        self._generic_input["pressure"] = float(pressure)
+        if max_iter is not None:
+            self._generic_input["max_iter"] = int(max_iter)
+        else:
+            self._generic_input["max_iter"] = max_iter
+        if isinstance(pressure, list):
+            self._generic_input["pressure"] = [float(p) for p in pressure]
+        elif pressure is not None:
+            self._generic_input["pressure"] = float(pressure)
+        else:
+            self._generic_input["pressure"] = pressure
         self._generic_input.remove_keys(
             ["temperature", "n_ionic_steps", "n_print", "velocity"]
         )
@@ -262,7 +270,9 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         self._generic_input["temperature_damping_timescale"] = float(
             temperature_damping_timescale
         )
-        if pressure is not None:
+        if isinstance(pressure, list):
+            self._generic_input["pressure"] = [float(p) for p in pressure]
+        elif pressure is not None:
             self._generic_input["pressure"] = float(pressure)
         if pressure_damping_timescale is not None:
             self._generic_input["pressure_damping_timescale"] = float(

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -222,7 +222,9 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         else:
             self._generic_input["max_iter"] = max_iter
         if isinstance(pressure, list):
-            self._generic_input["pressure"] = [float(p) for p in pressure]
+            self._generic_input["pressure"] = [
+                float(p) if not None else p for p in pressure
+            ]
         elif pressure is not None:
             self._generic_input["pressure"] = float(pressure)
         else:

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -264,7 +264,12 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
         langevin=False,
     ):
         self._generic_input["calc_mode"] = "md"
-        self._generic_input["temperature"] = float(temperature)
+        if isinstance(temperature, list):
+            self._generic_input["temperature"] = [float(t) for t in temperature]
+        elif temperature is not None:
+            self._generic_input["temperature"] = float(temperature)
+        else:
+            self._generic_input["temperature"] = temperature
         self._generic_input["n_ionic_steps"] = int(n_ionic_steps)
         self._generic_input["n_print"] = int(n_print)
         self._generic_input["temperature_damping_timescale"] = float(

--- a/pyiron_atomistics/atomistics/job/atomistic.py
+++ b/pyiron_atomistics/atomistics/job/atomistic.py
@@ -276,7 +276,9 @@ class AtomisticGenericJob(GenericJobCore, HasStructure):
             temperature_damping_timescale
         )
         if isinstance(pressure, list):
-            self._generic_input["pressure"] = [float(p) for p in pressure]
+            self._generic_input["pressure"] = [
+                float(p) if not None else p for p in pressure
+            ]
         elif pressure is not None:
             self._generic_input["pressure"] = float(pressure)
         if pressure_damping_timescale is not None:

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -559,9 +559,7 @@ class Atoms(ASEAtoms):
         if "calculator" in atoms_dict.keys():
             calc_dict = atoms_dict["calculator"]
             class_path = calc_dict.pop("class")
-            calc_module = importlib.import_module(
-                ".".join(class_path.split(".")[:-1])
-            )
+            calc_module = importlib.import_module(".".join(class_path.split(".")[:-1]))
             calc_class = getattr(calc_module, class_path.split(".")[-1])
             self.calc = calc_class(**calc_dict)
         return self
@@ -590,7 +588,9 @@ class Atoms(ASEAtoms):
             pyiron_atomistics.structure.atoms.Atoms: The retrieved atoms class
 
         """
-        return self.from_dict(atoms_dict=hdf.open(group_name).read_dict_from_hdf(recursive=True))
+        return self.from_dict(
+            atoms_dict=hdf.open(group_name).read_dict_from_hdf(recursive=True)
+        )
 
     def select_index(self, el):
         """

--- a/pyiron_atomistics/atomistics/structure/atoms.py
+++ b/pyiron_atomistics/atomistics/structure/atoms.py
@@ -494,6 +494,78 @@ class Atoms(ASEAtoms):
             hdf_structure["calculator"] = calc_dict
         return hdf_structure
 
+    def from_dict(self, atoms_dict):
+        if "new_species" in atoms_dict.keys():
+            self._pse.from_dict(pse_dict=atoms_dict["new_species"])
+
+        el_object_list = [
+            self.convert_element(el, self._pse) for el in atoms_dict["species"]
+        ]
+        self.arrays["indices"] = atoms_dict["indices"]
+
+        self.set_species(el_object_list)
+        self.bonds = None
+
+        tr_dict = {1: True, 0: False}
+        self.dimension = atoms_dict["dimension"]
+        self.units = atoms_dict["units"]
+
+        if "cell" in atoms_dict.keys():
+            self.cell = atoms_dict["cell"]["cell"]
+            self.pbc = atoms_dict["cell"]["pbc"]
+
+        # Backward compatibility
+        position_tag = "positions"
+        if position_tag not in atoms_dict.keys():
+            position_tag = "coordinates"
+        self.arrays["positions"] = atoms_dict[position_tag]
+        if (
+            "is_absolute" in atoms_dict.keys()
+            and not tr_dict[atoms_dict["is_absolute"]]
+        ):
+            self.set_scaled_positions(self.arrays["positions"])
+
+        self.arrays["numbers"] = self.get_atomic_numbers()
+
+        if "explicit_bonds" in atoms_dict.keys():
+            # print "bonds: "
+            self.bonds = atoms_dict["explicit_bonds"]
+        if "spins" in atoms_dict.keys():
+            self.spins = atoms_dict["spins"]
+        if "tags" in atoms_dict.keys():
+            tags_dict = atoms_dict["tags"]
+            for tag, tag_item in tags_dict.items():
+                if tag in ["initial_magmoms"]:
+                    continue
+                # tr_dict = {'0': False, '1': True}
+                if isinstance(tag_item, (list, np.ndarray)):
+                    my_list = tag_item
+                else:  # legacy of SparseList
+                    raise NotImplementedError()
+                self.set_array(tag, np.asarray(my_list))
+
+        if "bonds" in atoms_dict.keys():
+            self.bonds = atoms_dict["explicit_bonds"]
+
+        self._high_symmetry_points = None
+        if "high_symmetry_points" in atoms_dict.keys():
+            self._high_symmetry_points = atoms_dict["high_symmetry_points"]
+
+        self._high_symmetry_path = None
+        if "high_symmetry_path" in atoms_dict.keys():
+            self._high_symmetry_path = atoms_dict["high_symmetry_path"]
+        if "info" in atoms_dict.keys():
+            self.info = atoms_dict["info"]
+        if "calculator" in atoms_dict.keys():
+            calc_dict = atoms_dict["calculator"]
+            class_path = calc_dict.pop("class")
+            calc_module = importlib.import_module(
+                ".".join(class_path.split(".")[:-1])
+            )
+            calc_class = getattr(calc_module, class_path.split(".")[-1])
+            self.calc = calc_class(**calc_dict)
+        return self
+
     def to_hdf(self, hdf, group_name="structure"):
         """
         Save the object in a HDF5 file
@@ -518,145 +590,7 @@ class Atoms(ASEAtoms):
             pyiron_atomistics.structure.atoms.Atoms: The retrieved atoms class
 
         """
-        if "indices" in hdf[group_name].list_nodes():
-            with hdf.open(group_name) as hdf_atoms:
-                if "new_species" in hdf_atoms.list_groups():
-                    with hdf_atoms.open("new_species") as hdf_species:
-                        self._pse.from_hdf(hdf_species)
-
-                el_object_list = [
-                    self.convert_element(el, self._pse) for el in hdf_atoms["species"]
-                ]
-                self.arrays["indices"] = hdf_atoms["indices"]
-
-                self.set_species(el_object_list)
-                self.bonds = None
-
-                tr_dict = {1: True, 0: False}
-                self.dimension = hdf_atoms["dimension"]
-                self.units = hdf_atoms["units"]
-
-                if "cell" in hdf_atoms.list_groups():
-                    with hdf_atoms.open("cell") as hdf_cell:
-                        self.cell = hdf_cell["cell"]
-                        self.pbc = hdf_cell["pbc"]
-
-                # Backward compatibility
-                position_tag = "positions"
-                if position_tag not in hdf_atoms.list_nodes():
-                    position_tag = "coordinates"
-                self.arrays["positions"] = hdf_atoms[position_tag]
-                if (
-                    "is_absolute" in hdf_atoms.list_nodes()
-                    and not tr_dict[hdf_atoms["is_absolute"]]
-                ):
-                    self.set_scaled_positions(self.arrays["positions"])
-
-                self.arrays["numbers"] = self.get_atomic_numbers()
-
-                if "explicit_bonds" in hdf_atoms.list_nodes():
-                    # print "bonds: "
-                    self.bonds = hdf_atoms["explicit_bonds"]
-                if "spins" in hdf_atoms.list_nodes():
-                    self.spins = hdf_atoms["spins"]
-                if "tags" in hdf_atoms.list_groups():
-                    with hdf_atoms.open("tags") as hdf_tags:
-                        tags = hdf_tags.list_nodes()
-                        for tag in tags:
-                            if tag in ["initial_magmoms"]:
-                                continue
-                            # tr_dict = {'0': False, '1': True}
-                            if isinstance(hdf_tags[tag], (list, np.ndarray)):
-                                my_list = hdf_tags[tag]
-                            else:  # legacy of SparseList
-                                my_dict = hdf_tags.get_pandas(tag).to_dict()
-                                my_list = np.array(my_dict["values"])[
-                                    np.argsort(my_dict["index"])
-                                ]
-                            self.set_array(tag, np.asarray(my_list))
-
-                if "bonds" in hdf_atoms.list_nodes():
-                    self.bonds = hdf_atoms["explicit_bonds"]
-
-                self._high_symmetry_points = None
-                if "high_symmetry_points" in hdf_atoms.list_nodes():
-                    self._high_symmetry_points = hdf_atoms["high_symmetry_points"]
-
-                self._high_symmetry_path = None
-                if "high_symmetry_path" in hdf_atoms.list_nodes():
-                    self._high_symmetry_path = hdf_atoms["high_symmetry_path"]
-                if "info" in hdf_atoms.list_nodes():
-                    self.info = hdf_atoms["info"]
-                if "calculator" in hdf_atoms:
-                    calc_dict = hdf_atoms["calculator"]
-                    class_path = calc_dict.pop("class")
-                    calc_module = importlib.import_module(
-                        ".".join(class_path.split(".")[:-1])
-                    )
-                    calc_class = getattr(calc_module, class_path.split(".")[-1])
-                    self.calc = calc_class(**calc_dict)
-                return self
-
-        else:
-            return self._from_hdf_old(hdf, group_name)
-
-    def _from_hdf_old(self, hdf, group_name="structure"):
-        """
-        This function exits merely for the purpose of backward compatibility
-        """
-        with hdf.open(group_name) as hdf_atoms:
-            self._pse = PeriodicTable()
-            if "species" in hdf_atoms.list_groups():
-                with hdf_atoms.open("species") as hdf_species:
-                    self._pse.from_hdf(hdf_species)
-            chemical_symbols = np.array(hdf_atoms["elements"], dtype=str)
-            el_object_list = [
-                self.convert_element(el, self._pse) for el in chemical_symbols
-            ]
-            self.set_species(list(set(el_object_list)))
-            self.set_array(
-                "indices", [self._species_to_index_dict[el] for el in el_object_list]
-            )
-            self.bonds = None
-            if "explicit_bonds" in hdf_atoms.list_nodes():
-                # print "bonds: "
-                self.bonds = hdf_atoms["explicit_bonds"]
-
-            if "tags" in hdf_atoms.list_groups():
-                with hdf_atoms.open("tags") as hdf_tags:
-                    tags = hdf_tags.list_nodes()
-                    for tag in tags:
-                        # tr_dict = {'0': False, '1': True}
-                        if isinstance(hdf_tags[tag], (list, np.ndarray)):
-                            my_list = hdf_tags[tag]
-                        else:
-                            my_dict = hdf_tags.get_pandas(tag).to_dict()
-                            my_list = np.array(my_dict["values"])[
-                                np.argsort(my_dict["index"])
-                            ]
-                        self.set_array(tag, my_list)
-
-            self.cell = None
-            if "cell" in hdf_atoms.list_groups():
-                with hdf_atoms.open("cell") as hdf_cell:
-                    self.cell = hdf_cell["cell"]
-                    self.pbc = hdf_cell["pbc"]
-
-            tr_dict = {1: True, 0: False}
-            self.dimension = hdf_atoms["dimension"]
-            if "is_absolute" in hdf_atoms and not tr_dict[hdf_atoms["is_absolute"]]:
-                self.positions = hdf_atoms["coordinates"]
-            else:
-                self.set_scaled_positions(hdf_atoms["coordinates"])
-            self.units = hdf_atoms["units"]
-
-            if "bonds" in hdf_atoms.list_nodes():
-                self.bonds = hdf_atoms["explicit_bonds"]
-
-            self._high_symmetry_points = None
-            if "high_symmetry_points" in hdf_atoms.list_nodes():
-                self._high_symmetry_points = hdf_atoms["high_symmetry_points"]
-            return self
+        return self.from_dict(atoms_dict=hdf.open(group_name).read_dict_from_hdf(recursive=True))
 
     def select_index(self, el):
         """

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -728,21 +728,10 @@ class LammpsBase(AtomisticGenericJob):
         data_dict.update({"input/" + k: v for k, v in lammps_dict.items()})
         return data_dict
 
-    # define hdf5 output
-    def from_hdf(self, hdf=None, group_name=None):  # TODO: group_name should be removed
-        """
-
-        Args:
-            hdf:
-            group_name:
-
-        Returns:
-
-        """
-        super(LammpsBase, self).from_hdf(hdf=hdf, group_name=group_name)
-        self._structure_from_hdf()
-        with self.project_hdf5.open("input") as hdf_input:
-            self.input.from_dict(data_dict=hdf_input.read_dict_from_hdf(recursive=True))
+    def from_dict(self, job_dict):
+        super().from_dict(job_dict=job_dict)
+        self._structure_from_dict(job_dict=job_dict)
+        self.input.from_dict(data_dict=job_dict["input"])
 
     def write_restart_file(self, filename="restart.out"):
         """

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -1913,12 +1913,13 @@ class Input:
         )
 
     def to_dict(self):
-        return {
-            "incar": self.incar.to_dict(),
-            "kpoints": self.kpoints.to_dict(),
-            "potcar": self.potcar.to_dict(),
-            "vasp_dict": {"eddrmm_handling": self._eddrmm},
-        }
+        input_dict = {"vasp_dict/eddrmm_handling": self._eddrmm}
+        input_dict.update({"incar/" + k: v for k, v in self.incar.to_dict().items()})
+        input_dict.update(
+            {"kpoints/" + k: v for k, v in self.kpoints.to_dict().items()}
+        )
+        input_dict.update({"potcar/" + k: v for k, v in self.potcar.to_dict().items()})
+        return input_dict
 
     def from_dict(self, input_dict):
         self.incar.from_dict(obj_dict=input_dict["incar"])


### PR DESCRIPTION
This pull request includes the changes form https://github.com/pyiron/pyiron_atomistics/pull/1355 so it is recommended to merge https://github.com/pyiron/pyiron_atomistics/pull/1355 first. 

By implementing a `to_dict()` and `from_dict()` function for the input of the LAMMPS and VASP jobs, it is now possible to transfer these jobs without the need to serialise to HDF5 before. 

Transfer job object as dictionary: 
```python
from h5io_browser.pointer import get_hierarchical_dict
from pyiron_atomistics import Project
from pyiron_base.storage.hdfio import ProjectHDFio, _extract_module_class_name, _import_class

pr = Project("test")

# setup LAMMPS job object
job = pr.create.job.Lammps("lmp")
job.structure = pr.create.structure.ase.bulk("Al")
job.server.run_mode.non_modal = True

# serialize to dict
job_dict = job.to_dict()

# create a new job from dict - in a new project and using a new job_name
project, job_name = Project("test_reload"), "lmp_reload"
module_path, class_name = _extract_module_class_name(job_dict["TYPE"])
class_object = _import_class(module_path, class_name)
project_hdf = ProjectHDFio(project=project, file_name=job_name)
job_reload = class_object(project_hdf, job_name)
job_reload.from_dict(get_hierarchical_dict(job_dict))
job_reload.run()
```

This example also requires the changes in https://github.com/pyiron/pyiron_base/pull/1377 and https://github.com/pyiron/pyiron_base/pull/1380 . The same functionality can in principle also be used to copy jobs, still this would require all job types to implement this new functionality. 