### PR TITLE
Add monte carlo options to calphy job, edit code structure

### DIFF
--- a/pyiron_atomistics/calphy/job.py
+++ b/pyiron_atomistics/calphy/job.py
@@ -189,6 +189,14 @@ class Calphy(GenericJob, HasStructure):
                 "thermostat_damping": 100.0,
                 "barostat_damping": 100.0,
             },
+            "monte_carlo": {
+                "n_steps": 1,
+                "n_swaps": 0,
+                "forward_swap_types": [],
+                "reverse_swap_types": [],
+                "allow_all_swaps": True,
+                "use_custom_lammps": False,
+            },
         }
 
     def set_potentials(self, potential_filenames: Union[list, str]):
@@ -476,21 +484,12 @@ class Calphy(GenericJob, HasStructure):
         """
         calc = copy.deepcopy(self._default_input)
 
-        for key in self._default_input.keys():
-            if key not in ["md", "tolerance", "nose_hoover", "berendsen"]:
+        for key, value in self._default_input.items():
+            if isinstance(value, dict):
+                for subkey in value:
+                    calc[key][subkey] = self.input[key][subkey]
+            else:
                 calc[key] = self.input[key]
-
-        for key in self._default_input["md"].keys():
-            calc["md"][key] = self.input["md"][key]
-
-        for key in self._default_input["tolerance"].keys():
-            calc["tolerance"][key] = self.input["tolerance"][key]
-
-        for key in self._default_input["nose_hoover"].keys():
-            calc["nose_hoover"][key] = self.input["nose_hoover"][key]
-
-        for key in self._default_input["berendsen"].keys():
-            calc["berendsen"][key] = self.input["berendsen"][key]
 
         calc["lattice"] = os.path.join(self.working_directory, "conf.data")
 
@@ -505,8 +504,7 @@ class Calphy(GenericJob, HasStructure):
         calc["queue"] = {}
         calc["queue"]["cores"] = self.server.cores
 
-        calculations = {}
-        calculations["calculations"] = [calc]
+        calculations = {"calculations": [calc]}
 
         with open(os.path.join(self.working_directory, "input.yaml"), "w") as fout:
             yaml.safe_dump(calculations, fout)

--- a/pyiron_atomistics/calphy/job.py
+++ b/pyiron_atomistics/calphy/job.py
@@ -485,7 +485,13 @@ class Calphy(GenericJob, HasStructure):
         calc = copy.deepcopy(self._default_input)
 
         for key in self._default_input.keys():
-            if key not in ["md", "tolerance", "nose_hoover", "berendsen", "monte_carlo"]:
+            if key not in [
+                "md",
+                "tolerance",
+                "nose_hoover",
+                "berendsen",
+                "monte_carlo",
+            ]:
                 calc[key] = self.input[key]
 
         for key in self._default_input["md"].keys():

--- a/pyiron_atomistics/calphy/job.py
+++ b/pyiron_atomistics/calphy/job.py
@@ -484,12 +484,27 @@ class Calphy(GenericJob, HasStructure):
         """
         calc = copy.deepcopy(self._default_input)
 
-        for key, value in self._default_input.items():
-            if isinstance(value, dict):
-                for subkey in value:
-                    calc[key][subkey] = self.input[key][subkey]
-            else:
+        for key in self._default_input.keys():
+            if key not in ["md", "tolerance", "nose_hoover", "berendsen", "monte_carlo"]:
                 calc[key] = self.input[key]
+
+        for key in self._default_input["md"].keys():
+            calc["md"][key] = self.input["md"][key]
+
+        for key in self._default_input["tolerance"].keys():
+            calc["tolerance"][key] = self.input["tolerance"][key]
+
+        for key in self._default_input["nose_hoover"].keys():
+            calc["nose_hoover"][key] = self.input["nose_hoover"][key]
+
+        for key in self._default_input["berendsen"].keys():
+            calc["berendsen"][key] = self.input["berendsen"][key]
+
+        for key, default_val in self._default_input["monte_carlo"].items():
+            inp_val = self.input["monte_carlo"][key]
+            if isinstance(default_val, list):
+                inp_val = list(inp_val)
+            calc["monte_carlo"][key] = inp_val
 
         calc["lattice"] = os.path.join(self.working_directory, "conf.data")
 


### PR DESCRIPTION
* Added options to set monte carlo parameters for calphy
```python
"monte_carlo": {
    "n_steps": 1,
    "n_swaps": 0,
    "forward_swap_types": [],
    "reverse_swap_types": [],
    "allow_all_swaps": True,
    "use_custom_lammps": False,
}
```

* Edited code to not use hardcoded values:

Replaced
```python
for key in self._default_input.keys():
    if key not in ["md", "tolerance", "nose_hoover", "berendsen"]:
```
with
```python
if isinstance(value, dict):
    for subkey in value:
        calc[key][subkey] = self.input[key][subkey]
```