### PR TITLE
[Critical] Ensure atom order in Sphinx

### DIFF
--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -178,9 +178,9 @@ class SphinxBase(GenericDFTJob):
         if self.structure is None:
             raise ValueError("Structure not set")
         # Translate the chemical symbols into indices
-        indices = np.unique(
-            self.structure.get_chemical_symbols(), return_inverse=True
-        )[1]
+        indices = np.unique(self.structure.get_chemical_symbols(), return_inverse=True)[
+            1
+        ]
         # Add small ramp to ensure order uniqueness
         indices = indices + np.arange(len(indices)) / len(indices)
         return np.argsort(indices)

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -177,7 +177,13 @@ class SphinxBase(GenericDFTJob):
     def id_spx_to_pyi(self):
         if self.structure is None:
             raise ValueError("Structure not set")
-        return np.argsort(self.id_pyi_to_spx)
+        # Translate the chemical symbols into indices
+        indices = np.unique(
+            self.structure.get_chemical_symbols(), return_inverse=True
+        )[1]
+        # Add small ramp to ensure order uniqueness
+        indices = indices + np.arange(len(indices)) / len(indices)
+        return np.argsort(indices)
 
     @property
     def plane_wave_cutoff(self):


### PR DESCRIPTION
In DFT, we group atoms according to chemical species in the input files. For example if the structure has 2 Ni atoms and 2 Fe atoms in pyiron in the order of Ni, Fe, Ni, Fe, we sort the atoms by the alphabetical order of the chemical symbols, meaning in this example the order should be 2, 0, 3, 1 (first Fe, and then Ni). I realized that by simply applying `np.argsort`, the order within the same chemical symbol is not uniquely defined, meaning in the example here, we might end up with 3, 1, 2, 0 or any other permutation. This fix forces the ordering within the same chemical symbol by applying a small ramp on the enumeration.