### PR TITLE
Refactor resource loading in lammps/vasp/sphinx

### DIFF
--- a/pyiron_atomistics/atomistics/job/potentials.py
+++ b/pyiron_atomistics/atomistics/job/potentials.py
@@ -103,8 +103,25 @@ class PotentialAbstract(object):
     def __str__(self):
         return str(self.list())
 
-    @staticmethod
-    def _get_potential_df(plugin_name, file_name_lst):
+    @classmethod
+    def _get_resolver(cls, plugin_name):
+        """Return a ResourceResolver that can be searched for potential files or potential dataframes.
+
+        This exists primarily so that the lammps and sphinx sub classes can overload it to add their conda package
+        specific resource paths.
+
+        Args:
+            plugin_name (str): one of "lammps", "vasp", "sphinx"; i.e. the name of the resource folder to search
+        Returns:
+            :class:`.ResourceResolver`
+        """
+        return ResourceResolver(
+                state.settings.resource_paths,
+                plugin_name, "potentials",
+        )
+
+    @classmethod
+    def _get_potential_df(cls, plugin_name, file_name_lst):
         """
 
         Args:
@@ -115,7 +132,6 @@ class PotentialAbstract(object):
             pandas.DataFrame:
         """
         env = os.environ
-        resource_path_lst = state.settings.resource_paths
         def read_csv(path):
             return pandas.read_csv(
                     path,
@@ -133,10 +149,7 @@ class PotentialAbstract(object):
                         .split(", "),
                     },
             )
