### PR TITLE
Use either pyscal2/3 in calphy job

### DIFF
--- a/pyiron_atomistics/calphy/job.py
+++ b/pyiron_atomistics/calphy/job.py
@@ -27,7 +27,12 @@ with ImportAlarm(
     from calphy import Alchemy, Calculation, Liquid, Solid
     from calphy import __version__ as calphy_version
     from calphy.routines import routine_alchemy, routine_fe, routine_pscale, routine_ts
-    from pyscal.trajectory import Trajectory as PyscalTrajectory
+    # both trajectory classes behave the same, so we can use either depending
+    # on the env
+    try:
+        from pyscal.trajectory import Trajectory as PyscalTrajectory
+    except ImportError:
+        from pyscal3.trajectory import Trajectory as PyscalTrajectory
 
 __author__ = "Sarath Menon"
 __copyright__ = (

--- a/pyiron_atomistics/calphy/job.py
+++ b/pyiron_atomistics/calphy/job.py
@@ -27,6 +27,7 @@ with ImportAlarm(
     from calphy import Alchemy, Calculation, Liquid, Solid
     from calphy import __version__ as calphy_version
     from calphy.routines import routine_alchemy, routine_fe, routine_pscale, routine_ts
+
     # both trajectory classes behave the same, so we can use either depending
     # on the env
     try:


### PR DESCRIPTION
MPIE env recently switched from pyscal2 to pyscal3 because calphy dropped the dependency on pyscal2.