### PR TITLE
patches in default LORBIT writing

### DIFF
--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -862,10 +862,16 @@ class VaspBase(GenericDFTJob):
             if "ISPIN" not in self.input.incar._dataset["Parameter"]:
                 self.input.incar["ISPIN"] = 2
                 
-                # This ensures per-atom magnetisations are written to OUTCAR
+                # LORBIT MUST BE SET TO WRITE PER-ATOM MAGNETISATIONS
+                # Check if LORBIT is in the INCAR parameters
                 if "LORBIT" not in self.input.incar._dataset["Parameter"]:
+                    # If LORBIT is not set, set it to 10
+                    self.input.incar["LORBIT"] = 10
+                    warnings.warn("We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation.")
+                else:
+                    # If LORBIT is set but not in the valid range, set it to 10 and warn
                     if self.input.incar["LORBIT"] not in [0, 1, 2, 5, 10, 11, 12, 13, 14]:
-                        warnings.warn("We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarised calc")
+                        warnings.warn("Invalid LORBIT tag. We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation.")
                         self.input.incar["LORBIT"] = 10
 
             if self.input.incar["ISPIN"] != 1:

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -867,11 +867,11 @@ class VaspBase(GenericDFTJob):
                 if "LORBIT" not in self.input.incar._dataset["Parameter"]:
                     # If LORBIT is not set, set it to 10
                     self.input.incar["LORBIT"] = 10
-                    warnings.warn("We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation.")
+                    self.logger.warning("We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation.")  
                 else:
                     # If LORBIT is set but not in the valid range, set it to 10 and warn
                     if self.input.incar["LORBIT"] not in [0, 1, 2, 5, 10, 11, 12, 13, 14]:
-                        warnings.warn("Invalid LORBIT tag. We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation.")
+                        self.logger.warning("Invalid LORBIT tag. We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation.")  
                         self.input.incar["LORBIT"] = 10
 
             if self.input.incar["ISPIN"] != 1:
@@ -926,6 +926,17 @@ class VaspBase(GenericDFTJob):
                     raise ValueError(
                         "Spin constraints are only avilable for non collinear calculations."
                     )
+                # LORBIT MUST BE SET TO WRITE PER-ATOM MAGNETISATIONS
+                # Check if LORBIT is in the INCAR parameters
+                if "LORBIT" not in self.input.incar._dataset["Parameter"]:
+                    # If LORBIT is not set, set it to 10
+                    self.input.incar["LORBIT"] = 10
+                    self.logger.warning("We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation.")  
+                else:
+                    # If LORBIT is set but not in the valid range, set it to 10 and warn
+                    if self.input.incar["LORBIT"] not in [0, 1, 2, 5, 10, 11, 12, 13, 14]:
+                        self.logger.warning("Invalid LORBIT tag. We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation.")  
+                        self.input.incar["LORBIT"] = 10
             else:
                 state.logger.debug(
                     "Spin polarized calculation is switched off by the user. No magnetic moments are written."

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -861,6 +861,13 @@ class VaspBase(GenericDFTJob):
         if self.structure.has("initial_magmoms"):
             if "ISPIN" not in self.input.incar._dataset["Parameter"]:
                 self.input.incar["ISPIN"] = 2
+                
+                # This ensures per-atom magnetisations are written to OUTCAR
+                if "LORBIT" not in self.input.incar._dataset["Parameter"]:
+                    if self.input.incar["LORBIT"] not in [0, 1, 2, 5, 10, 11, 12, 13, 14]:
+                        warnings.warn("We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarised calc")
+                        self.input.incar["LORBIT"] = 10
+
             if self.input.incar["ISPIN"] != 1:
                 final_cmd = "   ".join(
                     [

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -861,17 +861,31 @@ class VaspBase(GenericDFTJob):
         if self.structure.has("initial_magmoms"):
             if "ISPIN" not in self.input.incar._dataset["Parameter"]:
                 self.input.incar["ISPIN"] = 2
-                
+
                 # LORBIT MUST BE SET TO WRITE PER-ATOM MAGNETISATIONS
                 # Check if LORBIT is in the INCAR parameters
                 if "LORBIT" not in self.input.incar._dataset["Parameter"]:
                     # If LORBIT is not set, set it to 10
                     self.input.incar["LORBIT"] = 10
-                    self.logger.warning("We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation.")  
+                    self.logger.warning(
+                        "We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation."
+                    )
                 else:
                     # If LORBIT is set but not in the valid range, set it to 10 and warn
-                    if self.input.incar["LORBIT"] not in [0, 1, 2, 5, 10, 11, 12, 13, 14]:
-                        self.logger.warning("Invalid LORBIT tag. We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation.")  
+                    if self.input.incar["LORBIT"] not in [
+                        0,
+                        1,
+                        2,
+                        5,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                    ]:
+                        self.logger.warning(
+                            "Invalid LORBIT tag. We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation."
+                        )
                         self.input.incar["LORBIT"] = 10
 
             if self.input.incar["ISPIN"] != 1:
@@ -931,11 +945,25 @@ class VaspBase(GenericDFTJob):
                 if "LORBIT" not in self.input.incar._dataset["Parameter"]:
                     # If LORBIT is not set, set it to 10
                     self.input.incar["LORBIT"] = 10
-                    self.logger.warning("We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation.")  
+                    self.logger.warning(
+                        "We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation."
+                    )
                 else:
                     # If LORBIT is set but not in the valid range, set it to 10 and warn
-                    if self.input.incar["LORBIT"] not in [0, 1, 2, 5, 10, 11, 12, 13, 14]:
-                        self.logger.warning("Invalid LORBIT tag. We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation.")  
+                    if self.input.incar["LORBIT"] not in [
+                        0,
+                        1,
+                        2,
+                        5,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                    ]:
+                        self.logger.warning(
+                            "Invalid LORBIT tag. We have set LORBIT = 10 to write magmoms to OUTCAR! This is a spin-polarized calculation."
+                        )
                         self.input.incar["LORBIT"] = 10
             else:
                 state.logger.debug(


### PR DESCRIPTION
LORBIT is not set by default when specifying spin-polarised calculations... This prevents writing of magnetisations to OUTCAR causing confusion; 

i.e.
https://github.com/pyiron/pyiron_atomistics/issues/1060
https://github.com/pyiron/pyiron_atomistics/issues/1423