### PR TITLE
Pass axis in QHA job plotting

### DIFF
--- a/pyiron_atomistics/atomistics/master/quasi.py
+++ b/pyiron_atomistics/atomistics/master/quasi.py
@@ -271,6 +271,6 @@ class QuasiHarmonicJob(AtomisticParallelMaster):
         )
         scalarmappaple = matplotlib.cm.ScalarMappable(norm=normalize, cmap=cmap)
         scalarmappaple.set_array(temperatures)
-        cbar = matplotlib.pyplot.colorbar(scalarmappaple)
+        cbar = matplotlib.pyplot.colorbar(scalarmappaple, ax=axis)
         cbar.set_label("Temperature")
         return axis


### PR DESCRIPTION
Previously `pyplot.colorbar` picked `pyplot.gca()` by default I think, but now it raises a hard error.  So I just resolved this.