### PR TITLE
[patch] remove initial magnetic moments

### DIFF
--- a/test_integration/tests_sphinx_sphinx_check_all.py
+++ b/test_integration/tests_sphinx_sphinx_check_all.py
@@ -19,6 +19,8 @@ class TestSphinx(unittest.TestCase):
     def test_Fe_nonmag(self):
         job = self.project.create_job(self.project.job_type.Sphinx, 'spx_Fe_nonmag')
         job.structure = self.project.create.structure.ase.bulk('Fe', a=self.a_Fe)
+        job.structure.arrays.pop("spin")
+        job.structure.arrays.pop("initial_magmoms")
         job.calc_static()
         job.run()
         self.assertLess(

--- a/test_integration/tests_sphinx_sphinx_check_all.py
+++ b/test_integration/tests_sphinx_sphinx_check_all.py
@@ -19,8 +19,11 @@ class TestSphinx(unittest.TestCase):
     def test_Fe_nonmag(self):
         job = self.project.create_job(self.project.job_type.Sphinx, 'spx_Fe_nonmag')
         job.structure = self.project.create.structure.ase.bulk('Fe', a=self.a_Fe)
-        job.structure.arrays.pop("spin")
-        job.structure.arrays.pop("initial_magmoms")
+        try:
+            job.structure.arrays.pop("spin")
+            job.structure.arrays.pop("initial_magmoms")
+        except KeyError:
+            pass
         job.calc_static()
         job.run()
         self.assertLess(


### PR DESCRIPTION
Apparently the latest ASE adds default magnetic moments to magnetic atoms, which breaks the Sphinx tests, so I remove the tags if they are present in the tests.