### PR TITLE
Change ElectronicStructure import path from pyiron_vasp to atomistics

### DIFF
--- a/pyiron_atomistics/dft/job/generic.py
+++ b/pyiron_atomistics/dft/job/generic.py
@@ -5,7 +5,6 @@
 import warnings
 
 import numpy as np
-from pyiron_atomistics.dft.waves.electronic import ElectronicStructure
 
 from pyiron_atomistics.atomistics.job.atomistic import (
     AtomisticGenericJob,
@@ -13,6 +12,7 @@ from pyiron_atomistics.atomistics.job.atomistic import (
 from pyiron_atomistics.atomistics.job.atomistic import (
     MapFunctions as AtomisticMapFunctions,
 )
+from pyiron_atomistics.dft.waves.electronic import ElectronicStructure
 
 __author__ = "Jan Janssen"
 __copyright__ = (

--- a/pyiron_atomistics/dft/job/generic.py
+++ b/pyiron_atomistics/dft/job/generic.py
@@ -5,7 +5,7 @@
 import warnings
 
 import numpy as np
-from pyiron_vasp.dft.waves.electronic import ElectronicStructure
+from pyiron_atomistics.dft.waves.electronic import ElectronicStructure
 
 from pyiron_atomistics.atomistics.job.atomistic import (
     AtomisticGenericJob,


### PR DESCRIPTION
Previously, it was imported directly from pyiron_vasp, but this class does not define to_hdf/from_hdf methods, leading the this error on calling `Vasp.get_electronic_structure()`

```python
    439 with self.project_hdf5.open("output") as ho:
    440     es_obj = ElectronicStructure()
--> 441     es_obj.from_hdf(ho)
    442 return es_obj

AttributeError: 'ElectronicStructure' object has no attribute 'from_hdf'
```

This changes the import path to the correct module that imports inherited `ElectronicStructure` object, which does define these methods.