### PR TITLE
remove calc_static from DFT

### DIFF
--- a/pyiron_atomistics/dft/job/generic.py
+++ b/pyiron_atomistics/dft/job/generic.py
@@ -333,7 +333,6 @@ class GenericDFTJob(AtomisticGenericJob):
         ionic_forces=None,
         volume_only=False,
     ):
-        self._generic_input["fix_symmetry"] = True
         super(GenericDFTJob, self).calc_minimize(max_iter=max_iter, pressure=pressure)
 
     def calc_md(

--- a/pyiron_atomistics/dft/job/generic.py
+++ b/pyiron_atomistics/dft/job/generic.py
@@ -318,22 +318,25 @@ class GenericDFTJob(AtomisticGenericJob):
             path_name=path_name,
         )
 
+    def calc_static(
+        self,
+        electronic_steps=60,
+    ):
+        super().calc_static()
+
     def calc_minimize(
         self,
         electronic_steps=60,
         ionic_steps=100,
         max_iter=None,
         pressure=None,
-        algorithm=None,
-        retain_charge_density=False,
-        retain_electrostatic_potential=False,
         ionic_energy_tolerance=None,
         ionic_force_tolerance=None,
         ionic_energy=None,
         ionic_forces=None,
         volume_only=False,
     ):
-        super(GenericDFTJob, self).calc_minimize(max_iter=max_iter, pressure=pressure)
+        super().calc_minimize(max_iter=max_iter, pressure=pressure)
 
     def calc_md(
         self,
@@ -341,12 +344,10 @@ class GenericDFTJob(AtomisticGenericJob):
         n_ionic_steps=1000,
         n_print=1,
         time_step=1.0,
-        retain_charge_density=False,
-        retain_electrostatic_potential=False,
         **kwargs,
     ):
         self._generic_input["fix_symmetry"] = False
