### PR TITLE
Update pylammpsmpi to 0.2.21

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -19,7 +19,7 @@ dependencies:
 - pint =0.24.3
 - pyiron_base =0.9.7
 - pyiron_snippets =0.1.2
-- pylammpsmpi =0.2.20
+- pylammpsmpi =0.2.21
 - pyscal3 =3.2.6
 - scikit-learn =1.5.1
 - scipy =1.14.0

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 - pint =0.24.3
 - pyiron_base =0.9.7
 - pyiron_snippets =0.1.2
-- pylammpsmpi =0.2.20
+- pylammpsmpi =0.2.21
 - pyscal3 =3.2.6
 - scikit-learn =1.5.1
 - scipy =1.14.0

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - pint =0.24.3
 - pyiron_base =0.9.7
 - pyiron_snippets =0.1.2
-- pylammpsmpi =0.2.20
+- pylammpsmpi =0.2.21
 - pyscal3 =3.2.6
 - scikit-learn =1.5.1
 - scipy =1.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pint==0.24.3",
     "pyiron_base==0.9.7",
     "pyiron_snippets==0.1.2",
-    "pylammpsmpi==0.2.20",
+    "pylammpsmpi==0.2.21",
     "pyscal3==3.2.6",
     "scipy==1.14.0",
     "scikit-learn==1.5.1",


### PR DESCRIPTION
This is hopefully the last dependency on `pympipool`.