### PR TITLE
Increase lammps parsing robustness

### DIFF
--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -440,8 +440,8 @@ class LammpsBase(AtomisticGenericJob):
                 }
             )
         else:
-            logger.warning("
-                "The number of atoms changed during the simulation. This can be a sign of massive issues in your simulation."
+            logger.warning(
+                "The number of atoms changed during the simulation. This can be a sign of massive issues in your simulation.\n"
                 "Not storing 'output/structure' to HDF"
             )
         self.project_hdf5.write_dict_to_hdf(data_dict=hdf_dict)

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -437,7 +437,7 @@ class LammpsBase(AtomisticGenericJob):
             logger.warning(
                 f"Caught ValueError: {e}\n"
                 "This can happen if the number of atoms changes during a simulation\n"
-                "Not storing output/structure to HDF"
+                "Not storing 'output/structure' to HDF"
             )
             final_structure = None
         if final_structure is not None:

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -13,8 +13,8 @@ import numpy as np
 import pandas
 from pyiron_base import state
 from pyiron_snippets.deprecate import deprecate
-
 from pyiron_snippets.logger import logger
+
 from pyiron_atomistics.atomistics.job.atomistic import AtomisticGenericJob
 from pyiron_atomistics.lammps.control import LammpsControl
 from pyiron_atomistics.lammps.output import (

--- a/pyiron_atomistics/lammps/base.py
+++ b/pyiron_atomistics/lammps/base.py
@@ -428,24 +428,21 @@ class LammpsBase(AtomisticGenericJob):
             data_dict=output_dict,
             group_name="output",
         )
-        try:
+        if len(self.structure) == len(hdf_dict["output/generic/indices"][-1]):
             final_structure = self.structure.copy()
             final_structure.indices = hdf_dict["output/generic/indices"][-1]
             final_structure.positions = hdf_dict["output/generic/positions"][-1]
             final_structure.cell = hdf_dict["output/generic/cells"][-1]
-        except ValueError as e:
-            logger.warning(
-                f"Caught ValueError: {e}\n"
-                "This can happen if the number of atoms changes during a simulation\n"
-                "Not storing 'output/structure' to HDF"
-            )
-            final_structure = None
-        if final_structure is not None:
             hdf_dict.update(
                 {
                     "output/structure/" + k: v
                     for k, v in final_structure.to_dict().items()
                 }
+            )
+        else:
+            logger.warning("
+                "The number of atoms changed during the simulation. This can be a sign of massive issues in your simulation."
+                "Not storing 'output/structure' to HDF"
             )
         self.project_hdf5.write_dict_to_hdf(data_dict=hdf_dict)
 

--- a/pyiron_atomistics/lammps/output.py
+++ b/pyiron_atomistics/lammps/output.py
@@ -75,7 +75,11 @@ def parse_lammps_output(
 
     for k, v in dump_dict.items():
         if len(v) > 0:
-            hdf_generic[k] = convert_units(np.array(v), label=k)
+            try:
+                hdf_generic[k] = convert_units(np.array(v), label=k)
+            except ValueError:
+                vals = [convert_units(np.array(val), label=k) for val in v]
+                hdf_generic[k] = vals
 
     if df is not None and pressure_dict is not None and generic_keys_lst is not None:
         for k, v in df.items():

--- a/pyiron_atomistics/lammps/output.py
+++ b/pyiron_atomistics/lammps/output.py
@@ -10,7 +10,7 @@ import h5py
 import numpy as np
 import pandas as pd
 from pyiron_base import extract_data_from_file
-
+from pyiron_snippets.logger import logger
 from pyiron_atomistics.lammps.structure import UnfoldingPrism
 from pyiron_atomistics.lammps.units import UnitConverter
 
@@ -327,6 +327,9 @@ def _collect_output_log(
             if read_thermo:
                 if l.startswith("Loop") or l.startswith("ERROR"):
                     read_thermo = False
+                    continue
+                elif l.startswith("WARNING:"):
+                    logger.warning(f"A warning was found in the log:\n{l}")
                     continue
                 thermo_lines += l
 

--- a/pyiron_atomistics/lammps/output.py
+++ b/pyiron_atomistics/lammps/output.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 from pyiron_base import extract_data_from_file
 from pyiron_snippets.logger import logger
+
 from pyiron_atomistics.lammps.structure import UnfoldingPrism
 from pyiron_atomistics.lammps.units import UnitConverter
 

--- a/pyiron_atomistics/lammps/output.py
+++ b/pyiron_atomistics/lammps/output.py
@@ -79,8 +79,7 @@ def parse_lammps_output(
             try:
                 hdf_generic[k] = convert_units(np.array(v), label=k)
             except ValueError:
-                vals = [convert_units(np.array(val), label=k) for val in v]
-                hdf_generic[k] = vals
+                hdf_generic[k] = [convert_units(np.array(val), label=k) for val in v]
 
     if df is not None and pressure_dict is not None and generic_keys_lst is not None:
         for k, v in df.items():


### PR DESCRIPTION
As the title says, this increases the robustness of  parsing lammps output.
The occasion here was a simulation where atoms got lost during the run.
With these changes:
- warnings in the log file are catched and logged with logger
- the amount of atoms in a dump file can change

The latter is done by modifying how and which output is written to hdf5, so it could have impacts on other code parts I guess, would be great if you have a look @jan-janssen  