### PR TITLE
Refactor Vasp output classes

### DIFF
--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -2026,6 +2026,7 @@ class Output:
         self.outcar = Outcar()
         self.oszicar = Oszicar()
         self.generic_output = GenericOutput()
+        self.dft_output = DFTOutput()
         self.description = (
             "This contains all the output static from this particular vasp run"
         )

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -345,9 +345,6 @@ class GenericOutput(GenericOutputBase):
         log_dict (dict): A dictionary of all tags and values of generic data (positions, forces, etc)
     """
 
-    def __init__(self):
-        super(GenericOutput, self).__init__()
-
     def to_hdf(self, hdf):
         """
         Save the object in a HDF5 file
@@ -374,9 +371,6 @@ class DFTOutput(DFTOutputBase):
     Attributes:
         log_dict (dict): A dictionary of all tags and values of DFT data
     """
-
-    def __init__(self):
-        super(DFTOutput, self).__init__()
 
     def to_hdf(self, hdf):
         """

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -11,7 +11,7 @@ from pyiron_atomistics.vasp.base import VaspBase
 from pyiron_atomistics.vasp.structure import vasp_sorter
 from pyiron_atomistics.vasp.potential import VaspPotentialSetter
 from pyiron_atomistics.vasp.base import GenericOutput as GenericOutputBase
-from pyiron_atomistics.vasp.base import DFTOutput as DFTOutputBase
+from pyiron_atomistics.vasp.base import DFTOutput
 from pyiron_atomistics.vasp.base import Output as OutputBase
 from pyiron_atomistics.atomistics.job.interactive import GenericInteractive
 
@@ -362,24 +362,3 @@ class GenericOutput(GenericOutputBase):
                     hdf_dft[key] = val
                 if self.bands.eigenvalue_matrix is not None:
                     self.bands.to_hdf(hdf_dft, "bands")
-
-
-class DFTOutput(DFTOutputBase):
-    """
-    This class stores the DFT specific output
-
-    Attributes:
-        log_dict (dict): A dictionary of all tags and values of DFT data
-    """
-
-    def to_hdf(self, hdf):
-        """
-        Save the object in a HDF5 file
-
-        Args:
-            hdf (pyiron_base.generic.hdfio.ProjectHDFio): HDF path to which the object is to be saved
-
-        """
-        with hdf.open("dft") as hdf_dft:
-            for key, val in self.log_dict.items():
-                hdf_dft[key] = val

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -10,7 +10,7 @@ from pyiron_atomistics.vasp.parser.outcar import Outcar
 from pyiron_atomistics.vasp.base import VaspBase
 from pyiron_atomistics.vasp.structure import vasp_sorter
 from pyiron_atomistics.vasp.potential import VaspPotentialSetter
-from pyiron_atomistics.vasp.base import GenericOutput as GenericOutputBase
+from pyiron_atomistics.vasp.base import GenericOutput
 from pyiron_atomistics.vasp.base import DFTOutput
 from pyiron_atomistics.vasp.base import Output as OutputBase
 from pyiron_atomistics.atomistics.job.interactive import GenericInteractive
@@ -333,32 +333,3 @@ class Output(OutputBase):
         super(Output, self).__init__()
         self.generic_output = GenericOutput()
         self.dft_output = DFTOutput()
-
-
-class GenericOutput(GenericOutputBase):
-    """
-
-    This class stores the generic output like different structures, energies and forces from a simulation in a highly
-    generic format. Usually the user does not have to access this class.
-
-    Attributes:
-        log_dict (dict): A dictionary of all tags and values of generic data (positions, forces, etc)
-    """
-
-    def to_hdf(self, hdf):
-        """
-        Save the object in a HDF5 file
-
-        Args:
-            hdf (pyiron_base.generic.hdfio.ProjectHDFio): HDF path to which the object is to be saved
-
-        """
-        with hdf.open("generic") as hdf_go:
-            # hdf_go["description"] = self.description
-            for key, val in self.log_dict.items():
-                hdf_go[key] = val
-            with hdf_go.open("dft") as hdf_dft:
-                for key, val in self.dft_log_dict.items():
-                    hdf_dft[key] = val
-                if self.bands.eigenvalue_matrix is not None:
-                    self.bands.to_hdf(hdf_dft, "bands")

--- a/pyiron_atomistics/vasp/interactive.py
+++ b/pyiron_atomistics/vasp/interactive.py
@@ -10,11 +10,13 @@ from pyiron_atomistics.vasp.parser.outcar import Outcar
 from pyiron_atomistics.vasp.base import VaspBase
 from pyiron_atomistics.vasp.structure import vasp_sorter
 from pyiron_atomistics.vasp.potential import VaspPotentialSetter
-from pyiron_atomistics.vasp.base import GenericOutput
-from pyiron_atomistics.vasp.base import DFTOutput
-from pyiron_atomistics.vasp.base import Output as OutputBase
 from pyiron_atomistics.atomistics.job.interactive import GenericInteractive
 
+# as of pyiron_atomistics <= 0.5.4 this module defined subclasses that are now removed; the base classes are still
+# imported here in case HDF5 files in the wild refer to them.  The imports can be removed on the next big version bump.
+from pyiron_atomistics.vasp.base import GenericOutput
+from pyiron_atomistics.vasp.base import DFTOutput
+from pyiron_atomistics.vasp.base import Output
 
 __author__ = "Osamu Waseda, Jan Janssen"
 __copyright__ = (
@@ -317,19 +319,3 @@ class VaspInteractive(VaspBase, GenericInteractive):
             return True
         else:
             return super().convergence_check()
-
-
-class Output(OutputBase):
-    """
-    Handles the output from a VASP simulation.
-
-    Attributes:
-        electronic_structure: Gives the electronic structure of the system
-        electrostatic_potential: Gives the electrostatic/local potential of the system
-        charge_density: Gives the charge density of the system
-    """
-
-    def __init__(self):
-        super(Output, self).__init__()
-        self.generic_output = GenericOutput()
-        self.dft_output = DFTOutput()


### PR DESCRIPTION
The vasp.interactive sub module defined subclasses that did not change the functionality of the base classes.  As far as I can tell they were not used except in `VaspInteractive.interactive_close`, so I have removed them but left the imports in place in case any HDF5 files still refer to them.