-        files = ResourceResolver(
-                resource_path_lst,
-                plugin_name, "potentials",
-            ).chain(
+        files = cls._get_resolver(plugin_name).chain(
             # support iprpy-data package; data paths in the iprpy are of a different form than in
             # pyiron resources, so we cannot add it as an additional path to the resolver above.
             # Instead make a new resolver and chain it after the first one.

--- a/pyiron_atomistics/atomistics/job/potentials.py
+++ b/pyiron_atomistics/atomistics/job/potentials.py
@@ -158,26 +158,20 @@ class PotentialAbstract(ABC):
         files = cls._get_resolver().search(file_name_lst)
         return pandas.concat(map(read_csv, files), ignore_index=True)
 
-    @staticmethod
+    @classmethod
     def _get_potential_default_df(
-        plugin_name,
-        file_name_lst={"potentials_vasp_pbe_default.csv"},
+            cls, file_name_lst={"potentials_vasp_pbe_default.csv"},
     ):
         """
 
         Args:
-            plugin_name (str):
             file_name_lst (set):
 
         Returns:
             pandas.DataFrame:
         """
         try:
-            file = ResourceResolver(
-                    state.settings.resource_paths,
-                    plugin_name, "potentials",
-            ).first(file_name_lst)
-            return pandas.read_csv(file, index_col=0)
+            return pandas.read_csv(cls._get_resolver().first(file_name_lst), index_col=0)
         except ResourceNotFound:
             raise ValueError("Was not able to locate the potential files.") from None
 

--- a/pyiron_atomistics/lammps/potential.py
+++ b/pyiron_atomistics/lammps/potential.py
@@ -66,15 +66,7 @@ class LammpsPotential(GenericParameters):
     @property
     def files(self):
         env = os.environ
-        resolver = ResourceResolver(
-                    state.settings.resource_paths,
-                    "lammps", "potentials",
-        ).chain(
-            ResourceResolver(
-                [env[var] for var in ("CONDA_PREFIX", "CONDA_DIR") if var in env],
-                "share", "iprpy",
-            )
-        )
+        resolver = LammpsPotentialFile._get_resolver()
         if len(self._df["Filename"].values[0]) > 0 and self._df["Filename"].values[
             0
         ] != [""]:
@@ -247,10 +239,21 @@ class LammpsPotentialFile(PotentialAbstract):
         selected_atoms:
     """
 
+    resource_plugin_name = "lammps"
+
+    @classmethod
+    def _get_resolver(cls):
+        env = os.environ
+        return super()._get_resolver().chain(
+            ResourceResolver(
+                [env[var] for var in ("CONDA_PREFIX", "CONDA_DIR") if var in env],
+                "share", "iprpy",
+            )
+        )
+
     def __init__(self, potential_df=None, default_df=None, selected_atoms=None):
         if potential_df is None:
             potential_df = self._get_potential_df(
-                plugin_name="lammps",
                 file_name_lst={"potentials_lammps.csv"},
             )
         super(LammpsPotentialFile, self).__init__(

--- a/pyiron_atomistics/lammps/potential.py
+++ b/pyiron_atomistics/lammps/potential.py
@@ -13,7 +13,7 @@ from pyiron_atomistics.atomistics.job.potentials import (
     PotentialAbstract
 )
 from pyiron_atomistics.atomistics.structure.atoms import Atoms
-from pyiron_snippets.resources import ResourceResolver, ResourceNotFound
+from pyiron_snippets.resources import ResourceResolver
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal, Jan Janssen"
 __copyright__ = (
@@ -66,7 +66,6 @@ class LammpsPotential(GenericParameters):
     @property
     def files(self):
         env = os.environ
-        resolver = LammpsPotentialFile._get_resolver()
         if len(self._df["Filename"].values[0]) > 0 and self._df["Filename"].values[
             0
         ] != [""]:
@@ -79,12 +78,7 @@ class LammpsPotential(GenericParameters):
                 if not os.path.isabs(files)
             ]
             for path in relative_file_paths:
-                try:
-                    absolute_file_paths.append(
-                            resolver.first(path)
-                    )
-                except ResourceNotFound:
-                    raise ValueError("Was not able to locate the potentials.") from None
+                absolute_file_paths.append(LammpsPotentialFile.find_potential_file(path))
             return absolute_file_paths
 
     def copy_pot_files(self, working_directory):

--- a/pyiron_atomistics/sphinx/base.py
+++ b/pyiron_atomistics/sphinx/base.py
@@ -38,9 +38,6 @@ from pyiron_atomistics.sphinx.output_parser import (
     collect_spins_dat,
 )
 from pyiron_atomistics.sphinx.potential import SphinxJTHPotentialFile
-from pyiron_atomistics.sphinx.potential import (
-    find_potential_file as find_potential_file_jth,
-)
 from pyiron_atomistics.sphinx.structure import read_atoms
 from pyiron_atomistics.sphinx.util import sxversions
 from pyiron_atomistics.sphinx.volumetric_data import SphinxVolumetricData
@@ -48,9 +45,6 @@ from pyiron_atomistics.vasp.potential import (
     VaspPotentialFile,
     VaspPotentialSetter,
     strip_xc_from_potential_name,
-)
-from pyiron_atomistics.vasp.potential import (
-    find_potential_file as find_potential_file_vasp,
 )
 
 __author__ = "Osamu Waseda, Jan Janssen"
@@ -1293,11 +1287,9 @@ class SphinxBase(GenericDFTJob):
 
         if potformat == "JTH":
             potentials = SphinxJTHPotentialFile(xc=xc)
-            find_potential_file = find_potential_file_jth
             pot_path_dict.setdefault("PBE", "jth-gga-pbe")
         elif potformat == "VASP":
             potentials = VaspPotentialFile(xc=xc)
-            find_potential_file = find_potential_file_vasp
             pot_path_dict.setdefault("PBE", "paw-gga-pbe")
             pot_path_dict.setdefault("LDA", "paw-lda")
         else:
@@ -1313,7 +1305,7 @@ class SphinxBase(GenericDFTJob):
             if "pseudo_potcar_file" in species_obj.tags.keys():
                 new_element = species_obj.tags["pseudo_potcar_file"]
                 potentials.add_new_element(parent_element=elem, new_element=new_element)
-                potential_path = find_potential_file(
+                potential_path = potentials.find_potential_file(
                     path=potentials.find_default(new_element)["Filename"].values[0][0]
                 )
                 assert os.path.isfile(
@@ -1327,14 +1319,14 @@ class SphinxBase(GenericDFTJob):
                     potentials.add_new_element(
                         parent_element=elem, new_element=new_element
                     )
-                    potential_path = find_potential_file(
+                    potential_path = potentials.find_potential_file(
                         path=potentials.find_default(new_element)["Filename"].values[0][
                             0
                         ]
                     )
             else:
                 ori_paths.append(
-                    find_potential_file(
+                    potentials.find_potential_file(
                         path=potentials.find_default(elem)["Filename"].values[0][0]
                     )
                 )

--- a/pyiron_atomistics/sphinx/potential.py
+++ b/pyiron_atomistics/sphinx/potential.py
@@ -48,7 +48,6 @@ class SphinxJTHPotentialFile(VaspPotentialAbstract):
         )
         if xc == "PBE":
             default_df = self._get_potential_default_df(
-                plugin_name="sphinx",
                 file_name_lst={"potentials_sphinx_jth_default.csv"},
             )
             potential_df = potential_df[(potential_df["Model"] == "jth-gga-pbe")]

--- a/pyiron_atomistics/sphinx/potential.py
+++ b/pyiron_atomistics/sphinx/potential.py
@@ -7,7 +7,7 @@ import os
 import pandas
 from pyiron_base import state
 from pyiron_atomistics.vasp.potential import VaspPotentialAbstract
-from pyiron_snippets.resources import ResourceResolver, ResourceNotFound
+from pyiron_snippets.resources import ResourceResolver
 
 __author__ = "Osamu Waseda"
 __copyright__ = (

--- a/pyiron_atomistics/sphinx/potential.py
+++ b/pyiron_atomistics/sphinx/potential.py
@@ -30,9 +30,20 @@ class SphinxJTHPotentialFile(VaspPotentialAbstract):
         xc (str): Exchange correlation functional ['PBE', 'LDA']
     """
 
+    resource_plugin_name = "sphinx"
+
+    @classmethod
+    def _get_resolver(cls):
+        env = os.environ
+        return super()._get_resolver().chain(
+            ResourceResolver(
+                [env[var] for var in ("CONDA_PREFIX", "CONDA_DIR") if var in env],
+                "share", "sphinxdft",
+            )
+        )
+
     def __init__(self, xc=None, selected_atoms=None):
         potential_df = self._get_potential_df(
-            plugin_name="sphinx",
             file_name_lst={"potentials_sphinx.csv"},
         )
         if xc == "PBE":
@@ -73,16 +84,3 @@ class SphinxJTHPotentialFile(VaspPotentialAbstract):
         ds.name = new_element
         ds["Name"] = "-".join(name_list)
         self._default_df = self._default_df.append(ds)
-
-
-def find_potential_file(path):
-    env = os.environ
-    return ResourceResolver(
-            state.settings.resource_paths,
-            "sphinx", "potentials"
-    ).chain(
-        ResourceResolver(
-            [env[var] for var in ("CONDA_PREFIX", "CONDA_DIR") if var in env],
-            "share", "sphinxdft",
-        )
-    ).first(path)

--- a/pyiron_atomistics/vasp/potential.py
+++ b/pyiron_atomistics/vasp/potential.py
@@ -36,10 +36,11 @@ class VaspPotentialAbstract(PotentialAbstract):
         selected_atoms:
     """
 
+    resource_plugin_name = "vasp"
+
     def __init__(self, potential_df=None, default_df=None, selected_atoms=None):
         if potential_df is None:
             potential_df = self._get_potential_df(
-                plugin_name="vasp",
                 file_name_lst={"potentials_vasp.csv"},
             )
         super(VaspPotentialAbstract, self).__init__(
@@ -150,7 +151,6 @@ class VaspPotentialFile(VaspPotentialAbstract):
 
     def __init__(self, xc=None, selected_atoms=None):
         potential_df = self._get_potential_df(
-            plugin_name="vasp",
             file_name_lst={"potentials_vasp.csv"},
         )
         if xc == "PBE":

--- a/pyiron_atomistics/vasp/potential.py
+++ b/pyiron_atomistics/vasp/potential.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas
 from pyiron_base import GenericParameters, state
 from pyiron_snippets.deprecate import deprecate
-from pyiron_snippets.resources import ResourceResolver, ResourceNotFound
+from pyiron_snippets.resources import ResourceResolver
 
 from pyiron_atomistics.atomistics.job.potentials import (
     PotentialAbstract,

--- a/pyiron_atomistics/vasp/potential.py
+++ b/pyiron_atomistics/vasp/potential.py
@@ -257,16 +257,6 @@ class VaspPotentialSetter(object):
         return self._potential_dict.__repr__()
 
 
-def find_potential_file(path):
-    try:
-        return ResourceResolver(
-                state.settings.resource_paths,
-                "vasp", "potentials",
-        ).first(path)
-    except ResourceNotFound:
-        return None
-
-
 @deprecate(
     "use get_enmax_among_potentials and note the adjustment to the signature (*args instead of list)"
 )
@@ -333,7 +323,7 @@ def get_enmax_among_potentials(*names, return_list=False, xc="PBE"):
 
     enmax_lst = []
     for n in names:
-        with open(find_potential_file(path=_get_potcar_filename(n, xc))) as pf:
+        with open(self.vasp_potentials.find_potential_file(path=_get_potcar_filename(n, xc))) as pf:
             for i, line in enumerate(pf):
                 if i == 14:
                     encut_str = line.split()[2][:-1]
@@ -431,7 +421,7 @@ class Potcar(GenericParameters):
                 self.vasp_potentials.add_new_element(
                     parent_element=el, new_element=new_element
                 )
-                el_path = find_potential_file(
+                el_path = self.vasp_potentials.find_potential_file(
                     path=self.vasp_potentials.find_default(new_element)[
                         "Filename"
                     ].values[0][0]
@@ -446,13 +436,13 @@ class Potcar(GenericParameters):
                     self.vasp_potentials.add_new_element(
                         parent_element=el, new_element=new_element
                     )
-                    el_path = find_potential_file(
+                    el_path = self.vasp_potentials.find_potential_file(
                         path=self.vasp_potentials.find_default(new_element)[
                             "Filename"
                         ].values[0][0]
                     )
             else:
-                el_path = find_potential_file(
+                el_path = self.vasp_potentials.find_potential_file(
                     path=self.vasp_potentials.find_default(el)["Filename"].values[0][0]
                 )
 

--- a/pyiron_atomistics/vasp/potential.py
+++ b/pyiron_atomistics/vasp/potential.py
@@ -155,19 +155,16 @@ class VaspPotentialFile(VaspPotentialAbstract):
         )
         if xc == "PBE":
             default_df = self._get_potential_default_df(
-                plugin_name="vasp",
                 file_name_lst={"potentials_vasp_pbe_default.csv"},
             )
             potential_df = potential_df[(potential_df["Model"] == "gga-pbe")]
         elif xc == "GGA":
             default_df = self._get_potential_default_df(
-                plugin_name="vasp",
                 file_name_lst={"potentials_vasp_pbe_default.csv"},
             )
             potential_df = potential_df[(potential_df["Model"] == "gga-pbe")]
         elif xc == "LDA":
             default_df = self._get_potential_default_df(
-                plugin_name="vasp",
                 file_name_lst={"potentials_vasp_lda_default.csv"},
             )
             potential_df = potential_df[(potential_df["Model"] == "lda")]


### PR DESCRIPTION
Just refactorings on #1527, but as a separate PR for readability.  It mostly makes sure that the resolvers are not defined multiple times and moves the sphinx/lammps conda path hacks into the respective PotentialAbstract classes.