-        super(GenericDFTJob, self).calc_md(
+        super().calc_md(
             temperature=temperature,
             n_ionic_steps=n_ionic_steps,
             n_print=n_print,

--- a/pyiron_atomistics/dft/job/generic.py
+++ b/pyiron_atomistics/dft/job/generic.py
@@ -318,16 +318,6 @@ class GenericDFTJob(AtomisticGenericJob):
             path_name=path_name,
         )
 
-    def calc_static(
-        self,
-        electronic_steps=100,
-        algorithm=None,
-        retain_charge_density=False,
-        retain_electrostatic_potential=False,
-    ):
-        self._generic_input["fix_symmetry"] = True
-        super(GenericDFTJob, self).calc_static()
-
     def calc_minimize(
         self,
         electronic_steps=60,

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -639,6 +639,7 @@ class SphinxBase(GenericDFTJob):
         for arg in ["Istep", "dF", "dE"]:
             if arg in self.input:
                 del self.input[arg]
+        super().calc_static()
         self.load_default_groups()
 
     def calc_minimize(

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -705,12 +705,7 @@ class SphinxBase(GenericDFTJob):
         self.load_default_groups()
 
     def calc_md(
-        self,
-        temperature=None,
-        n_ionic_steps=1000,
-        n_print=1,
-        time_step=1.0,
-        **kwargs
+        self, temperature=None, n_ionic_steps=1000, n_print=1, time_step=1.0, **kwargs
     ):
         raise NotImplementedError("calc_md() not implemented in SPHInX.")
 

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -621,9 +621,7 @@ class SphinxBase(GenericDFTJob):
         main Group.
 
         Args:
-            electronic_steps (float): max # of electronic steps
-            electronic_steps (int): maximum number of electronic steps
-                which can be used to achieve convergence
+            electronic_steps (int): max # of electronic steps
         """
         if electronic_steps is not None:
             self.input["Estep"] = electronic_steps

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -613,13 +613,7 @@ class SphinxBase(GenericDFTJob):
         if "noWavesStorage" not in guess:
             guess["noWavesStorage"] = not self.input["WriteWaves"]
 
-    def calc_static(
-        self,
-        electronic_steps=100,
-        algorithm=None,
-        retain_charge_density=False,
-        retain_electrostatic_potential=False,
-    ):
+    def calc_static(self, electronic_steps=100):
         """
         Setup the hamiltonian to perform a static SCF run.
 
@@ -628,9 +622,6 @@ class SphinxBase(GenericDFTJob):
 
         Args:
             electronic_steps (float): max # of electronic steps
-            retain_electrostatic_potential:
-            retain_charge_density:
-            algorithm (str): CCG or blockCCG (not implemented)
             electronic_steps (int): maximum number of electronic steps
                 which can be used to achieve convergence
         """
@@ -639,7 +630,7 @@ class SphinxBase(GenericDFTJob):
         for arg in ["Istep", "dF", "dE"]:
             if arg in self.input:
                 del self.input[arg]
-        super().calc_static()
+        super().calc_static(electronic_steps=electronic_steps)
         self.load_default_groups()
 
     def calc_minimize(
@@ -648,9 +639,6 @@ class SphinxBase(GenericDFTJob):
         ionic_steps=None,
         max_iter=None,
         pressure=None,
-        algorithm=None,
-        retain_charge_density=False,
-        retain_electrostatic_potential=False,
         ionic_energy=None,
         ionic_forces=None,
         ionic_energy_tolerance=None,
@@ -672,9 +660,6 @@ class SphinxBase(GenericDFTJob):
             in an error.
 
         Args:
-            retain_electrostatic_potential:
-            retain_charge_density:
-            algorithm:
             pressure:
             max_iter:
             electronic_steps (int): maximum number of electronic steps
@@ -713,25 +698,13 @@ class SphinxBase(GenericDFTJob):
             ionic_steps=ionic_steps,
             max_iter=max_iter,
             pressure=pressure,
-            algorithm=algorithm,
-            retain_charge_density=retain_charge_density,
-            retain_electrostatic_potential=retain_electrostatic_potential,
             ionic_energy_tolerance=ionic_energy_tolerance,
             ionic_force_tolerance=ionic_force_tolerance,
             volume_only=volume_only,
         )
         self.load_default_groups()
 
-    def calc_md(
-        self,
-        temperature=None,
-        n_ionic_steps=1000,
-        n_print=1,
-        time_step=1.0,
-        retain_charge_density=False,
-        retain_electrostatic_potential=False,
-        **kwargs,
-    ):
+    def calc_md(self, **kwargs):
         raise NotImplementedError("calc_md() not implemented in SPHInX.")
 
     def restart_for_band_structure_calculations(self, job_name=None):

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -705,7 +705,7 @@ class SphinxBase(GenericDFTJob):
         self.load_default_groups()
 
     def calc_md(
-        self
+        self,
         temperature=None,
         n_ionic_steps=1000,
         n_print=1,

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -704,7 +704,14 @@ class SphinxBase(GenericDFTJob):
         )
         self.load_default_groups()
 
-    def calc_md(self, **kwargs):
+    def calc_md(
+        self
+        temperature=None,
+        n_ionic_steps=1000,
+        n_print=1,
+        time_step=1.0,
+        **kwargs
+    ):
         raise NotImplementedError("calc_md() not implemented in SPHInX.")
 
     def restart_for_band_structure_calculations(self, job_name=None):

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -639,12 +639,6 @@ class SphinxBase(GenericDFTJob):
         for arg in ["Istep", "dF", "dE"]:
             if arg in self.input:
                 del self.input[arg]
-        super(SphinxBase, self).calc_static(
-            electronic_steps=electronic_steps,
-            algorithm=algorithm,
-            retain_charge_density=retain_charge_density,
-            retain_electrostatic_potential=retain_electrostatic_potential,
-        )
         self.load_default_groups()
 
     def calc_minimize(

--- a/pyiron_atomistics/sphinx/interactive.py
+++ b/pyiron_atomistics/sphinx/interactive.py
@@ -232,9 +232,6 @@ class SphinxInteractive(SphinxBase, GenericInteractive):
         ionic_steps=None,
         max_iter=None,
         pressure=None,
-        algorithm=None,
-        retain_charge_density=False,
-        retain_electrostatic_potential=False,
         ionic_energy_tolerance=None,
         ionic_force_tolerance=None,
         ionic_energy=None,
@@ -254,9 +251,6 @@ class SphinxInteractive(SphinxBase, GenericInteractive):
                 ionic_steps=ionic_steps,
                 max_iter=max_iter,
                 pressure=pressure,
-                algorithm=algorithm,
-                retain_charge_density=retain_charge_density,
-                retain_electrostatic_potential=retain_electrostatic_potential,
                 ionic_energy_tolerance=ionic_energy_tolerance,
                 ionic_force_tolerance=ionic_force_tolerance,
                 volume_only=volume_only,
@@ -305,31 +299,6 @@ class SphinxInteractive(SphinxBase, GenericInteractive):
 
     def _interactive_pipe_read(self):
         return self._interactive_library_read.readline()
-
-    def calc_static(
-        self,
-        electronic_steps=100,
-        blockSize=8,
-        dSpinMoment=1e-8,
-        algorithm=None,
-        retain_charge_density=False,
-        retain_electrostatic_potential=False,
-    ):
-        """
-        Function to setup the hamiltonian to perform static SCF DFT runs
-
-        Args:
-            retain_electrostatic_potential:
-            retain_charge_density:
-            algorithm:
-            electronic_steps (int): maximum number of electronic steps, which can be used to achieve convergence
-        """
-        super(SphinxInteractive, self).calc_static(
-            electronic_steps=electronic_steps,
-            algorithm=algorithm,
-            retain_charge_density=retain_charge_density,
-            retain_electrostatic_potential=retain_electrostatic_potential,
-        )
 
     def load_main_group(self):
         main_group = Group()

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -1025,9 +1025,6 @@ class VaspBase(GenericDFTJob):
             ionic_steps=ionic_steps,
             max_iter=max_iter,
             pressure=pressure,
-            algorithm=algorithm,
-            retain_charge_density=retain_charge_density,
-            retain_electrostatic_potential=retain_electrostatic_potential,
             ionic_energy_tolerance=ionic_energy_tolerance,
             ionic_force_tolerance=ionic_force_tolerance,
             volume_only=volume_only,
@@ -1079,7 +1076,7 @@ class VaspBase(GenericDFTJob):
             retain_charge_density (bool): True if
             retain_electrostatic_potential (bool): True/False
         """
-        super().calc_static()
+        super().calc_static(electronic_steps=electronic_steps)
         self.input.incar["IBRION"] = -1
         self.input.incar["NELM"] = electronic_steps
         # Make sure vasp runs only 1 ionic step
@@ -1118,8 +1115,6 @@ class VaspBase(GenericDFTJob):
             n_ionic_steps=n_ionic_steps,
             n_print=n_print,
             time_step=time_step,
-            retain_charge_density=retain_charge_density,
-            retain_electrostatic_potential=retain_electrostatic_potential,
             **kwargs,
         )
         if temperature is not None:

--- a/pyiron_atomistics/vasp/base.py
+++ b/pyiron_atomistics/vasp/base.py
@@ -1079,12 +1079,7 @@ class VaspBase(GenericDFTJob):
             retain_charge_density (bool): True if
             retain_electrostatic_potential (bool): True/False
         """
-        super(VaspBase, self).calc_static(
-            electronic_steps=electronic_steps,
-            algorithm=algorithm,
-            retain_charge_density=retain_charge_density,
-            retain_electrostatic_potential=retain_electrostatic_potential,
-        )
+        super().calc_static()
         self.input.incar["IBRION"] = -1
         self.input.incar["NELM"] = electronic_steps
         # Make sure vasp runs only 1 ionic step

--- a/tests/sphinx/test_base.py
+++ b/tests/sphinx/test_base.py
@@ -70,8 +70,8 @@ class TestSphinx(unittest.TestCase):
         cls.sphinx.input["VaspPot"] = False
         cls.sphinx.structure.add_tag(selective_dynamics=(True, True, True))
         cls.sphinx.structure.selective_dynamics[1] = (False, False, False)
-        cls.sphinx.load_default_groups()
         cls.sphinx.fix_symmetry = False
+        cls.sphinx.load_default_groups()
         cls.sphinx.write_input()
         cls.sphinx_2_3.to_hdf()
         cls.sphinx_2_3.decompress()
@@ -590,6 +590,11 @@ class TestSphinx(unittest.TestCase):
             "\tatom {\n",
             '\t\tlabel = "spin_0.5";\n',
             "\t\tcoords = [2.4566439620135014, 2.4566439620135014, 2.4566439620135014];\n",
+            "\t}\n",
+            "}\n",
+            "symmetry {\n",
+            "\toperator {\n",
+            "\t\tS = [[1,0,0],[0,1,0],[0,0,1]];\n",
             "\t}\n",
             "}\n",
         ]

--- a/tests/sphinx/test_base.py
+++ b/tests/sphinx/test_base.py
@@ -330,11 +330,11 @@ class TestSphinx(unittest.TestCase):
         self.assertIsInstance(self.sphinx.fix_spin_constraint, bool)
 
     def test_calc_static(self):
-        self.sphinx.calc_static(algorithm="wrong_algorithm")
+        self.sphinx.calc_static()
         self.assertFalse("keepRho" in self.sphinx.input.sphinx.main.to_sphinx())
         self.assertTrue("blockCCG" in self.sphinx.input.sphinx.main.to_sphinx())
         self.sphinx.restart_file_list.append("randomfile")
-        self.sphinx.calc_static(algorithm="ccg")
+        self.sphinx.calc_static()
         self.assertTrue("keepRho" in self.sphinx.input.sphinx.main.to_sphinx())
         self.assertEqual(self.sphinx.input["Estep"], 100)
         self.assertTrue("CCG" in self.sphinx.input.sphinx.main.to_sphinx())


### PR DESCRIPTION
It’s mainly to close [this issue](https://github.com/pyiron/pyiron_atomistics/issues/428) and [this issue](https://github.com/pyiron/pyiron_atomistics/issues/1103), but it looks to me that this function shouldn’t have the current form, as the arguments are simply ignored. So I just removed it and let’s see if the tests pass