### PR TITLE
[patch] replace logger with snippets version

### DIFF
--- a/pyiron_atomistics/project.py
+++ b/pyiron_atomistics/project.py
@@ -16,9 +16,9 @@ from pyiron_base import (
     Project as ProjectCore,
     Creator as CreatorCore,
 )
-from pyiron_base.state.logger import logger
 from pyiron_base.project.maintenance import Maintenance, LocalMaintenance
 from pyiron_snippets.deprecate import deprecate
+from pyiron_snippets.logger import logger
 
 try:
     from pyiron_base import ProjectGUI


### PR DESCRIPTION
i.e. pyiron_base.state.logger.logger with pyiron_snippets.logger.logger. The original location leaves a re-direct for backwards compatibility.