### PR TITLE
Vasp submit to executor

### DIFF
--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -400,10 +400,12 @@ class VaspBase(GenericDFTJob):
                         "The POSCAR file will be overwritten by the CONTCAR file specified in restart_file_list."
                     )
         input_file_dict = super().get_input_file_dict()
-        input_file_dict["files_to_create"].update(self.input.get_input_file_dict(
-            structure=self.structure,
-            modified_elements=modified_elements,
-        ))
+        input_file_dict["files_to_create"].update(
+            self.input.get_input_file_dict(
+                structure=self.structure,
+                modified_elements=modified_elements,
+            )
+        )
         return input_file_dict
 
     def _store_output(self, output_dict):

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -399,13 +399,12 @@ class VaspBase(GenericDFTJob):
                     self.logger.info(
                         "The POSCAR file will be overwritten by the CONTCAR file specified in restart_file_list."
                     )
-        return {
-            "files_to_create": self.input.get_input_file_dict(
-                structure=self.structure,
-                modified_elements=modified_elements,
-            ),
-            "files_to_copy": {},
-        }
+        input_file_dict = super().get_input_file_dict()
+        input_file_dict["files_to_create"].update(self.input.get_input_file_dict(
+            structure=self.structure,
+            modified_elements=modified_elements,
+        ))
+        return input_file_dict
 
     def _store_output(self, output_dict):
         output_dict_to_hdf(


### PR DESCRIPTION
This pull request is the continuation of https://github.com/pyiron/pyiron_atomistics/pull/1130 and https://github.com/pyiron/pyiron_atomistics/pull/1451 to define a `calculate()` function which can be submitted using an `pympipool.Executor`. Example:
```python
from pympipool import Executor
import os
import posixpath
import shutil
import subprocess
from pyiron_atomistics import Project
from pyiron_atomistics.vasp.output import parse_vasp_output

def calculate_vasp(working_directory, input_file_dict, executable_dict, collect_output_kwargs):
    os.makedirs(working_directory, exist_ok=True)
    for file_name, content in input_file_dict["files_to_create"].items():
        with open(os.path.join(working_directory, file_name), "w") as f:
            f.writelines(content)
    for file_name, source in input_file_dict["files_to_copy"].items():
        shutil.copy(source, os.path.join(working_directory, file_name))
    _ = subprocess.run(
        executable_dict["command"],
        cwd=working_directory,
        shell=executable_dict["shell"],
        stdout=subprocess.PIPE,
        stderr=subprocess.STDOUT,
        universal_newlines=True,
        check=True,
    )
    return parse_vasp_output(
        working_directory=working_directory,
        **collect_output_kwargs,
    )

pr = Project("test")
pr.remove_jobs(recursive=True, silently=True)
job = pr.create.job.Vasp("vasp")
job.structure = pr.create.structure.ase.bulk("Al", cubic=True)
job.validate_ready_to_run()

executable, shell = job.executable.get_input_for_subprocess_call(
    cores=job.server.cores, threads=job.server.threads, gpus=job.server.gpus
)
with Executor(backend="mpi") as exe:
    future = exe.submit(
        calculate_vasp, 
        working_directory="tmp", 
        input_file_dict=job.get_input_file_dict(), 
        executable_dict={
            "command": executable,
            "shell": shell,
        }, 
        collect_output_kwargs={
            "sorted_indices": job.sorted_indices,
            "structure": job.structure,
        },
    )
    output_dict = future.result()

job._python_only_job = True
job.save()
job._store_output(output_dict=output_dict)

job_reload = pr.load(job.job_name)
print(job_reload.output.energy_pot)
```