### PR TITLE
Bump pyiron-base from 0.15.14 to 0.15.15 (#2005)

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - pandas =2.3.3
 - phonopy =4.1.0
 - pint =0.25.2
-- pyiron_base =0.15.14
+- pyiron_base =0.15.15
 - lammpsparser =0.0.4
 - vaspparser =0.0.4
 - pyiron_snippets =1.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "pandas==2.3.3",
     "phonopy==4.1.0",
     "pint==0.25.2",
-    "pyiron_base==0.15.14",
+    "pyiron_base==0.15.15",
     "lammpsparser==0.0.4",
     "pyiron_snippets==1.2.1",
     "vaspparser==0.0.4",


### PR DESCRIPTION
* Bump pyiron-base from 0.15.14 to 0.15.15

Bumps [pyiron-base](https://github.com/pyiron/pyiron_base) from 0.15.14 to 0.15.15.
- [Release notes](https://github.com/pyiron/pyiron_base/releases)
- [Changelog](https://github.com/pyiron/pyiron_base/blob/main/CHANGELOG.md)
- [Commits](https://github.com/pyiron/pyiron_base/compare/pyiron_base-0.15.14...pyiron_base-0.15.15)

---
updated-dependencies:
- dependency-name: pyiron-base dependency-version: 0.15.15 dependency-type: direct:production update-type: version-update:semver-patch ...



* bump pyiron_base in env

---------