### PR TITLE
Vasp: Refactor bader analysis

### DIFF
--- a/pyiron_atomistics/dft/bader.py
+++ b/pyiron_atomistics/dft/bader.py
@@ -43,7 +43,9 @@ class Bader:
         """
         Create CUBE format files of the total and valce charges to be used by the Bader program
         """
-        cd_val, cd_total = get_valence_and_total_charge_density(working_directory=self._working_directory)
+        cd_val, cd_total = get_valence_and_total_charge_density(
+            working_directory=self._working_directory
+        )
         cd_val.write_cube_file(
             filename=os.path.join(self._working_directory, "valence_charge.CUBE")
         )

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -435,7 +435,9 @@ class VaspBase(GenericDFTJob):
         if os.path.isfile(os.path.join(cwd, "AECCAR0")) and os.path.isfile(
             os.path.join(cwd, "AECCAR2")
         ):
-            bader = Bader(working_directory=self.working_directory, structure=self.structure)
+            bader = Bader(
+                working_directory=self.working_directory, structure=self.structure
+            )
             try:
                 charges_orig, volumes_orig = bader.compute_bader_charges()
             except ValueError:
@@ -1460,7 +1462,9 @@ class VaspBase(GenericDFTJob):
         Returns:
             tuple: The required charge densities
         """
-        return get_valence_and_total_charge_density(working_directory=self.working_directory)
+        return get_valence_and_total_charge_density(
+            working_directory=self.working_directory
+        )
 
     def get_electrostatic_potential(self):
         """

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -40,7 +40,7 @@ from pyiron_atomistics.dft.waves.electronic import (
     electronic_structure_dict_to_hdf,
 )
 from pyiron_atomistics.dft.waves.bandstructure import Bandstructure
-from pyiron_atomistics.dft.bader import Bader
+from pyiron_atomistics.dft.bader import Bader, get_valence_and_total_charge_density
 import warnings
 
 __author__ = "Sudarsan Surendralal, Felix Lochner"
@@ -435,7 +435,7 @@ class VaspBase(GenericDFTJob):
         if os.path.isfile(os.path.join(cwd, "AECCAR0")) and os.path.isfile(
             os.path.join(cwd, "AECCAR2")
         ):
-            bader = Bader(self)
+            bader = Bader(working_directory=self.working_directory, structure=self.structure)
             try:
                 charges_orig, volumes_orig = bader.compute_bader_charges()
             except ValueError:
@@ -1460,16 +1460,7 @@ class VaspBase(GenericDFTJob):
         Returns:
             tuple: The required charge densities
         """
-        cd_core = VaspVolumetricData()
-        cd_total = VaspVolumetricData()
-        cd_val = VaspVolumetricData()
-        if os.path.isfile(self.working_directory + "/AECCAR0"):
-            cd_core.from_file(self.working_directory + "/AECCAR0")
-            cd_val.from_file(self.working_directory + "/AECCAR2")
-            cd_val.atoms = cd_val.atoms
-            cd_total.total_data = cd_core.total_data + cd_val.total_data
-            cd_total.atoms = cd_val.atoms
-        return cd_val, cd_total
+        return get_valence_and_total_charge_density(working_directory=self.working_directory)
 
     def get_electrostatic_potential(self):
         """


### PR DESCRIPTION
Rather than requiring the `job` object as input the `Bader` class now only requires the `structure` and the `working_directory`. This simplifies the refactoring of the output in https://github.com/pyiron/pyiron_atomistics/pull/1452 